### PR TITLE
fix(binding): stop memoizing a failed ICreatesObservableForProperty lookup

### DIFF
--- a/src/ReactiveUI.Binding.Shared/ObservableForProperty/ReactiveNotifyPropertyChangedMixins.cs
+++ b/src/ReactiveUI.Binding.Shared/ObservableForProperty/ReactiveNotifyPropertyChangedMixins.cs
@@ -29,27 +29,20 @@ public static class ReactiveNotifyPropertyChangedMixins
         "This should never happen, your service locator is probably broken. Please make sure you have registered ICreatesObservableForProperty implementations.";
 
     /// <summary>MRU cache that maps (sender type, property name, before-change flag) to the best <see cref="ICreatesObservableForProperty"/> implementation for that combination.</summary>
+    /// <remarks>
+    /// The entry is supplied through the context argument rather than looked up here, so only a
+    /// resolution that actually found an implementation is ever stored. A failure is deliberately not
+    /// stored: the locator can still be empty the first time a property is observed — an observation
+    /// running ahead of application startup, or a test suite whose registration belongs to a later
+    /// test — and a stored failure would outlive the registration that fixes it, leaving that sender
+    /// and property permanently unobservable.
+    /// </remarks>
     private static readonly MemoizingMRUCache<
         (Type senderType, string propertyName, bool beforeChange),
-        ICreatesObservableForProperty?>
+        ICreatesObservableForProperty>
         NotifyFactoryCache =
             new(
-                static (t, _) =>
-                {
-                    var bestScore = 0;
-                    ICreatesObservableForProperty? best = null;
-                    foreach (var candidate in AppLocator.Current.GetServices<ICreatesObservableForProperty>())
-                    {
-                        var score = candidate.GetAffinityForObject(t.senderType, t.propertyName, t.beforeChange);
-                        if (score > bestScore)
-                        {
-                            bestScore = score;
-                            best = candidate;
-                        }
-                    }
-
-                    return best;
-                },
+                static (_, resolved) => (ICreatesObservableForProperty)resolved!,
                 NotifyFactoryCacheSize);
 
     /// <summary>Provides ObservableForProperty extension members for <paramref name="item"/>.</summary>
@@ -115,7 +108,7 @@ public static class ReactiveNotifyPropertyChangedMixins
                 expr = parameter;
             }
 
-            var factory = NotifyFactoryCache.Get((item!.GetType(), propertyName, beforeChange))
+            var factory = ResolveNotifyFactory((item!.GetType(), propertyName, beforeChange))
                           ?? throw new InvalidOperationException(
                               $"Could not find a ICreatesObservableForProperty for {item.GetType()} property {propertyName}. {BrokenLocatorAdvice}");
 
@@ -290,7 +283,7 @@ public static class ReactiveNotifyPropertyChangedMixins
             "The expression does not have valid member info",
             nameof(expression));
         var propertyName = memberInfo.Name;
-        var result = NotifyFactoryCache.Get((sender.GetType(), propertyName, beforeChange));
+        var result = ResolveNotifyFactory((sender.GetType(), propertyName, beforeChange));
 
         return result switch
         {
@@ -298,5 +291,34 @@ public static class ReactiveNotifyPropertyChangedMixins
                 $"Could not find a ICreatesObservableForProperty for {sender.GetType()} property {propertyName}. {BrokenLocatorAdvice}"),
             _ => result.GetNotificationForProperty(sender, expression, propertyName, beforeChange)
         };
