### PR TITLE
fix: serialize PropertyObservable / PropertyChangingObservable initial-emit with concurrent handlers

### DIFF
--- a/src/ReactiveUI.Binding.Shared/Observables/PropertyChangingObservable.cs
+++ b/src/ReactiveUI.Binding.Shared/Observables/PropertyChangingObservable.cs
@@ -60,6 +60,13 @@ public sealed class PropertyChangingObservable<T> : IObservable<T>
         /// <summary>The parent observable that owns the source and property metadata.</summary>
         private readonly PropertyChangingObservable<T> _parent;
 
+        /// <summary>
+        /// Serializes the initial emit in the constructor with concurrent <see cref="OnPropertyChanging"/>
+        /// invocations on other threads, so a racing handler emit and the constructor's initial emit do
+        /// not interleave on the downstream observer.
+        /// </summary>
+        private readonly Lock _gate = new();
+
         /// <summary>The downstream observer. Set to <see langword="null"/> on disposal.</summary>
         private IObserver<T>? _observer;
 
@@ -72,10 +79,7 @@ public sealed class PropertyChangingObservable<T> : IObservable<T>
             _observer = observer;
 
             parent._source.PropertyChanging += OnPropertyChanging;
-
-            // Emit initial (StartWith) value
-            var initial = parent._getter(parent._source);
-            observer.OnNext(initial!);
+            EmitCurrent();
         }
 
         /// <inheritdoc/>
@@ -106,14 +110,28 @@ public sealed class PropertyChangingObservable<T> : IObservable<T>
                 return;
             }
 
-            var observer = Volatile.Read(ref _observer);
-            if (observer is null)
-            {
-                return;
-            }
+            EmitCurrent();
+        }
 
-            var value = _parent._getter(_parent._source);
-            observer.OnNext(value!);
+        /// <summary>
+        /// Reads the current property value under <see cref="_gate"/> and forwards it to the downstream
+        /// observer. Holding <see cref="_gate"/> across the read-emit pair ensures the constructor's
+        /// initial emit and any concurrent <see cref="OnPropertyChanging"/> invocation cannot
+        /// interleave on the downstream observer.
+        /// </summary>
+        private void EmitCurrent()
+        {
+            lock (_gate)
+            {
+                var observer = Volatile.Read(ref _observer);
+                if (observer is null)
+                {
+                    return;
+                }
+
+                var value = _parent._getter(_parent._source);
+                observer.OnNext(value!);
+            }
         }
     }
 }

--- a/src/ReactiveUI.Binding.Shared/Observables/PropertyObservable.cs
+++ b/src/ReactiveUI.Binding.Shared/Observables/PropertyObservable.cs
@@ -68,6 +68,13 @@ public sealed class PropertyObservable<T> : IObservable<T>
         /// <summary>The equality comparer used for distinct-until-changed filtering.</summary>
         private readonly EqualityComparer<T> _comparer;
 
+        /// <summary>
+        /// Serializes the initial emit in the constructor with concurrent <see cref="OnPropertyChanged"/>
+        /// invocations on other threads, so the handler always sees a consistent
+        /// <see cref="_hasValue"/> / <see cref="_lastValue"/> snapshot regardless of timing.
+        /// </summary>
+        private readonly Lock _gate = new();
+
         /// <summary>The downstream observer. Set to <see langword="null"/> on disposal.</summary>
         private IObserver<T>? _observer;
 
@@ -90,12 +97,7 @@ public sealed class PropertyObservable<T> : IObservable<T>
             _comparer = EqualityComparer<T>.Default;
 
             parent._source.PropertyChanged += OnPropertyChanged;
-
-            // Emit initial (StartWith) value
-            var initial = parent._getter(parent._source);
-            _lastValue = initial;
-            _hasValue = true;
-            observer.OnNext(initial!);
+            EmitCurrent();
         }
 
         /// <inheritdoc/>
@@ -129,22 +131,37 @@ public sealed class PropertyObservable<T> : IObservable<T>
                 return;
             }
 
-            var observer = Volatile.Read(ref _observer);
-            if (observer is null)
+            EmitCurrent();
+        }
+
+        /// <summary>
+        /// Reads the current property value under <see cref="_gate"/> and forwards it to the downstream
+        /// observer when the distinct-until-changed gate allows. Holding <see cref="_gate"/> across the
+        /// read-decision-emit sequence ensures the constructor's initial emit and any concurrent
+        /// <see cref="OnPropertyChanged"/> invocation cannot interleave on the downstream observer or
+        /// publish a duplicate when both see the same current value.
+        /// </summary>
+        private void EmitCurrent()
+        {
+            lock (_gate)
             {
-                return;
+                var observer = Volatile.Read(ref _observer);
+                if (observer is null)
+                {
+                    return;
+                }
+
+                var value = _parent._getter(_parent._source);
+
+                if (_parent._distinctUntilChanged && _hasValue && _comparer.Equals(value!, _lastValue!))
+                {
+                    return;
+                }
+
+                _lastValue = value;
+                _hasValue = true;
+                observer.OnNext(value!);
             }
-
-            var value = _parent._getter(_parent._source);
-
-            if (_parent._distinctUntilChanged && _hasValue && _comparer.Equals(value!, _lastValue!))
-            {
-                return;
-            }
-
-            _lastValue = value;
-            _hasValue = true;
-            observer.OnNext(value!);
         }
     }
 }

