### PR TITLE
chore(renovate): hold the generator and analyzer at the Roslyn baseline

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,17 @@
     ],
     "packageRules": [
         {
+            "description": "The generator and analyzer are held at the Roslyn 4.8.0 baseline (VS 2022 17.8, .NET 8.0.1xx SDK) and must not move with the toolchain. Both ship in the version-less analyzers/dotnet/cs folder, and a compiler refuses to load a generator or analyzer built against a newer Roslyn than itself, so raising this floor silently drops every consumer on an older SDK. It is a compatibility decision, not a maintenance lag, and the only reason to change it is to raise the minimum supported SDK on purpose. Microsoft.CodeAnalysis.Analyzers is deliberately absent: it supplies analyzer-authoring rules and has no bearing on the load floor.",
+            "matchManagers": [
+                "nuget"
+            ],
+            "enabled": false,
+            "matchPackageNames": [
+                "/^Microsoft\\.CodeAnalysis\\.CSharp$/",
+                "/^Microsoft\\.CodeAnalysis\\.CSharp\\.Workspaces$/"
+            ]
+        },
+        {
             "description": "Analyzer packages all gate the build through the same warnings-as-errors pass, so landing them separately just means several red CI runs in a row. Move them in one PR.",
             "matchManagers": [
                 "nuget"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Build configuration.

## What is the new behavior?

- `Microsoft.CodeAnalysis.CSharp` and `Microsoft.CodeAnalysis.CSharp.Workspaces` no longer receive dependency update PRs. The generator and analyzer stay on the Roslyn 4.8.0 baseline until someone raises the minimum supported SDK deliberately.
- `Microsoft.CodeAnalysis.Analyzers` continues to update. It supplies analyzer-authoring rules and has no bearing on which compilers can load the generator.

## What is the current behavior?

Both packages were treated as ordinary dependencies, so each Roslyn release produced an update PR proposing to raise the floor. #45 is the current one, moving 4.8.0 to 4.14.0.

The pin is a compatibility decision rather than a maintenance lag, and the reason is already recorded in both project files: the generator and analyzer ship in the version-less `analyzers/dotnet/cs` folder, and a compiler will not load a generator or analyzer built against a newer Roslyn than itself. Building against 4.8.0 is what keeps consumers on VS 2022 17.8 and the .NET 8.0.1xx SDK working. Accepting one of those update PRs would silently drop them.

## What might this PR break?

- None for consumers. Nothing about the shipped packages changes.
- The trade-off is that these two packages will not be updated by automation, so the generator remains limited to APIs present in Roslyn 4.8. That constraint already applies and is documented in `ReactiveUI.Binding.SourceGenerators.csproj`. Raising the baseline is now an explicit edit to the project files and this rule, which is the intent.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

The rule matches the two package names exactly rather than a `Microsoft.CodeAnalysis.*` prefix, so a future package under that prefix is not silently frozen along with them.

Supersedes #45, which should be closed rather than merged.