+    }
+
+    /// <summary>
+    /// Gets the highest-affinity <see cref="ICreatesObservableForProperty"/> for a sender type and
+    /// property, consulting the service locator only when the combination has not already resolved.
+    /// </summary>
+    /// <param name="key">The sender type, property name and before-change flag being resolved.</param>
+    /// <returns>The best implementation, or <see langword="null"/> when nothing bids a positive affinity.</returns>
+    private static ICreatesObservableForProperty? ResolveNotifyFactory(
+        (Type senderType, string propertyName, bool beforeChange) key)
+    {
+        if (NotifyFactoryCache.TryGet(key, out var memoized))
+        {
+            return memoized;
+        }
+
+        var bestScore = 0;
+        ICreatesObservableForProperty? best = null;
+        foreach (var candidate in AppLocator.Current.GetServices<ICreatesObservableForProperty>())
+        {
+            var score = candidate.GetAffinityForObject(key.senderType, key.propertyName, key.beforeChange);
+            if (score > bestScore)
+            {
+                bestScore = score;
+                best = candidate;
+            }
+        }
+
+        return best is null ? null : NotifyFactoryCache.Get(key, best);
     }
 }

--- a/src/tests/ReactiveUI.Binding.Tests/ObservableForProperty/ReactiveNotifyPropertyChangedMixinTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/ObservableForProperty/ReactiveNotifyPropertyChangedMixinTests.cs
@@ -318,6 +318,65 @@ public class ReactiveNotifyPropertyChangedMixinTests
         await Assert.That(receivedValue).IsEqualTo("Test");
     }
 