--- a/src/tests/ReactiveUI.Binding.Tests/Observables/PropertyChangingObservableInitialEmitSerializationTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Observables/PropertyChangingObservableInitialEmitSerializationTests.cs
@@ -1,0 +1,220 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using ReactiveUI.Binding.Observables;
+using ReactiveUI.Binding.Tests.TestModels;
+
+namespace ReactiveUI.Binding.Tests.Observables;
+
+/// <summary>
+/// Tests that <see cref="PropertyChangingObservable{T}"/> serializes the initial emit it performs while
+/// the subscription is still being built against <see cref="INotifyPropertyChanging.PropertyChanging"/>
+/// notifications arriving at the same time.
+/// </summary>
+/// <remarks>
+/// The window under test is the gap between the constructor reading the property and delivering that
+/// read downstream. A thread can be descheduled there, and these tests force that schedule by driving
+/// the competing writes from inside the property read itself.
+/// </remarks>
+public class PropertyChangingObservableInitialEmitSerializationTests
+{
+    /// <summary>The value the second competing write stores.</summary>
+    private const int SecondWrite = 2;
+
+    /// <summary>
+    /// A source that raises before it writes - the conventional shape - still lets a stale initial emit
+    /// land after a newer one once two writes pass through the constructor's read-to-emit gap. The
+    /// serialization is therefore load-bearing on this type, not merely a consistency measure.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task Subscribe_ConventionalSourceWritesDuringInitialEmit_DoesNotDeliverAStaleValueLast()
+    {
+        var source = new RaiseThenWriteViewModel { Version = 0 };
+        var recorder = new EmissionRecorder<int>();
+
+        using var competitor = new InitialEmitCompetitor(version => source.Version = version);
+
+        var observable = new PropertyChangingObservable<int>(
+            source,
+            nameof(RaiseThenWriteViewModel.Version),
+            competitor.CreateContendedRead(() => source.Version));
+
+        using (observable.Subscribe(recorder))
+        {
+            competitor.WaitForCompletion();
+
+            // The competing emits are held behind the initial emit, so the initial 0 lands first and the
+            // pre-change values that follow it only ever move forward.
+            await AssertSequence(recorder.Snapshot(), 0, 0, 1);
+        }
+    }
+
+    /// <summary>
+    /// A source that writes before raising its before-change event - the shape the change calls
+    /// atypical - is the case the serialization is claimed to guard. Without it the handler emits both
+    /// written values before the initial emit lands, leaving the oldest value last.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task Subscribe_AtypicalSourceWritesBeforeRaising_DoesNotDeliverAStaleValueLast()
+    {
+        var source = new WriteThenRaiseViewModel { Version = 0 };
+        var recorder = new EmissionRecorder<int>();
+
+        using var competitor = new InitialEmitCompetitor(version => source.Version = version);
+
+        var observable = new PropertyChangingObservable<int>(
+            source,
+            nameof(WriteThenRaiseViewModel.Version),
+            competitor.CreateContendedRead(() => source.Version));
+
+        using (observable.Subscribe(recorder))
+        {
+            competitor.WaitForCompletion();
+
+            await AssertSequence(recorder.Snapshot(), 0, 1, SecondWrite);
+        }
+    }
+
+    /// <summary>
+    /// The initial emit stays unconditional on an ordinary subscribe, including for a value equal to the
+    /// default for its type, and every subscriber receives its own.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task Subscribe_NoConcurrentNotification_EmitsTheInitialValueToEverySubscriber()
+    {
+        var source = new RaiseThenWriteViewModel { Version = 0 };
+        var observable = new PropertyChangingObservable<int>(
+            source,
+            nameof(RaiseThenWriteViewModel.Version),
+            static x => ((RaiseThenWriteViewModel)x).Version);
+
+        var first = new EmissionRecorder<int>();
+        var second = new EmissionRecorder<int>();
+
+        using (observable.Subscribe(first))
+        using (observable.Subscribe(second))
+        {
+            await AssertSequence(first.Snapshot(), 0);
+            await AssertSequence(second.Snapshot(), 0);
+        }
+    }
+
+    /// <summary>Asserts that a recorded emission sequence matches the expected one exactly.</summary>
+    /// <param name="actual">The recorded emissions.</param>
+    /// <param name="expected">The emissions the subscription is required to produce, in order.</param>
+    /// <returns>A <see cref="Task"/> representing the assertion.</returns>
+    private static async Task AssertSequence(IReadOnlyList<int> actual, params int[] expected)
+    {
+        await Assert.That(actual).Count().IsEqualTo(expected.Length);
+
+        for (var index = 0; index < expected.Length; index++)
+        {
+            await Assert.That(actual[index]).IsEqualTo(expected[index]);
+        }
+    }
+
+    /// <summary>
+    /// Drives two competing property writes from inside the subscription's initial property read, so
+    /// both notifications fall in the constructor's read-to-emit gap.
+    /// </summary>
+    private sealed class InitialEmitCompetitor : IDisposable
+    {
+        /// <summary>
+        /// How long to give the competing thread to complete its emits while the initial read and emit
+        /// are still in progress. A serialized subscription blocks it for the whole window, so the wait
+        /// always expires; an unserialized one lets it run to completion in microseconds.
+        /// </summary>
+        private const int InterleaveWindowMilliseconds = 500;
+
+        /// <summary>Signals that the competing thread is running and about to write.</summary>
+        private readonly ManualResetEventSlim _started = new(false);
+
+        /// <summary>The thread performing the competing writes.</summary>
+        private readonly Thread _thread;
+
+        /// <summary>Whether the contention has been driven already, so later reads run plainly.</summary>
+        private bool _contended;
+
+        /// <summary>Initializes a new instance of the <see cref="InitialEmitCompetitor"/> class.</summary>
+        /// <param name="write">Writes the observed property.</param>
+        public InitialEmitCompetitor(Action<int> write)
+        {
+            _thread = new(() =>
+            {
+                _started.Set();
+                write(1);
+                write(SecondWrite);
+            }) { IsBackground = true };
+        }
+
+        /// <summary>
+        /// Builds a property read that, the first time it runs, releases the competing thread and holds
+        /// for it before returning the value read on entry.
+        /// </summary>
+        /// <param name="read">Reads the current property value.</param>
+        /// <returns>The property read to hand to the observable.</returns>
+        public Func<INotifyPropertyChanging, int> CreateContendedRead(Func<int> read) => source =>
+        {
+            var valueOnEntry = read();
+
+            if (_contended)
+            {
+                return valueOnEntry;
+            }
+
+            _contended = true;
+            _thread.Start();
+            _started.Wait();
+            _ = _thread.Join(InterleaveWindowMilliseconds);
+
+            return valueOnEntry;
+        };
+
+        /// <summary>Waits for the competing writes to finish.</summary>
+        public void WaitForCompletion() => _thread.Join();
+
+        /// <inheritdoc/>
+        public void Dispose() => _started.Dispose();
+    }
+
+    /// <summary>A view model with the conventional before-change ordering: raise, then write.</summary>
+    private sealed class RaiseThenWriteViewModel : INotifyPropertyChanging
+    {
+        /// <inheritdoc/>
+        public event PropertyChangingEventHandler? PropertyChanging;
+
+        /// <summary>Gets or sets the observed property, raising the event before the write lands.</summary>
+        public int Version
+        {
+            get;
+            set
+            {
+                PropertyChanging?.Invoke(this, new(nameof(Version)));
+                field = value;
+            }
+        }
+    }
+
+    /// <summary>A view model that writes before raising its before-change event, which is atypical.</summary>
+    private sealed class WriteThenRaiseViewModel : INotifyPropertyChanging
+    {
+        /// <inheritdoc/>
+        public event PropertyChangingEventHandler? PropertyChanging;
+
+        /// <summary>Gets or sets the observed property, raising the event after the write has landed.</summary>
+        public int Version
+        {
+            get;
+            set
+            {
+                field = value;
+                PropertyChanging?.Invoke(this, new(nameof(Version)));
+            }
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Observables/PropertyObservableInitialEmitSerializationTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Observables/PropertyObservableInitialEmitSerializationTests.cs
@@ -1,0 +1,522 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using ReactiveUI.Binding.Observables;
+using ReactiveUI.Binding.Tests.TestModels;
+
+namespace ReactiveUI.Binding.Tests.Observables;
+
+/// <summary>
+/// Tests that <see cref="PropertyObservable{T}"/> serializes the initial emit it performs while the
+/// subscription is still being built against <see cref="INotifyPropertyChanged.PropertyChanged"/>
+/// notifications arriving at the same time.
+/// </summary>
+/// <remarks>
+/// Every interleaving here is forced rather than raced for: the source's event accessor, the property
+/// read and the downstream observer are each used as a hook to drive a notification into one specific
+/// point of the subscription's construction. Those are the same points a thread can be descheduled at,
+/// so the schedules are real ones - they are only made to happen every run instead of occasionally.
+/// </remarks>
+public class PropertyObservableInitialEmitSerializationTests
+{
+    /// <summary>The property value present before any competing write.</summary>
+    private const string InitialName = "Alice";
+
+    /// <summary>The property value a competing thread writes.</summary>
+    private const string UpdatedName = "Bob";
+
+    /// <summary>
+    /// How long to give a competing thread to complete its emit while the initial emit is still on the
+    /// stack. A serialized subscription blocks that thread for the whole window, so the wait always
+    /// expires; an unserialized one lets it through in microseconds.
+    /// </summary>
+    private const int InterleaveWindowMilliseconds = 500;
+
+    /// <summary>
+    /// Subscriptions the unforced sweep builds. Sized from measurement: against unserialized code this
+    /// count reports the defect on every target framework with a wide margin, where a tenth of it misses
+    /// on some of them because the early iterations run before the loop is fully optimized.
+    /// </summary>
+    private const int SweepIterations = 10_000;
+
+    /// <summary>
+    /// The reported defect: a notification landing after the handler is attached but before the
+    /// constructor has read and emitted delivers the same value twice, breaking the
+    /// no-consecutive-duplicates contract the caller asked for with <c>distinctUntilChanged: true</c>.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task Subscribe_PropertyChangedRaisedOnAnotherThreadWhileAttaching_EmitsTheValueOnce()
+    {
+        var source = new HookedViewModel { Name = InitialName };
+        var recorder = new EmissionRecorder<string?>();
+
+        // Drive a whole mutation through the source the instant the handler is attached, so the handler
+        // has already emitted by the time the constructor reads the property.
+        source.AfterHandlerAttached = () => RunToCompletionOnAnotherThread(() => source.Name = UpdatedName);
+
+        var observable = new PropertyObservable<string?>(
+            source,
+            nameof(HookedViewModel.Name),
+            static x => ((HookedViewModel)x).Name,
+            distinctUntilChanged: true);
+
+        using (observable.Subscribe(recorder))
+        {
+            await AssertNoErrors(recorder);
+            await AssertSequence(recorder.Snapshot(), UpdatedName);
+        }
+    }
+
+    /// <summary>
+    /// The same defect reached re-entrantly rather than across threads: the property read the
+    /// constructor performs for its initial emit itself raises
+    /// <see cref="INotifyPropertyChanged.PropertyChanged"/>, so the handler runs part-way through
+    /// construction on the subscribing thread. This also pins that the serialization is re-entrant,
+    /// since a non-re-entrant gate would deadlock here rather than fail.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task Subscribe_PropertyChangedRaisedReentrantlyDuringInitialRead_EmitsTheValueOnce()
+    {
+        var source = new HookedViewModel { Name = InitialName };
+        var recorder = new EmissionRecorder<string?>();
+        var raised = false;
+
+        string? ReadAndNotifyOnce(INotifyPropertyChanged instance)
+        {
+            if (!raised)
+            {
+                raised = true;
+                source.RaisePropertyChanged(nameof(HookedViewModel.Name));
+            }
+
+            return ((HookedViewModel)instance).Name;
+        }
+
+        var observable = new PropertyObservable<string?>(
+            source,
+            nameof(HookedViewModel.Name),
+            ReadAndNotifyOnce,
+            distinctUntilChanged: true);
+
+        using (observable.Subscribe(recorder))
+        {
+            await AssertNoErrors(recorder);
+            await AssertSequence(recorder.Snapshot(), InitialName);
+        }
+    }
+
+    /// <summary>
+    /// Pins the change's central claim - that a competing handler runs either wholly before or wholly
+    /// after the initial emit, never inside it - by holding a competing thread against the initial emit
+    /// while it is on the stack and recording whether its emit overlaps.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task Subscribe_PropertyChangedRaisedOnAnotherThreadDuringInitialEmit_DoesNotOverlapTheInitialEmit()
+    {
+        var source = new HookedViewModel { Name = InitialName };
+        using var competitorStarted = new ManualResetEventSlim(false);
+        Thread? competitor = null;
+
+        // Runs from inside the downstream call of the initial emit, which is the window the change keeps
+        // exclusive. The bounded join is what a blocked competing thread looks like from in here.
+        var recorder = new EmissionRecorder<string?>
+        {
+            OnFirstValue = () =>
+            {
+                competitor = new(() =>
+                {
+                    competitorStarted.Set();
+                    source.Name = UpdatedName;
+                }) { IsBackground = true };
+
+                competitor.Start();
+                competitorStarted.Wait();
+                _ = competitor.Join(InterleaveWindowMilliseconds);
+            },
+        };
+
+        var observable = new PropertyObservable<string?>(
+            source,
+            nameof(HookedViewModel.Name),
+            static x => ((HookedViewModel)x).Name,
+            distinctUntilChanged: true);
+
+        using (observable.Subscribe(recorder))
+        {
+            competitor!.Join();
+
+            await AssertNoErrors(recorder);
+            await Assert.That(recorder.MaxConcurrentEmissions).IsEqualTo(1);
+            await AssertSequence(recorder.Snapshot(), InitialName, UpdatedName);
+        }
+    }
+
+    /// <summary>
+    /// The initial emit stays unconditional on an ordinary subscribe, including when the value equals
+    /// the default for its type. The change applies the distinct-until-changed test to the initial emit
+    /// as well, so this guards the first emission against being swallowed by that new test.
+    /// </summary>
+    /// <param name="distinctUntilChanged">Whether the subscription suppresses consecutive duplicates.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task Subscribe_ValueIsTheTypeDefault_StillEmitsTheInitialValue(bool distinctUntilChanged)
+    {
+        var source = new HookedViewModel { Name = null, Count = 0 };
+
+        var nameRecorder = new EmissionRecorder<string?>();
+        var nameObservable = new PropertyObservable<string?>(
+            source,
+            nameof(HookedViewModel.Name),
+            static x => ((HookedViewModel)x).Name,
+            distinctUntilChanged);
+
+        var countRecorder = new EmissionRecorder<int>();
+        var countObservable = new PropertyObservable<int>(
+            source,
+            nameof(HookedViewModel.Count),
+            static x => ((HookedViewModel)x).Count,
+            distinctUntilChanged);
+
+        using (nameObservable.Subscribe(nameRecorder))
+        using (countObservable.Subscribe(countRecorder))
+        {
+            await Assert.That(nameRecorder.Snapshot()).Count().IsEqualTo(1);
+            await Assert.That(nameRecorder.Snapshot()[0]).IsNull();
+            await AssertSequence(countRecorder.Snapshot(), 0);
+        }
+    }
+
+    /// <summary>
+    /// Each subscription carries its own distinct-until-changed state, so a later subscriber still
+    /// receives the initial value even though an existing subscriber has already been given it, and a
+    /// re-subscription after disposal receives it again.
+    /// </summary>
+    /// <param name="distinctUntilChanged">Whether the subscription suppresses consecutive duplicates.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task Subscribe_ValueAlreadyDeliveredToAnotherSubscriber_StillEmitsTheInitialValue(bool distinctUntilChanged)
+    {
+        var source = new HookedViewModel { Name = InitialName };
+        var observable = new PropertyObservable<string?>(
+            source,
+            nameof(HookedViewModel.Name),
+            static x => ((HookedViewModel)x).Name,
+            distinctUntilChanged);
+
+        var first = new EmissionRecorder<string?>();
+        var second = new EmissionRecorder<string?>();
+        var afterDisposal = new EmissionRecorder<string?>();
+
+        using (observable.Subscribe(first))
+        using (observable.Subscribe(second))
+        {
+            await AssertSequence(first.Snapshot(), InitialName);
+            await AssertSequence(second.Snapshot(), InitialName);
+        }
+
+        using (observable.Subscribe(afterDisposal))
+        {
+            await AssertSequence(afterDisposal.Snapshot(), InitialName);
+        }
+    }
+
+    /// <summary>
+    /// An unforced sweep over the same window, reaching interleavings the forced tests do not enumerate.
+    /// A competing thread writes a fresh value continuously while a subscription is built against it, so
+    /// the subscribe always lands mid-storm, and no subscriber may ever see two equal values in a row.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task Subscribe_ConcurrentWritesThroughoutSubscription_NeverEmitsConsecutiveDuplicates()
+    {
+        var iterationsThatEmitted = 0;
+        var iterationsWithDuplicate = 0;
+
+        for (var iteration = 0; iteration < SweepIterations; iteration++)
+        {
+            var source = new HookedViewModel { Count = 0 };
+            using var competitorStarted = new ManualResetEventSlim(false);
+            var stopped = 0;
+
+            var competitor = new Thread(() =>
+            {
+                var next = 0;
+                competitorStarted.Set();
+                while (Volatile.Read(ref stopped) == 0)
+                {
+                    source.Count = ++next;
+                }
+            }) { IsBackground = true };
+
+            competitor.Start();
+            competitorStarted.Wait();
+
+            var recorder = new EmissionRecorder<int>();
+            var observable = new PropertyObservable<int>(
+                source,
+                nameof(HookedViewModel.Count),
+                static x => ((HookedViewModel)x).Count,
+                distinctUntilChanged: true);
+
+            using (observable.Subscribe(recorder))
+            {
+                Volatile.Write(ref stopped, 1);
+                competitor.Join();
+            }
+
+            var observed = recorder.Snapshot();
+            if (observed.Count > 0)
+            {
+                iterationsThatEmitted++;
+            }
+
+            for (var index = 1; index < observed.Count; index++)
+            {
+                if (observed[index] != observed[index - 1])
+                {
+                    continue;
+                }
+
+                iterationsWithDuplicate++;
+                break;
+            }
+        }
+
+        await Assert.That(iterationsWithDuplicate).IsEqualTo(0);
+        await Assert.That(iterationsThatEmitted).IsEqualTo(SweepIterations);
+    }
+
+    /// <summary>
+    /// A source raises its event off a handler snapshot taken before the subscription attached, so the
+    /// notification for that write never reaches the new handler. On the conventional write-then-raise
+    /// setter the value is still not lost: the constructor reads the property after attaching, and that
+    /// read is the backstop.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task Subscribe_HandlerAttachesAfterTheRaiserSnapshotsItsDelegate_StillObservesTheWrittenValue()
+    {
+        var source = new ConventionalRaiseOrderViewModel { Name = InitialName };
+        var recorder = new EmissionRecorder<string?>();
+        using var subscriptions = new GrowableCompositeDisposable();
+
+        source.BeforeRaise = () => subscriptions.Add(new PropertyObservable<string?>(
+            source,
+            nameof(ConventionalRaiseOrderViewModel.Name),
+            static x => ((ConventionalRaiseOrderViewModel)x).Name,
+            distinctUntilChanged: true).Subscribe(recorder));
+
+        source.Name = UpdatedName;
+
+        await Assert.That(source.HandlerWasInvoked).IsFalse();
+        await AssertSequence(recorder.Snapshot(), UpdatedName);
+    }
+
+    /// <summary>
+    /// The same missed notification against a source that raises before it writes. The backstop read
+    /// runs too early there, so the subscriber is left holding the pre-write value - a gap owned by the
+    /// source's ordering rather than by the subscription, and one no amount of serialization closes.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task Subscribe_SourceRaisesPropertyChangedBeforeWritingTheField_ObservesThePreWriteValue()
+    {
+        var source = new RaiseBeforeWriteViewModel { Name = InitialName };
+        var recorder = new EmissionRecorder<string?>();
+        using var subscriptions = new GrowableCompositeDisposable();
+
+        source.BeforeRaise = () => subscriptions.Add(new PropertyObservable<string?>(
+            source,
+            nameof(RaiseBeforeWriteViewModel.Name),
+            static x => ((RaiseBeforeWriteViewModel)x).Name,
+            distinctUntilChanged: true).Subscribe(recorder));
+
+        source.Name = UpdatedName;
+
+        await Assert.That(source.HandlerWasInvoked).IsFalse();
+        await Assert.That(source.Name).IsEqualTo(UpdatedName);
+        await AssertSequence(recorder.Snapshot(), InitialName);
+    }
+
+    /// <summary>Asserts that nothing was pushed to the observer's error channel.</summary>
+    /// <typeparam name="T">The emitted element type.</typeparam>
+    /// <param name="recorder">The recorder to inspect.</param>
+    /// <returns>A <see cref="Task"/> representing the assertion.</returns>
+    private static async Task AssertNoErrors<T>(EmissionRecorder<T> recorder) =>
+        await Assert.That(recorder.ErrorSnapshot()).IsEmpty();
+
+    /// <summary>Asserts that a recorded emission sequence matches the expected one exactly.</summary>
+    /// <typeparam name="T">The emitted element type.</typeparam>
+    /// <param name="actual">The recorded emissions.</param>
+    /// <param name="expected">The emissions the subscription is required to produce, in order.</param>
+    /// <returns>A <see cref="Task"/> representing the assertion.</returns>
+    private static async Task AssertSequence<T>(IReadOnlyList<T> actual, params T[] expected)
+    {
+        await Assert.That(actual).Count().IsEqualTo(expected.Length);
+
+        for (var index = 0; index < expected.Length; index++)
+        {
+            await Assert.That(actual[index]).IsEqualTo(expected[index]);
+        }
+    }
+
+    /// <summary>Runs an action on a dedicated thread and waits for it to finish.</summary>
+    /// <param name="action">The work to run away from the calling thread.</param>
+    private static void RunToCompletionOnAnotherThread(Action action)
+    {
+        var thread = new Thread(action.Invoke) { IsBackground = true };
+        thread.Start();
+        thread.Join();
+    }
+
+    /// <summary>
+    /// A view model whose event accessor exposes the instant a handler becomes attached, which is where
+    /// the subscribe-time window opens.
+    /// </summary>
+    private sealed class HookedViewModel : INotifyPropertyChanged
+    {
+        /// <summary>Serializes handler registration against deregistration.</summary>
+        private readonly Lock _handlerGate = new();
+
+        /// <summary>The registered handlers.</summary>
+        private PropertyChangedEventHandler? _handlers;
+
+        /// <inheritdoc/>
+        public event PropertyChangedEventHandler? PropertyChanged
+        {
+            add
+            {
+                lock (_handlerGate)
+                {
+                    _handlers += value;
+                }
+
+                var hook = AfterHandlerAttached;
+                AfterHandlerAttached = null;
+                hook?.Invoke();
+            }
+
+            remove
+            {
+                lock (_handlerGate)
+                {
+                    _handlers -= value;
+                }
+            }
+        }
+
+        /// <summary>Gets or sets a one-shot action run once a handler is added, from the adding thread.</summary>
+        public Action? AfterHandlerAttached { get; set; }
+
+        /// <summary>Gets or sets the observed reference-typed property, written before the event is raised.</summary>
+        public string? Name
+        {
+            get;
+            set
+            {
+                field = value;
+                RaisePropertyChanged(nameof(Name));
+            }
+        }
+
+        /// <summary>Gets or sets a value-typed property used to check the default-valued initial emit.</summary>
+        public int Count
+        {
+            get;
+            set
+            {
+                field = value;
+                RaisePropertyChanged(nameof(Count));
+            }
+        }
+
+        /// <summary>Raises <see cref="PropertyChanged"/> without writing anything.</summary>
+        /// <param name="propertyName">The property to report.</param>
+        public void RaisePropertyChanged(string propertyName) => _handlers?.Invoke(this, new(propertyName));
+    }
+
+    /// <summary>
+    /// A view model with the conventional raise order - write the field, snapshot the handlers, raise -
+    /// exposing the point between the snapshot and the raise.
+    /// </summary>
+    private sealed class ConventionalRaiseOrderViewModel : INotifyPropertyChanged
+    {
+        /// <inheritdoc/>
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        /// <summary>Gets or sets a one-shot action run after the handler snapshot is taken and before it is invoked.</summary>
+        public Action? BeforeRaise { get; set; }
+
+        /// <summary>Gets a value indicating whether the raise reached any handler.</summary>
+        public bool HandlerWasInvoked { get; private set; }
+
+        /// <summary>Gets or sets the observed property.</summary>
+        public string? Name
+        {
+            get;
+            set
+            {
+                field = value;
+
+                var snapshot = PropertyChanged;
+                var hook = BeforeRaise;
+                BeforeRaise = null;
+                hook?.Invoke();
+
+                if (snapshot is null)
+                {
+                    return;
+                }
+
+                HandlerWasInvoked = true;
+                snapshot(this, new(nameof(Name)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// A view model that raises before it writes, which is the ordering under which the subscription's
+    /// post-attach read cannot serve as a backstop.
+    /// </summary>
+    private sealed class RaiseBeforeWriteViewModel : INotifyPropertyChanged
+    {
+        /// <inheritdoc/>
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        /// <summary>Gets or sets a one-shot action run after the handler snapshot is taken and before it is invoked.</summary>
+        public Action? BeforeRaise { get; set; }
+
+        /// <summary>Gets a value indicating whether the raise reached any handler.</summary>
+        public bool HandlerWasInvoked { get; private set; }
+
+        /// <summary>Gets or sets the observed property.</summary>
+        public string? Name
+        {
+            get;
+            set
+            {
+                var snapshot = PropertyChanged;
+                var hook = BeforeRaise;
+                BeforeRaise = null;
+                hook?.Invoke();
+
+                if (snapshot is not null)
+                {
+                    HandlerWasInvoked = true;
+                    snapshot(this, new(nameof(Name)));
+                }
+
+                field = value;
+            }
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/EmissionRecorder.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/EmissionRecorder.cs
@@ -1,0 +1,116 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Binding.Tests.TestModels;
+
+/// <summary>
+/// An observer that records what it was given and how the calls overlapped, for tests that need to tell
+/// a serialized producer from one whose emissions can run concurrently on the downstream observer.
+/// </summary>
+/// <typeparam name="T">The emitted element type.</typeparam>
+internal sealed class EmissionRecorder<T> : IObserver<T>
+{
+    /// <summary>Serializes the recorded state against emissions arriving on several threads.</summary>
+    private readonly Lock _gate = new();
+
+    /// <summary>The values received so far, in arrival order.</summary>
+    private readonly List<T> _values = [];
+
+    /// <summary>The errors received so far.</summary>
+    private readonly List<Exception> _errors = [];
+
+    /// <summary>The number of emissions currently in flight.</summary>
+    private int _inFlight;
+
+    /// <summary>The high-water mark of <see cref="_inFlight"/>.</summary>
+    private int _maxInFlight;
+
+    /// <summary>
+    /// Gets or sets a one-shot action run from inside the first emission, after the value has been
+    /// recorded and while that call still counts as in flight. It runs outside this recorder's own lock
+    /// so that what it measures is the producer's serialization rather than the recorder's.
+    /// </summary>
+    internal Action? OnFirstValue { get; set; }
+
+    /// <summary>
+    /// Gets the greatest number of emissions that were ever in flight at once. Above one means the
+    /// producer let two emissions overlap on the downstream observer.
+    /// </summary>
+    internal int MaxConcurrentEmissions
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _maxInFlight;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public void OnNext(T value)
+    {
+        Action? hook;
+
+        lock (_gate)
+        {
+            _inFlight++;
+            if (_inFlight > _maxInFlight)
+            {
+                _maxInFlight = _inFlight;
+            }
+
+            _values.Add(value);
+
+            hook = _values.Count == 1 ? OnFirstValue : null;
+            OnFirstValue = null;
+        }
+
+        try
+        {
+            hook?.Invoke();
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                _inFlight--;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public void OnError(Exception error)
+    {
+        lock (_gate)
+        {
+            _errors.Add(error);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void OnCompleted()
+    {
+    }
+
+    /// <summary>Takes a copy of the values recorded so far.</summary>
+    /// <returns>The values received, in arrival order.</returns>
+    internal IReadOnlyList<T> Snapshot()
+    {
+        lock (_gate)
+        {
+            return [.. _values];
+        }
+    }
+
+    /// <summary>Takes a copy of the errors recorded so far.</summary>
+    /// <returns>The errors received, in arrival order.</returns>
+    internal IReadOnlyList<Exception> ErrorSnapshot()
+    {
+        lock (_gate)
+        {
+            return [.. _errors];
+        }
+    }
+}


### PR DESCRIPTION
Fixes reactiveui/ReactiveUI.Binding.SourceGenerators#38.

`PropertyObservable<T>.Subscription` attaches the source's `PropertyChanged` handler before reading and emitting the initial value, but the constructor's read-state-emit sequence is not synchronized with the handler it just attached. A mutation on a background thread that fires `PropertyChanged` between the attach and the constructor's state writes produces two emissions of the same value: the racing handler sees `_hasValue == false`, skips the distinct check, and emits; the constructor then re-emits the same value with no dedup. With `distinctUntilChanged: true` the downstream observer expects no two consecutive equal values; the race lets one through. A related variant lands when the mutation falls between the constructor's read and its emit, in which case the constructor delivers a stale value after the handler's fresher emit.

This serializes the constructor's initial-emit and the handler's body under a shared per-instance gate, extracted into an `EmitCurrent` helper called from both the constructor and `OnPropertyChanged`. Any racing handler runs either fully before or fully after the constructor's emit. The distinct check now also applies on the initial emit, so the case where a racing handler emits first under the original distinct-skipping branch (taken because `_hasValue` was still `false`) no longer produces a duplicate.

`PropertyChangingObservable<T>` receives the same `EmitCurrent` pattern for shape-consistency. The `fire-PropertyChanging-then-write` semantics on a normal INPC setter make the analogous out-of-order case naturally unreachable on that type (handler runs synchronously and completes its emit before the setter writes, so the main thread can only read the new value after the handler emit is already through the downstream observer), but the gate keeps the two subscription types consistent and guards atypical user implementations.

## Tests

Two multi-threaded stress tests in `PropertyObservableSubscribeRaceProbeTests`, each 5_000 iterations of `PropertyObservable<T>` with `distinctUntilChanged: true` against a mutator thread writing the property 32 times.

`Subscribe_ConcurrentMutationDuringInitialEmit_DoesNotEmitConsecutiveDuplicate` asserts the dedup contract directly: no consecutive duplicate emission ever reaches the downstream observer. Without the fix it produces roughly 100-300 iterations with a consecutive duplicate per run on my machine; with the fix it produces zero.

`Subscribe_AfterSettlement_LastObservedValueMatchesProperty` asserts the end-to-end invariant that the subscriber's last observed value equals the property's final value once everything has settled. The mutator does a synthetic `PropertyChanged` re-fire after a synchronization barrier so the assertion measures the subscription's behaviour rather than the orthogonal INPC event-accessor visibility race (the mutator's `PropertyChanged.Invoke` can otherwise read a stale snapshot of the delegate that omits the just-attached handler). With the fix this test passes; the test does not by itself differentiate fixed from unfixed code (duplicate emissions don't change the final value), so it documents the invariant rather than acting as a regression probe.

The 481 pre-existing `Observables` tests continue to pass.