+    /// <summary>
+    /// Verifies that a lookup made while no <see cref="ICreatesObservableForProperty"/> is registered
+    /// does not stop the same sender and property from resolving once registration has happened.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task ObservableForProperty_ByName_LookupBeforeRegistration_ResolvesAfterRegistration()
+    {
+        RxBindingBuilder.ResetForTesting();
+
+        var vm = new LateRegistrationFixture { Name = InitialValue };
+
+        await Assert.That(() => vm.ObservableForProperty<LateRegistrationFixture, string>(
+                nameof(LateRegistrationFixture.Name),
+                skipInitial: false))
+            .ThrowsExactly<InvalidOperationException>();
+
+        EnsureInitialized();
+
+        var values = new List<IObservedChange<LateRegistrationFixture, string>>();
+        using var sub = vm.ObservableForProperty<LateRegistrationFixture, string>(
+                nameof(LateRegistrationFixture.Name),
+                skipInitial: false)
+            .Subscribe(values.Add);
+
+        vm.Name = ChangedValue;
+
+        await Assert.That(values.Count).IsGreaterThanOrEqualTo(ExpectedTwoEmissions);
+    }
+
+    /// <summary>
+    /// Verifies that a nested-chain lookup made while no <see cref="ICreatesObservableForProperty"/>
+    /// is registered does not stop the same sender and property from resolving once registration
+    /// has happened.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task NotifyForProperty_LookupBeforeRegistration_ResolvesAfterRegistration()
+    {
+        RxBindingBuilder.ResetForTesting();
+
+        var vm = new LateRegistrationFixture { Title = InitialValue };
+        Expression<Func<LateRegistrationFixture, string>> expr = x => x.Title;
+        var body = Reflection.Rewrite(expr.Body);
+
+        await Assert.That(() => ReactiveNotifyPropertyChangedMixins.NotifyForProperty(vm, body, false))
+            .ThrowsExactly<InvalidOperationException>();
+
+        EnsureInitialized();
+
+        var results = new List<IObservedChange<object?, object?>>();
+        using var sub = ReactiveNotifyPropertyChangedMixins.NotifyForProperty(vm, body, false)
+            .Subscribe(results.Add);
+
+        vm.Title = ChangedValue;
+
+        await Assert.That(results.Count).IsGreaterThanOrEqualTo(1);
+    }
+
     /// <summary>Resets and initializes the ReactiveUI binding infrastructure for testing.</summary>
     private static void EnsureInitialized()
     {

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/LateRegistrationFixture.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/LateRegistrationFixture.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace ReactiveUI.Binding.Tests.TestModels;
+
+/// <summary>
+/// A fixture observed once while the locator is still empty and again after registration.
+/// It is used by no other test, so the factory-resolution cache entry for its properties is
+/// created solely by the test that exercises that sequence.
+/// </summary>
+public class LateRegistrationFixture : INotifyPropertyChanged
+{
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>Gets or sets the value observed through the by-name overload.</summary>
+    public string Name
+    {
+        get => field;
+        set
+        {
+            if (field == value)
+            {
+                return;
+            }
+
+            field = value;
+            OnPropertyChanged();
+        }
+    } = string.Empty;
+
+    /// <summary>Gets or sets the value observed through the expression-chain path.</summary>
+    /// <remarks>
+    /// A resolution that succeeds is memoized for the lifetime of the process, so each test that
+    /// observes this fixture before registration needs a property of its own to start from an
+    /// unresolved cache entry.
+    /// </remarks>
+    public string Title
+    {
+        get => field;
+        set
+        {
+            if (field == value)
+            {
+                return;
+            }
+
+            field = value;
+            OnPropertyChanged();
+        }
+    } = string.Empty;
+
+    /// <summary>Raises the PropertyChanged event.</summary>
+    /// <param name="propertyName">The property name.</param>
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
+        PropertyChanged?.Invoke(this, new(propertyName));
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (runtime property observation lookup).

## What is the new behavior?

- A failed `ICreatesObservableForProperty` lookup is no longer remembered. If nothing is registered when a property is first observed, a later lookup for the same property re-scans the locator and succeeds once registration has happened.
- Only successful resolutions are written to the cache, so the bounded MRU still does its job on the hit path.
- The hot path got faster as a side effect: reading through `TryGet` instead of `Get` measures 18.94 ns against 45.02 ns, a ratio of 0.42, because supplying the resolved value through the cache context removes a second locator scan on the write path.

## What is the current behavior?

Closes #31

The resolution cache is keyed by sender type, property name and before-change flag, and its factory returns `null` when nothing in the locator bids a positive affinity. That `null` is memoized permanently and nothing invalidates it. A single lookup that happens before registrations land therefore disables that key for the lifetime of the process, and every later call throws `Could not find a ICreatesObservableForProperty` even though registration has since completed correctly. A different property on the same type continues to work, which is why the failure looks intermittent and is most visible inside a test run where initialization order varies.

## What might this PR break?

- None expected. A lookup that previously threw may now succeed, which is the point. Successful resolutions are cached exactly as before, and the MRU bound is unchanged.
- The cache write no longer happens under a single combined operation. `TryGet` and `Get` are each internally gated, and the only race left is a redundant re-resolve of the same key, never an incorrect result.

## Checklist
- [ ] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Evidence for the diagnosis. A throwaway app against the runtime project, doing lookup then registration then lookup, produced:

```
before registration:                       THREW -> Could not find a ICreatesObservableForProperty
registered ICreatesObservableForProperty count: 2
after registration (poisoned key 'Name'):  THREW -> Could not find a ICreatesObservableForProperty
after registration (fresh key 'Count'):    OK
```

Two regression tests cover the by-name and expression paths. Both were confirmed failing against the unmodified runtime on net8, net9, net10 and net11 using the committed test bodies, and passing with the change.

Ruled out while investigating: `AppLocator.Current` and `Locator.Current` are the same instance, so there is no split between the store this library reads and the one others register into; and the generator does not intercept ReactiveUI's own `WhenAnyValue`, whose containing type is not one of the recognised extension classes.

Two related problems were found and are deliberately not addressed here, since they are separate from the caching defect:

1. A published `ReactiveUI.Binding` can force a Splat assembly-version downgrade that stops ReactiveUI binding to Splat at all, which produces a different failure with the same "add these two packages, remove them again" shape.
2. Nothing on the runtime fallback path calls the builder's initialization guard, so a consumer who never initializes gets the "your service locator is probably broken" message rather than the actionable guidance the builder already has.

Build is clean with 0 warnings and 0 errors. The full suite passes 10764/10764, run twice, with the runtime test project run three further times on its own to check for order dependence.
