### PR TITLE
fix(generator): preserve legacy null-chain observation semantics

### DIFF
--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs
@@ -720,7 +720,10 @@ internal static class ObservationCodeGenerator
     /// for inner segments, so reusing the root's plugin is safe whatever the segment declares.
     /// </param>
     /// <param name="isBeforeChange">Whether before-change notifications are being observed.</param>
-    /// <remarks>Missing parents suppress values to match the runtime expression-chain fallback.</remarks>
+    /// <remarks>
+    /// Missing parents propagate through intermediate stages so downstream subscriptions detach,
+    /// while the leaf suppresses the default value to match the runtime expression-chain fallback.
+    /// </remarks>
     private static void EmitObservationChainInnerSegments(
         StringBuilder sb,
         EquatableArray<PropertyPathSegment> path,
@@ -736,6 +739,15 @@ internal static class ObservationCodeGenerator
             var lambdaParam = $"__parent{s}";
             var segType = seg.PropertyTypeFullName;
 
+            // Only the leaf suppresses. Inner segments keep pushing the null downstream so the
+            // stage below re-parents onto null and drops its subscription on the detached subtree.
+            var nullParentBehavior = s == path.Length - 1
+                ? NullParentObservationBehavior.SuppressEmission
+                : NullParentObservationBehavior.EmitDefault;
+            var nullParentObservable = nullParentBehavior == NullParentObservationBehavior.EmitDefault
+                ? $"new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))"
+                : $"global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance";
+
             if (rootPlugin is not null)
             {
                 rootPlugin.EmitDeepChainInnerSegment(
@@ -745,7 +757,7 @@ internal static class ObservationCodeGenerator
                     lambdaParam,
                     seg,
                     isBeforeChange,
-                    NullParentObservationBehavior.SuppressEmission);
+                    nullParentBehavior);
             }
             else if (IsINPChanging(classInfo) && isBeforeChange)
             {
@@ -758,7 +770,7 @@ internal static class ObservationCodeGenerator
                                                          (global::System.ComponentModel.INotifyPropertyChanging){lambdaParam},
                                                          "{seg.PropertyName}",
                                                          (global::System.ComponentModel.INotifyPropertyChanging __o) => (({seg.DeclaringTypeFullName})__o).{seg.PropertyName})
-                                                     : (global::System.IObservable<{segType}>)global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance));
+                                                     : (global::System.IObservable<{segType}>){nullParentObservable}));
                                  """);
             }
             else
@@ -770,7 +782,7 @@ internal static class ObservationCodeGenerator
                                                  {lambdaParam} => {lambdaParam} != null
                                                      ? (global::System.IObservable<{segType}>)
                                                          new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>((({seg.DeclaringTypeFullName}){lambdaParam}).{seg.PropertyName})
-                                                     : (global::System.IObservable<{segType}>)global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance));
+                                                     : (global::System.IObservable<{segType}>){nullParentObservable}));
                                  """);
             }
         }
@@ -789,7 +801,10 @@ internal static class ObservationCodeGenerator
     /// </param>
     /// <param name="isBeforeChange">Whether before-change notifications are being observed.</param>
     /// <param name="varName">The variable-name prefix for the emitted stages.</param>
-    /// <remarks>Missing parents suppress values to match the runtime expression-chain fallback.</remarks>
+    /// <remarks>
+    /// Missing parents propagate through intermediate stages so downstream subscriptions detach,
+    /// while the leaf suppresses the default value to match the runtime expression-chain fallback.
+    /// </remarks>
     private static void EmitDeepChainInnerSegments(
         StringBuilder sb,
         EquatableArray<PropertyPathSegment> path,
@@ -806,6 +821,13 @@ internal static class ObservationCodeGenerator
             var lambdaParam = $"{varName}_p{s}";
             var segType = seg.PropertyTypeFullName;
 
+            var nullParentBehavior = s == path.Length - 1
+                ? NullParentObservationBehavior.SuppressEmission
+                : NullParentObservationBehavior.EmitDefault;
+            var nullParentObservable = nullParentBehavior == NullParentObservationBehavior.EmitDefault
+                ? $"new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))"
+                : $"global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance";
+
             if (rootPlugin is not null)
             {
                 rootPlugin.EmitDeepChainInnerSegment(
@@ -815,7 +837,7 @@ internal static class ObservationCodeGenerator
                     lambdaParam,
                     seg,
                     isBeforeChange,
-                    NullParentObservationBehavior.SuppressEmission);
+                    nullParentBehavior);
             }
             else if (IsINPChanging(classInfo) && isBeforeChange)
             {
@@ -828,7 +850,7 @@ internal static class ObservationCodeGenerator
                                                          (global::System.ComponentModel.INotifyPropertyChanging){lambdaParam},
                                                          "{seg.PropertyName}",
                                                          (global::System.ComponentModel.INotifyPropertyChanging __o) => (({seg.DeclaringTypeFullName})__o).{seg.PropertyName})
-                                                     : (global::System.IObservable<{segType}>)global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance));
+                                                     : (global::System.IObservable<{segType}>){nullParentObservable}));
                                  """);
             }
             else
@@ -840,7 +862,7 @@ internal static class ObservationCodeGenerator
                           {lambdaParam} => {lambdaParam} != null
                               ? (global::System.IObservable<{segType}>)
                                   new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>((({seg.DeclaringTypeFullName}){lambdaParam}).{seg.PropertyName})
-                              : (global::System.IObservable<{segType}>)global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance));
+                              : (global::System.IObservable<{segType}>){nullParentObservable}));
           """);
             }
         }

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs
@@ -720,6 +720,7 @@ internal static class ObservationCodeGenerator
     /// for inner segments, so reusing the root's plugin is safe whatever the segment declares.
     /// </param>
     /// <param name="isBeforeChange">Whether before-change notifications are being observed.</param>
+    /// <remarks>Missing parents suppress values to match the runtime expression-chain fallback.</remarks>
     private static void EmitObservationChainInnerSegments(
         StringBuilder sb,
         EquatableArray<PropertyPathSegment> path,
@@ -737,7 +738,14 @@ internal static class ObservationCodeGenerator
 
             if (rootPlugin is not null)
             {
-                rootPlugin.EmitDeepChainInnerSegment(sb, prevVar, curVar, lambdaParam, seg, isBeforeChange);
+                rootPlugin.EmitDeepChainInnerSegment(
+                    sb,
+                    prevVar,
+                    curVar,
+                    lambdaParam,
+                    seg,
+                    isBeforeChange,
+                    NullParentObservationBehavior.SuppressEmission);
             }
             else if (IsINPChanging(classInfo) && isBeforeChange)
             {
@@ -750,7 +758,7 @@ internal static class ObservationCodeGenerator
                                                          (global::System.ComponentModel.INotifyPropertyChanging){lambdaParam},
                                                          "{seg.PropertyName}",
                                                          (global::System.ComponentModel.INotifyPropertyChanging __o) => (({seg.DeclaringTypeFullName})__o).{seg.PropertyName})
-                                                     : (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))));
+                                                     : (global::System.IObservable<{segType}>)global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance));
                                  """);
             }
             else
@@ -759,8 +767,10 @@ internal static class ObservationCodeGenerator
                     .AppendLine($"""
                                          var {curVar} = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
                                              global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select({prevVar},
-                                                 {lambdaParam} => (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(
-                                                     {lambdaParam} != null ? (({seg.DeclaringTypeFullName}){lambdaParam}).{seg.PropertyName} : default({segType}))));
+                                                 {lambdaParam} => {lambdaParam} != null
+                                                     ? (global::System.IObservable<{segType}>)
+                                                         new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>((({seg.DeclaringTypeFullName}){lambdaParam}).{seg.PropertyName})
+                                                     : (global::System.IObservable<{segType}>)global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance));
                                  """);
             }
         }
@@ -779,6 +789,7 @@ internal static class ObservationCodeGenerator
     /// </param>
     /// <param name="isBeforeChange">Whether before-change notifications are being observed.</param>
     /// <param name="varName">The variable-name prefix for the emitted stages.</param>
+    /// <remarks>Missing parents suppress values to match the runtime expression-chain fallback.</remarks>
     private static void EmitDeepChainInnerSegments(
         StringBuilder sb,
         EquatableArray<PropertyPathSegment> path,
@@ -797,7 +808,14 @@ internal static class ObservationCodeGenerator
 
             if (rootPlugin is not null)
             {
-                rootPlugin.EmitDeepChainInnerSegment(sb, prevObsVar, curObsVar, lambdaParam, seg, isBeforeChange);
+                rootPlugin.EmitDeepChainInnerSegment(
+                    sb,
+                    prevObsVar,
+                    curObsVar,
+                    lambdaParam,
+                    seg,
+                    isBeforeChange,
+                    NullParentObservationBehavior.SuppressEmission);
             }
             else if (IsINPChanging(classInfo) && isBeforeChange)
             {
@@ -810,7 +828,7 @@ internal static class ObservationCodeGenerator
                                                          (global::System.ComponentModel.INotifyPropertyChanging){lambdaParam},
                                                          "{seg.PropertyName}",
                                                          (global::System.ComponentModel.INotifyPropertyChanging __o) => (({seg.DeclaringTypeFullName})__o).{seg.PropertyName})
-                                                     : (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))));
+                                                     : (global::System.IObservable<{segType}>)global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance));
                                  """);
             }
             else
@@ -819,8 +837,10 @@ internal static class ObservationCodeGenerator
                     .AppendLine($"""
                   var {curObsVar} = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
                       global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select({prevObsVar},
-                          {lambdaParam} => (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(
-                              {lambdaParam} != null ? (({seg.DeclaringTypeFullName}){lambdaParam}).{seg.PropertyName} : default({segType}))));
+                          {lambdaParam} => {lambdaParam} != null
+                              ? (global::System.IObservable<{segType}>)
+                                  new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>((({seg.DeclaringTypeFullName}){lambdaParam}).{seg.PropertyName})
+                              : (global::System.IObservable<{segType}>)global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance));
           """);
             }
         }
@@ -836,6 +856,7 @@ internal static class ObservationCodeGenerator
     /// <param name="classInfo">The root type's binding info, when known.</param>
     /// <param name="plugin">The observation plugin for the root type, when one matched.</param>
     /// <param name="variableName">The name of the variable the chain result is assigned to.</param>
+    /// <remarks>Missing parents emit defaults here so binding consumers can clear their targets.</remarks>
     private static void EmitInlineDeepChain(
         StringBuilder sb,
         string rootVar,
@@ -866,7 +887,14 @@ internal static class ObservationCodeGenerator
 
             if (plugin is not null)
             {
-                plugin.EmitDeepChainInnerSegment(sb, prevVar, curVar, lambdaParam, seg, false);
+                plugin.EmitDeepChainInnerSegment(
+                    sb,
+                    prevVar,
+                    curVar,
+                    lambdaParam,
+                    seg,
+                    isBeforeChange: false,
+                    nullParentBehavior: NullParentObservationBehavior.EmitDefault);
                 continue;
             }
 
@@ -876,8 +904,10 @@ internal static class ObservationCodeGenerator
                 .AppendLine($"""
                                  var {curVar} = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
                                      global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select({prevVar},
-                                         {lambdaParam} => (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(
-                                             {lambdaParam} != null ? (({declType}){lambdaParam}).{seg.PropertyName} : default({segType}))));
+                                         {lambdaParam} => {lambdaParam} != null
+                                             ? (global::System.IObservable<{segType}>)
+                                                 new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>((({declType}){lambdaParam}).{seg.PropertyName})
+                                             : (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))));
                              """);
         }
 

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/IObservationPlugin.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/IObservationPlugin.cs
@@ -102,13 +102,15 @@ internal interface IObservationPlugin
     /// <param name="lambdaParam">The lambda parameter name for the parent value.</param>
     /// <param name="segment">The current property path segment.</param>
     /// <param name="isBeforeChange">True for WhenChanging (before-change).</param>
+    /// <param name="nullParentBehavior">The behavior to use while the parent segment is null.</param>
     void EmitDeepChainInnerSegment(
         StringBuilder sb,
         string prevVar,
         string curVar,
         string lambdaParam,
         PropertyPathSegment segment,
-        bool isBeforeChange);
+        bool isBeforeChange,
+        NullParentObservationBehavior nullParentBehavior);
 
     /// <summary>Emits an inline observation variable for binding generators. Used by BindOneWay/BindTwoWay for direct observation code.</summary>
     /// <param name="sb">The string builder to append to.</param>

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/NullParentObservationBehavior.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/NullParentObservationBehavior.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Binding.SourceGenerators.Plugins;
+
+/// <summary>Specifies what a generated deep-chain observer emits while its parent segment is null.</summary>
+internal enum NullParentObservationBehavior
+{
+    /// <summary>Suppresses values until the parent becomes non-null.</summary>
+    SuppressEmission,
+
+    /// <summary>Emits the leaf type's default value so binding consumers can clear their target.</summary>
+    EmitDefault,
+}

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/AndroidObservationPlugin.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/AndroidObservationPlugin.cs
@@ -102,17 +102,23 @@ internal sealed class AndroidObservationPlugin : IObservationPlugin
         string curVar,
         string lambdaParam,
         PropertyPathSegment segment,
-        bool isBeforeChange)
+        bool isBeforeChange,
+        NullParentObservationBehavior nullParentBehavior)
     {
         var segType = segment.PropertyTypeFullName;
         var declType = segment.DeclaringTypeFullName;
+        var nullParentObservable = nullParentBehavior == NullParentObservationBehavior.EmitDefault
+            ? $"new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))"
+            : $"global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance";
 
         _ = sb.AppendLine()
             .AppendLine($"""
                                  var {curVar} = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
                                      global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select({prevVar},
-                                         {lambdaParam} => (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(
-                                             {lambdaParam} != null ? (({declType}){lambdaParam}).{segment.PropertyName} : default({segType}))));
+                                         {lambdaParam} => {lambdaParam} != null
+                                             ? (global::System.IObservable<{segType}>)
+                                                 new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>((({declType}){lambdaParam}).{segment.PropertyName})
+                                             : (global::System.IObservable<{segType}>){nullParentObservable}));
                          """);
     }
 

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/INPCObservationPlugin.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/INPCObservationPlugin.cs
@@ -119,9 +119,13 @@ internal sealed class INPCObservationPlugin : IObservationPlugin
         string curVar,
         string lambdaParam,
         PropertyPathSegment segment,
-        bool isBeforeChange)
+        bool isBeforeChange,
+        NullParentObservationBehavior nullParentBehavior)
     {
         var segType = segment.PropertyTypeFullName;
+        var nullParentObservable = nullParentBehavior == NullParentObservationBehavior.EmitDefault
+            ? $"new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))"
+            : $"global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance";
 
         _ = sb.AppendLine()
             .AppendLine(isBeforeChange
@@ -133,7 +137,7 @@ internal sealed class INPCObservationPlugin : IObservationPlugin
                                            (global::System.ComponentModel.INotifyPropertyChanging){lambdaParam},
                                            "{segment.PropertyName}",
                                            (global::System.ComponentModel.INotifyPropertyChanging __o) => (({segment.DeclaringTypeFullName})__o).{segment.PropertyName})
-                                       : (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))));
+                                       : (global::System.IObservable<{segType}>){nullParentObservable}));
                    """
                 : $"""
                            var {curVar} = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
@@ -144,7 +148,7 @@ internal sealed class INPCObservationPlugin : IObservationPlugin
                                            "{segment.PropertyName}",
                                            (global::System.ComponentModel.INotifyPropertyChanged __o) => (({segment.DeclaringTypeFullName})__o).{segment.PropertyName},
                                            false)
-                                       : (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))));
+                                       : (global::System.IObservable<{segType}>){nullParentObservable}));
                    """);
     }
 

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/KVOObservationPlugin.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/KVOObservationPlugin.cs
@@ -125,11 +125,15 @@ internal sealed class KVOObservationPlugin : IObservationPlugin
         string curVar,
         string lambdaParam,
         PropertyPathSegment segment,
-        bool isBeforeChange)
+        bool isBeforeChange,
+        NullParentObservationBehavior nullParentBehavior)
     {
         var segType = segment.PropertyTypeFullName;
         var declType = segment.DeclaringTypeFullName;
         var keyPath = ToKvoKeyPath(segment.PropertyName, segment.PropertyTypeFullName);
+        var nullParentObservable = nullParentBehavior == NullParentObservationBehavior.EmitDefault
+            ? $"new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))"
+            : $"global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance";
 
         _ = sb.AppendLine()
             .AppendLine($"""
@@ -142,7 +146,7 @@ internal sealed class KVOObservationPlugin : IObservationPlugin
                                                  (global::Foundation.NSObject __o) => (({declType})__o).{segment.PropertyName},
                                                  false,
                                                  {BoolLiteral(isBeforeChange)})
-                                             : (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))));
+                                             : (global::System.IObservable<{segType}>){nullParentObservable}));
                          """);
     }
 

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/ReactiveObjectObservationPlugin.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/ReactiveObjectObservationPlugin.cs
@@ -120,9 +120,13 @@ internal sealed class ReactiveObjectObservationPlugin : IObservationPlugin
         string curVar,
         string lambdaParam,
         PropertyPathSegment segment,
-        bool isBeforeChange)
+        bool isBeforeChange,
+        NullParentObservationBehavior nullParentBehavior)
     {
         var segType = segment.PropertyTypeFullName;
+        var nullParentObservable = nullParentBehavior == NullParentObservationBehavior.EmitDefault
+            ? $"new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))"
+            : $"global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance";
 
         _ = sb.AppendLine()
             .AppendLine(isBeforeChange
@@ -134,7 +138,7 @@ internal sealed class ReactiveObjectObservationPlugin : IObservationPlugin
                                            (global::System.ComponentModel.INotifyPropertyChanging){lambdaParam},
                                            "{segment.PropertyName}",
                                            (global::System.ComponentModel.INotifyPropertyChanging __o) => (({segment.DeclaringTypeFullName})__o).{segment.PropertyName})
-                                       : (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))));
+                                       : (global::System.IObservable<{segType}>){nullParentObservable}));
                    """
                 : $"""
                            var {curVar} = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
@@ -145,7 +149,7 @@ internal sealed class ReactiveObjectObservationPlugin : IObservationPlugin
                                            "{segment.PropertyName}",
                                            (global::System.ComponentModel.INotifyPropertyChanged __o) => (({segment.DeclaringTypeFullName})__o).{segment.PropertyName},
                                            false)
-                                       : (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))));
+                                       : (global::System.IObservable<{segType}>){nullParentObservable}));
                    """);
     }
 

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/WinFormsObservationPlugin.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/WinFormsObservationPlugin.cs
@@ -138,10 +138,14 @@ internal sealed class WinFormsObservationPlugin : IObservationPlugin
         string curVar,
         string lambdaParam,
         PropertyPathSegment segment,
-        bool isBeforeChange)
+        bool isBeforeChange,
+        NullParentObservationBehavior nullParentBehavior)
     {
         var segType = segment.PropertyTypeFullName;
         var declType = segment.DeclaringTypeFullName;
+        var nullParentObservable = nullParentBehavior == NullParentObservationBehavior.EmitDefault
+            ? $"new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))"
+            : $"global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance";
 
         if (isBeforeChange)
         {
@@ -149,8 +153,10 @@ internal sealed class WinFormsObservationPlugin : IObservationPlugin
                 .AppendLine($"""
                                      var {curVar} = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
                                          global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select({prevVar},
-                                             {lambdaParam} => (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(
-                                                 {lambdaParam} != null ? (({declType}){lambdaParam}).{segment.PropertyName} : default({segType}))));
+                                             {lambdaParam} => {lambdaParam} != null
+                                                 ? (global::System.IObservable<{segType}>)
+                                                     new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>((({declType}){lambdaParam}).{segment.PropertyName})
+                                                 : (global::System.IObservable<{segType}>){nullParentObservable}));
                              """);
             return;
         }
@@ -165,7 +171,7 @@ internal sealed class WinFormsObservationPlugin : IObservationPlugin
                                                  __h => (({declType}){lambdaParam}).{segment.PropertyName}Changed -= __h,
                                                  () => (({declType}){lambdaParam}).{segment.PropertyName},
                                                  false)
-                                             : (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))));
+                                             : (global::System.IObservable<{segType}>){nullParentObservable}));
                          """);
     }
 

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/WinUIObservationPlugin.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/WinUIObservationPlugin.cs
@@ -133,10 +133,14 @@ internal sealed class WinUIObservationPlugin : IObservationPlugin
         string curVar,
         string lambdaParam,
         PropertyPathSegment segment,
-        bool isBeforeChange)
+        bool isBeforeChange,
+        NullParentObservationBehavior nullParentBehavior)
     {
         var segType = segment.PropertyTypeFullName;
         var declType = segment.DeclaringTypeFullName;
+        var nullParentObservable = nullParentBehavior == NullParentObservationBehavior.EmitDefault
+            ? $"new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))"
+            : $"global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance";
 
         if (isBeforeChange)
         {
@@ -144,8 +148,10 @@ internal sealed class WinUIObservationPlugin : IObservationPlugin
                 .AppendLine($"""
                                      var {curVar} = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
                                          global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select({prevVar},
-                                             {lambdaParam} => (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(
-                                                 {lambdaParam} != null ? (({declType}){lambdaParam}).{segment.PropertyName} : default({segType}))));
+                                             {lambdaParam} => {lambdaParam} != null
+                                                 ? (global::System.IObservable<{segType}>)
+                                                     new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>((({declType}){lambdaParam}).{segment.PropertyName})
+                                                 : (global::System.IObservable<{segType}>){nullParentObservable}));
                              """);
             return;
         }
@@ -160,7 +166,7 @@ internal sealed class WinUIObservationPlugin : IObservationPlugin
                                                  {declType}.{segment.PropertyName}Property,
                                                  (global::Microsoft.UI.Xaml.DependencyObject __o) => (({declType})__o).{segment.PropertyName},
                                                  false)
-                                             : (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))));
+                                             : (global::System.IObservable<{segType}>){nullParentObservable}));
                          """);
     }
 

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/WpfObservationPlugin.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/WpfObservationPlugin.cs
@@ -146,10 +146,14 @@ internal sealed class WpfObservationPlugin : IObservationPlugin
         string curVar,
         string lambdaParam,
         PropertyPathSegment segment,
-        bool isBeforeChange)
+        bool isBeforeChange,
+        NullParentObservationBehavior nullParentBehavior)
     {
         var segType = segment.PropertyTypeFullName;
         var declType = segment.DeclaringTypeFullName;
+        var nullParentObservable = nullParentBehavior == NullParentObservationBehavior.EmitDefault
+            ? $"new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))"
+            : $"global::ReactiveUI.Binding.Observables.EmptyObservable<{segType}>.Instance";
 
         if (isBeforeChange)
         {
@@ -158,8 +162,10 @@ internal sealed class WpfObservationPlugin : IObservationPlugin
                 .AppendLine($"""
                                      var {curVar} = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
                                          global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select({prevVar},
-                                             {lambdaParam} => (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(
-                                                 {lambdaParam} != null ? (({declType}){lambdaParam}).{segment.PropertyName} : default({segType}))));
+                                             {lambdaParam} => {lambdaParam} != null
+                                                 ? (global::System.IObservable<{segType}>)
+                                                     new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>((({declType}){lambdaParam}).{segment.PropertyName})
+                                                 : (global::System.IObservable<{segType}>){nullParentObservable}));
                              """);
             return;
         }
@@ -176,7 +182,7 @@ internal sealed class WpfObservationPlugin : IObservationPlugin
                                                      {declType}.{segment.PropertyName}Property, typeof({declType})).RemoveValueChanged({lambdaParam}, __h),
                                                  () => (({declType}){lambdaParam}).{segment.PropertyName},
                                                  false)
-                                             : (global::System.IObservable<{segType}>)new global::ReactiveUI.Binding.Observables.ReturnObservable<{segType}>(default({segType}))));
+                                             : (global::System.IObservable<{segType}>){nullParentObservable}));
                          """);
     }
 

--- a/src/tests/ReactiveUI.Binding.GeneratedCode.TestModels/Scenarios/WhenAnyValueScenarios.cs
+++ b/src/tests/ReactiveUI.Binding.GeneratedCode.TestModels/Scenarios/WhenAnyValueScenarios.cs
@@ -43,4 +43,19 @@ public static class WhenAnyValueScenarios
     /// <returns>An observable of the nested City property value.</returns>
     public static IObservable<string> DeepChain_AddressCity(BigViewModel vm) =>
         vm.WhenAnyValue(x => x.Address.City);
+
+    /// <summary>
+    /// Deep property chain observation on HostTestFixture.Child!.Name.
+    /// Uses the null-forgiving operator to test generator support for nullable intermediates.
+    /// </summary>
+    /// <param name="host">The host fixture to observe.</param>
+    /// <returns>An observable of the nested Name property value.</returns>
+    public static IObservable<string> DeepChain_ChildName(HostTestFixture host) =>
+        host.WhenAnyValue(x => x.Child!.Name);
+
+    /// <summary>Deep property chain observation on HostTestFixture.Child!.Age.</summary>
+    /// <param name="host">The host fixture to observe.</param>
+    /// <returns>An observable of the nested Age property value.</returns>
+    public static IObservable<int> DeepChain_ChildAge(HostTestFixture host) =>
+        host.WhenAnyValue(x => x.Child!.Age);
 }

--- a/src/tests/ReactiveUI.Binding.GeneratedCode.TestModels/Scenarios/WhenAnyValueScenarios.cs
+++ b/src/tests/ReactiveUI.Binding.GeneratedCode.TestModels/Scenarios/WhenAnyValueScenarios.cs
@@ -53,6 +53,12 @@ public static class WhenAnyValueScenarios
     public static IObservable<string> DeepChain_ChildName(HostTestFixture host) =>
         host.WhenAnyValue(x => x.Child!.Name);
 
+    /// <summary>Three-link property chain observation on HostTestFixture.Child!.Child!.Name.</summary>
+    /// <param name="host">The host fixture to observe.</param>
+    /// <returns>An observable of the nested grandchild Name property value.</returns>
+    public static IObservable<string> DeepChain_GrandchildName(HostTestFixture host) =>
+        host.WhenAnyValue(x => x.Child!.Child!.Name);
+
     /// <summary>Deep property chain observation on HostTestFixture.Child!.Age.</summary>
     /// <param name="host">The host fixture to observe.</param>
     /// <returns>An observable of the nested Age property value.</returns>

--- a/src/tests/ReactiveUI.Binding.GeneratedCode.TestModels/TestModels/TestViewModel.cs
+++ b/src/tests/ReactiveUI.Binding.GeneratedCode.TestModels/TestModels/TestViewModel.cs
@@ -51,4 +51,21 @@ public class TestViewModel : INotifyPropertyChanged, INotifyPropertyChanging
             PropertyChanged?.Invoke(this, new(nameof(Age)));
         }
     }
+
+    /// <summary>Gets or sets the nested child used by three-link observation tests.</summary>
+    public TestViewModel? Child
+    {
+        get => field;
+        set
+        {
+            if (field == value)
+            {
+                return;
+            }
+
+            PropertyChanging?.Invoke(this, new(nameof(Child)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Child)));
+        }
+    }
 }

--- a/src/tests/ReactiveUI.Binding.GeneratedCode.Tests/WhenAnyValue/WhenAnyValueEdgeCaseTests.cs
+++ b/src/tests/ReactiveUI.Binding.GeneratedCode.Tests/WhenAnyValue/WhenAnyValueEdgeCaseTests.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using ReactiveUI.Binding.Fallback;
 using ReactiveUI.Binding.GeneratedCode.TestModels.Scenarios;
 using ReactiveUI.Binding.GeneratedCode.TestModels.TestModels;
 
@@ -33,6 +34,9 @@ public class WhenAnyValueEdgeCaseTests
 
     /// <summary>The value written to a property to trigger a change notification.</summary>
     private const string ChangedValue = "Changed";
+
+    /// <summary>The initial child name used in nullable deep-chain tests.</summary>
+    private const string Alice = "Alice";
 
     /// <summary>Verifies that disposing the WhenAnyValue subscription stops listening for changes.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
@@ -132,6 +136,78 @@ public class WhenAnyValueEdgeCaseTests
         newAddress.City = "Eugene";
 
         await Assert.That(values).Contains("Eugene");
+    }
+
+    /// <summary>
+    /// Verifies that a nullable deep chain preserves legacy ReactiveUI WhenAnyValue semantics.
+    /// A missing intermediate suppresses emission, and replacing it reattaches the observation.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task DeepChain_NullIntermediate_MatchesLegacyReactiveUISemantics()
+    {
+        var generatedHost = new HostTestFixture { Child = null };
+        var fallbackHost = new HostTestFixture { Child = null };
+        var generatedValues = new List<string>();
+        var fallbackValues = new List<string>();
+
+        using var generatedSub = WhenAnyValueScenarios.DeepChain_ChildName(generatedHost)
+            .Subscribe(generatedValues.Add);
+        using var fallbackSub = RuntimeObservationFallback
+            .WhenAnyValue(fallbackHost, x => x.Child!.Name)
+            .Subscribe(fallbackValues.Add);
+
+        generatedHost.Child = new() { Name = Alice };
+        fallbackHost.Child = new() { Name = Alice };
+        generatedHost.Child.Name = "Bob";
+        fallbackHost.Child.Name = "Bob";
+
+        generatedHost.Child = null;
+        fallbackHost.Child = null;
+
+        generatedHost.Child = new() { Name = "Charlie" };
+        fallbackHost.Child = new() { Name = "Charlie" };
+
+        var generatedTrace = string.Join('|', generatedValues);
+        var fallbackTrace = string.Join('|', fallbackValues);
+        await Assert.That(generatedTrace).IsEqualTo(fallbackTrace);
+        await Assert.That(generatedTrace).IsEqualTo("Alice|Bob|Charlie");
+    }
+
+    /// <summary>Verifies that a null leaf is still emitted when every intermediate object exists.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task DeepChain_NullLeaf_StillEmits()
+    {
+        var host = new HostTestFixture { Child = new() { Name = Alice } };
+        var values = new List<string>();
+
+        using var sub = WhenAnyValueScenarios.DeepChain_ChildName(host)
+            .Subscribe(values.Add);
+
+        host.Child.Name = null!;
+
+        await Assert.That(values.Count).IsEqualTo(ExpectedEmissionCount);
+        await Assert.That(values[1]).IsNull();
+    }
+
+    /// <summary>Verifies that a missing intermediate is distinct from a legitimate default-valued leaf.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task DeepChain_DefaultValueLeaf_EmitsOnlyWhenIntermediateExists()
+    {
+        var host = new HostTestFixture { Child = null };
+        var values = new List<int>();
+
+        using var sub = WhenAnyValueScenarios.DeepChain_ChildAge(host)
+            .Subscribe(values.Add);
+
+        await Assert.That(values.Count).IsEqualTo(0);
+
+        host.Child = new() { Age = 0 };
+
+        await Assert.That(values.Count).IsEqualTo(1);
+        await Assert.That(values[0]).IsEqualTo(0);
     }
 
     /// <summary>Verifies that WhenAnyValue with selector re-emits when properties change.</summary>

--- a/src/tests/ReactiveUI.Binding.GeneratedCode.Tests/WhenAnyValue/WhenAnyValueEdgeCaseTests.cs
+++ b/src/tests/ReactiveUI.Binding.GeneratedCode.Tests/WhenAnyValue/WhenAnyValueEdgeCaseTests.cs
@@ -38,6 +38,9 @@ public class WhenAnyValueEdgeCaseTests
     /// <summary>The initial child name used in nullable deep-chain tests.</summary>
     private const string Alice = "Alice";
 
+    /// <summary>The replacement child name used in nullable deep-chain tests.</summary>
+    private const string Charlie = "Charlie";
+
     /// <summary>Verifies that disposing the WhenAnyValue subscription stops listening for changes.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
@@ -165,13 +168,49 @@ public class WhenAnyValueEdgeCaseTests
         generatedHost.Child = null;
         fallbackHost.Child = null;
 
-        generatedHost.Child = new() { Name = "Charlie" };
-        fallbackHost.Child = new() { Name = "Charlie" };
+        generatedHost.Child = new() { Name = Charlie };
+        fallbackHost.Child = new() { Name = Charlie };
 
         var generatedTrace = string.Join('|', generatedValues);
         var fallbackTrace = string.Join('|', fallbackValues);
         await Assert.That(generatedTrace).IsEqualTo(fallbackTrace);
         await Assert.That(generatedTrace).IsEqualTo("Alice|Bob|Charlie");
+    }
+
+    /// <summary>
+    /// Verifies that breaking a three-link chain detaches the generated and legacy observers from
+    /// the orphaned subtree, while repairing the chain reattaches both implementations.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task DeepChain_ThreeLinks_DetachesOrphanedSubtreeLikeLegacyReactiveUI()
+    {
+        var generatedMiddle = new TestViewModel { Child = new() { Name = Alice } };
+        var fallbackMiddle = new TestViewModel { Child = new() { Name = Alice } };
+        var generatedHost = new HostTestFixture { Child = generatedMiddle };
+        var fallbackHost = new HostTestFixture { Child = fallbackMiddle };
+        var generatedValues = new List<string>();
+        var fallbackValues = new List<string>();
+
+        using var generatedSub = WhenAnyValueScenarios.DeepChain_GrandchildName(generatedHost)
+            .Subscribe(generatedValues.Add);
+        using var fallbackSub = RuntimeObservationFallback
+            .WhenAnyValue(fallbackHost, x => x.Child!.Child!.Name)
+            .Subscribe(fallbackValues.Add);
+
+        generatedHost.Child = null;
+        fallbackHost.Child = null;
+
+        generatedMiddle.Child!.Name = "Orphan mutation";
+        fallbackMiddle.Child!.Name = "Orphan mutation";
+
+        generatedHost.Child = new() { Child = new() { Name = Charlie } };
+        fallbackHost.Child = new() { Child = new() { Name = Charlie } };
+
+        var generatedTrace = string.Join('|', generatedValues);
+        var fallbackTrace = string.Join('|', fallbackValues);
+        await Assert.That(generatedTrace).IsEqualTo(fallbackTrace);
+        await Assert.That(generatedTrace).IsEqualTo("Alice|Charlie");
     }
 
     /// <summary>Verifies that a null leaf is still emitted when every intermediate object exists.</summary>

--- a/src/tests/ReactiveUI.Binding.GeneratedCode.Tests/WhenChanged/WhenChangedEdgeCaseTests.cs
+++ b/src/tests/ReactiveUI.Binding.GeneratedCode.Tests/WhenChanged/WhenChangedEdgeCaseTests.cs
@@ -331,10 +331,10 @@ public class WhenChangedEdgeCaseTests
         await Assert.That(values).Contains("Bob");
     }
 
-    /// <summary>Verifies that deep chain with null-forgiving operator emits default when the intermediate object is null.</summary>
+    /// <summary>Verifies that deep chain with null-forgiving operator does not emit when the intermediate object is null.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task DeepChain_NullForgiving_EmitsDefaultWhenChildNull()
+    public async Task DeepChain_NullForgiving_DoesNotEmitWhenChildNull()
     {
         var host = new HostTestFixture { Child = null };
         var values = new List<string>();
@@ -342,8 +342,7 @@ public class WhenChangedEdgeCaseTests
         using var sub = WhenChangedScenarios.DeepChain_ChildName(host)
             .Subscribe(values.Add);
 
-        // When Child is null, should emit default (null for string)
-        await Assert.That(values.Count).IsGreaterThanOrEqualTo(1);
+        await Assert.That(values.Count).IsEqualTo(0);
     }
 
     /// <summary>Verifies that deep chain with null-forgiving operator re-subscribes when the intermediate object is replaced.</summary>

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Plugins/ObservationPluginTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Plugins/ObservationPluginTests.cs
@@ -177,7 +177,7 @@ public class ObservationPluginTests
         var sb = new StringBuilder();
         var segment = ModelFactory.CreatePropertyPathSegment("City", StringName, AddressTypeName);
 
-        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, false);
+        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, false, NullParentObservationBehavior.SuppressEmission);
 
         var result = sb.ToString();
         await Assert.That(result).Contains(EventObservableName);
@@ -193,7 +193,7 @@ public class ObservationPluginTests
         var sb = new StringBuilder();
         var segment = ModelFactory.CreatePropertyPathSegment("City", StringName, AddressTypeName);
 
-        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, true);
+        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, true, NullParentObservationBehavior.SuppressEmission);
 
         await Assert.That(sb.ToString()).Contains(ReturnObservableName);
     }
@@ -336,7 +336,7 @@ public class ObservationPluginTests
         var sb = new StringBuilder();
         var segment = ModelFactory.CreatePropertyPathSegment("Text", StringName, InnerTypeName);
 
-        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, false);
+        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, false, NullParentObservationBehavior.SuppressEmission);
 
         var result = sb.ToString();
         await Assert.That(result).Contains(EventObservableName);
@@ -352,7 +352,7 @@ public class ObservationPluginTests
         var sb = new StringBuilder();
         var segment = ModelFactory.CreatePropertyPathSegment("Text", StringName, InnerTypeName);
 
-        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, true);
+        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, true, NullParentObservationBehavior.SuppressEmission);
 
         await Assert.That(sb.ToString()).Contains(ReturnObservableName);
     }
@@ -468,7 +468,7 @@ public class ObservationPluginTests
         var sb = new StringBuilder();
         var segment = ModelFactory.CreatePropertyPathSegment("Text", StringName, InnerTypeName);
 
-        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, false);
+        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, false, NullParentObservationBehavior.SuppressEmission);
 
         var result = sb.ToString();
         await Assert.That(result).Contains(WinUIDPObservableLocal);
@@ -484,7 +484,7 @@ public class ObservationPluginTests
         var sb = new StringBuilder();
         var segment = ModelFactory.CreatePropertyPathSegment("Text", StringName, InnerTypeName);
 
-        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, true);
+        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, true, NullParentObservationBehavior.SuppressEmission);
 
         await Assert.That(sb.ToString()).Contains(ReturnObservableName);
     }
@@ -594,7 +594,7 @@ public class ObservationPluginTests
         var sb = new StringBuilder();
         var segment = ModelFactory.CreatePropertyPathSegment("City", StringName, AddressTypeName);
 
-        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, false);
+        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, false, NullParentObservationBehavior.SuppressEmission);
 
         var result = sb.ToString();
         await Assert.That(result).Contains(KVOObservableLocal);
@@ -610,7 +610,7 @@ public class ObservationPluginTests
         var sb = new StringBuilder();
         var segment = ModelFactory.CreatePropertyPathSegment("City", StringName, AddressTypeName);
 
-        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, true);
+        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, true, NullParentObservationBehavior.SuppressEmission);
 
         var result = sb.ToString();
         await Assert.That(result).Contains(KVOObservableLocal);
@@ -749,7 +749,7 @@ public class ObservationPluginTests
         var sb = new StringBuilder();
         var segment = ModelFactory.CreatePropertyPathSegment("City", StringName, AddressTypeName);
 
-        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, false);
+        plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, false, NullParentObservationBehavior.SuppressEmission);
 
         var result = sb.ToString();
         await Assert.That(result).Contains(ReturnObservableName);

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.MP_DC#WhenAnyDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.MP_DC#WhenAnyDispatch.g.verified.cs
@@ -48,7 +48,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "Name",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ChildModel)__o).Name,
                         false)
-                    : (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.ReturnObservable<string>(default(string))));
+                    : (global::System.IObservable<string>)global::ReactiveUI.Binding.Observables.EmptyObservable<string>.Instance));
             var __propObs0 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.DistinctUntilChanged(__propObs0_s1);
 
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.SP_DC#WhenAnyDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.SP_DC#WhenAnyDispatch.g.verified.cs
@@ -45,7 +45,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "Name",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAny.DeepPropertyChain.ChildModel)__o).Name,
                         false)
-                    : (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.ReturnObservable<string>(default(string))));
+                    : (global::System.IObservable<string>)global::ReactiveUI.Binding.Observables.EmptyObservable<string>.Instance));
             var __propObs0 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.DistinctUntilChanged(__propObs0_s1);
 
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.2O_DC_CL#WhenAnyObservableDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.2O_DC_CL#WhenAnyObservableDispatch.g.verified.cs
@@ -48,7 +48,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "Count",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel)__o).Count,
                         false)
-                    : (global::System.IObservable<global::System.IObservable<int>>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::System.IObservable<int>>(default(global::System.IObservable<int>))));
+                    : (global::System.IObservable<global::System.IObservable<int>>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::System.IObservable<int>>.Instance));
             var __obsProperty0 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.DistinctUntilChanged(__obsProperty0_s1);
 
 
@@ -70,7 +70,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "Message",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel)__o).Message,
                         false)
-                    : (global::System.IObservable<global::System.IObservable<string>>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::System.IObservable<string>>(default(global::System.IObservable<string>))));
+                    : (global::System.IObservable<global::System.IObservable<string>>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::System.IObservable<string>>.Instance));
             var __obsProperty1 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.DistinctUntilChanged(__obsProperty1_s1);
 
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.2O_DC_Merge#WhenAnyObservableDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.2O_DC_Merge#WhenAnyObservableDispatch.g.verified.cs
@@ -47,7 +47,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "Command1",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel)__o).Command1,
                         false)
-                    : (global::System.IObservable<global::System.IObservable<string>>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::System.IObservable<string>>(default(global::System.IObservable<string>))));
+                    : (global::System.IObservable<global::System.IObservable<string>>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::System.IObservable<string>>.Instance));
             var __obsProperty0 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.DistinctUntilChanged(__obsProperty0_s1);
 
 
@@ -69,7 +69,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "Command2",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel)__o).Command2,
                         false)
-                    : (global::System.IObservable<global::System.IObservable<string>>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::System.IObservable<string>>(default(global::System.IObservable<string>))));
+                    : (global::System.IObservable<global::System.IObservable<string>>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::System.IObservable<string>>.Instance));
             var __obsProperty1 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.DistinctUntilChanged(__obsProperty1_s1);
 
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.SingleObservable_DC#WhenAnyObservableDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.SingleObservable_DC#WhenAnyObservableDispatch.g.verified.cs
@@ -44,7 +44,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "MyCommand",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ChildModel)__o).MyCommand,
                         false)
-                    : (global::System.IObservable<global::System.IObservable<string>>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::System.IObservable<string>>(default(global::System.IObservable<string>))));
+                    : (global::System.IObservable<global::System.IObservable<string>>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::System.IObservable<string>>.Instance));
             var __obsProperty = global::ReactiveUI.Binding.Observables.RxBindingExtensions.DistinctUntilChanged(__obsProperty_s1);
 
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.DPC#WhenAnyValueDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.DPC#WhenAnyValueDispatch.g.verified.cs
@@ -50,7 +50,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "Name",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ChildModel)__o).Name,
                         false)
-                    : (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.ReturnObservable<string>(default(string))));
+                    : (global::System.IObservable<string>)global::ReactiveUI.Binding.Observables.EmptyObservable<string>.Instance));
             return global::ReactiveUI.Binding.Observables.RxBindingExtensions.DistinctUntilChanged(__obs1);
         }
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.4LDC#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.4LDC#WhenChangedDispatch.g.verified.cs
@@ -50,7 +50,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "Model",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level2)__o).Model,
                         false)
-                    : (global::System.IObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level3>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level3>.Instance));
+                    : (global::System.IObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level3>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level3>(default(global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level3))));
 
         var __obs2 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
             global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select(__obs1,
@@ -60,7 +60,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "Model",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level3)__o).Model,
                         false)
-                    : (global::System.IObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Model>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Model>.Instance));
+                    : (global::System.IObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Model>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Model>(default(global::SharedScenarios.WhenChanged.FourLevelDeepChain.Model))));
 
         var __obs3 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
             global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select(__obs2,

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.4LDC#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.4LDC#WhenChangedDispatch.g.verified.cs
@@ -50,7 +50,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "Model",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level2)__o).Model,
                         false)
-                    : (global::System.IObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level3>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level3>(default(global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level3))));
+                    : (global::System.IObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level3>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level3>.Instance));
 
         var __obs2 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
             global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select(__obs1,
@@ -60,7 +60,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "Model",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level3)__o).Model,
                         false)
-                    : (global::System.IObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Model>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Model>(default(global::SharedScenarios.WhenChanged.FourLevelDeepChain.Model))));
+                    : (global::System.IObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Model>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Model>.Instance));
 
         var __obs3 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
             global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select(__obs2,
@@ -70,7 +70,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "Value",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.FourLevelDeepChain.Model)__o).Value,
                         false)
-                    : (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.ReturnObservable<string>(default(string))));
+                    : (global::System.IObservable<string>)global::ReactiveUI.Binding.Observables.EmptyObservable<string>.Instance));
             return global::ReactiveUI.Binding.Observables.RxBindingExtensions.DistinctUntilChanged(__obs3);
         }
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.DPC#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.DPC#WhenChangedDispatch.g.verified.cs
@@ -50,7 +50,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "Name",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.DeepPropertyChain.ChildModel)__o).Name,
                         false)
-                    : (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.ReturnObservable<string>(default(string))));
+                    : (global::System.IObservable<string>)global::ReactiveUI.Binding.Observables.EmptyObservable<string>.Instance));
             return global::ReactiveUI.Binding.Observables.RxBindingExtensions.DistinctUntilChanged(__obs1);
         }
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.MP_WDC#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.MP_WDC#WhenChangedDispatch.g.verified.cs
@@ -56,7 +56,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "City",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.AddressModel)__o).City,
                         false)
-                    : (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.ReturnObservable<string>(default(string))));
+                    : (global::System.IObservable<string>)global::ReactiveUI.Binding.Observables.EmptyObservable<string>.Instance));
             var __propObs0 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.DistinctUntilChanged(__propObs0_s1);
 
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.NullForgivingDC#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.NullForgivingDC#WhenChangedDispatch.g.verified.cs
@@ -50,7 +50,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         "Name",
                         (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ChildModel)__o).Name,
                         false)
-                    : (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.ReturnObservable<string>(default(string))));
+                    : (global::System.IObservable<string>)global::ReactiveUI.Binding.Observables.EmptyObservable<string>.Instance));
             return global::ReactiveUI.Binding.Observables.RxBindingExtensions.DistinctUntilChanged(__obs1);
         }
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.4LDC#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.4LDC#WhenChangingDispatch.g.verified.cs
@@ -48,7 +48,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         (global::System.ComponentModel.INotifyPropertyChanging)__parent1,
                         "Model",
                         (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2)__o).Model)
-                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>(default(global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3))));
+                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>.Instance));
 
         var __obs2 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
             global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select(__obs1,
@@ -57,7 +57,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         (global::System.ComponentModel.INotifyPropertyChanging)__parent2,
                         "Model",
                         (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3)__o).Model)
-                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>(default(global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model))));
+                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>.Instance));
 
         var __obs3 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
             global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select(__obs2,
@@ -66,7 +66,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         (global::System.ComponentModel.INotifyPropertyChanging)__parent3,
                         "Value",
                         (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model)__o).Value)
-                    : (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.ReturnObservable<string>(default(string))));
+                    : (global::System.IObservable<string>)global::ReactiveUI.Binding.Observables.EmptyObservable<string>.Instance));
             return __obs3;
         }
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.4LDC#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.4LDC#WhenChangingDispatch.g.verified.cs
@@ -48,7 +48,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         (global::System.ComponentModel.INotifyPropertyChanging)__parent1,
                         "Model",
                         (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2)__o).Model)
-                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>.Instance));
+                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>(default(global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3))));
 
         var __obs2 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
             global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select(__obs1,
@@ -57,7 +57,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         (global::System.ComponentModel.INotifyPropertyChanging)__parent2,
                         "Model",
                         (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3)__o).Model)
-                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>.Instance));
+                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>(default(global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model))));
 
         var __obs3 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
             global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select(__obs2,

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.4LDC_CFP#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.4LDC_CFP#WhenChangingDispatch.g.verified.cs
@@ -46,7 +46,7 @@ namespace ReactiveUI.Binding
                         (global::System.ComponentModel.INotifyPropertyChanging)__parent1,
                         "Model",
                         (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2)__o).Model)
-                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>.Instance));
+                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>(default(global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3))));
 
         var __obs2 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
             global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select(__obs1,
@@ -55,7 +55,7 @@ namespace ReactiveUI.Binding
                         (global::System.ComponentModel.INotifyPropertyChanging)__parent2,
                         "Model",
                         (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3)__o).Model)
-                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>.Instance));
+                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>(default(global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model))));
 
         var __obs3 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
             global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select(__obs2,

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.4LDC_CFP#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.4LDC_CFP#WhenChangingDispatch.g.verified.cs
@@ -46,7 +46,7 @@ namespace ReactiveUI.Binding
                         (global::System.ComponentModel.INotifyPropertyChanging)__parent1,
                         "Model",
                         (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2)__o).Model)
-                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>(default(global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3))));
+                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>.Instance));
 
         var __obs2 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
             global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select(__obs1,
@@ -55,7 +55,7 @@ namespace ReactiveUI.Binding
                         (global::System.ComponentModel.INotifyPropertyChanging)__parent2,
                         "Model",
                         (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3)__o).Model)
-                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>)new global::ReactiveUI.Binding.Observables.ReturnObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>(default(global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model))));
+                    : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>)global::ReactiveUI.Binding.Observables.EmptyObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model>.Instance));
 
         var __obs3 = global::ReactiveUI.Binding.Observables.RxBindingExtensions.Switch(
             global::ReactiveUI.Binding.Observables.RxBindingExtensions.Select(__obs2,
@@ -64,7 +64,7 @@ namespace ReactiveUI.Binding
                         (global::System.ComponentModel.INotifyPropertyChanging)__parent3,
                         "Value",
                         (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.FourLevelDeepChain.Model)__o).Value)
-                    : (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.ReturnObservable<string>(default(string))));
+                    : (global::System.IObservable<string>)global::ReactiveUI.Binding.Observables.EmptyObservable<string>.Instance));
             return __obs3;
         }
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.DPC#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.DPC#WhenChangingDispatch.g.verified.cs
@@ -48,7 +48,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         (global::System.ComponentModel.INotifyPropertyChanging)__parent1,
                         "Name",
                         (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel)__o).Name)
-                    : (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.ReturnObservable<string>(default(string))));
+                    : (global::System.IObservable<string>)global::ReactiveUI.Binding.Observables.EmptyObservable<string>.Instance));
             return __obs1;
         }
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.DPC_CFP#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.DPC_CFP#WhenChangingDispatch.g.verified.cs
@@ -46,7 +46,7 @@ namespace ReactiveUI.Binding
                         (global::System.ComponentModel.INotifyPropertyChanging)__parent1,
                         "Name",
                         (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel)__o).Name)
-                    : (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.ReturnObservable<string>(default(string))));
+                    : (global::System.IObservable<string>)global::ReactiveUI.Binding.Observables.EmptyObservable<string>.Instance));
             return __obs1;
         }
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.MP_WDC#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.MP_WDC#WhenChangingDispatch.g.verified.cs
@@ -54,7 +54,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                         (global::System.ComponentModel.INotifyPropertyChanging)__propObs0_p1,
                         "City",
                         (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.AddressModel)__o).City)
-                    : (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.ReturnObservable<string>(default(string))));
+                    : (global::System.IObservable<string>)global::ReactiveUI.Binding.Observables.EmptyObservable<string>.Instance));
             var __propObs0 = __propObs0_s1;
 
 


### PR DESCRIPTION
@glennawatson I came across this behavioural difference when trying to upgrade some applications. Performance improvements are incredible :D but this is blocking the upgrade.

## What kind of change does this PR introduce?

Bug fix - generated observation code no longer diverges from the runtime expression-chain semantics when an intermediate object in a property path is null.

## What is the new behavior?

`WhenAnyValue` and the other generated observation APIs suppress emission while an intermediate parent is null, and reattach when it becomes non-null again:

- `EmptyObservable<T>` is used while an intermediate parent is null.
- The outer `Switch` subscription stays alive, so observation reattaches once the parent is set.
- The behavior is applied across the generated observation mechanisms and the generic fallbacks.
- `ReturnObservable<T>(default(T))` is preserved for inline binding consumers, which need the default notification to clear targets and unregister handlers.
- The distinction is made explicit through the new `NullParentObservationBehavior` enum.

A legitimate null or default leaf is unaffected: if `Child` exists and `Child.Name` is null, that null is still emitted.

## What is the current behavior?

`WhenAnyValue` is documented as a drop-in ReactiveUI compatibility shim, but generated deep-property observations substitute `default(T)` whenever an intermediate object is null. Given:

```csharp
source.WhenAnyValue(x => x.Child!.Name)
```

the generated implementation emits `new ReturnObservable<T>(default(T))` while `Child` is null. An isolated comparison over an identical transition trace produced:

| Implementation | Emissions |
|---|---|
| ReactiveUI 22.3.1 | `Alice, Bob, Charlie` |
| `RuntimeObservationFallback` | `Alice, Bob, Charlie` |
| v4 generated implementation | `null, Alice, Bob, null, Charlie` |

Those synthetic values are observable behavior changes: reference-type consumers can receive an unexpected null and throw, and value-type consumers can receive a synthetic zero or false.

## What might this PR break?

This is an intentional behavioural change for generated observation:

- Consumers that relied on receiving `default(T)` while an intermediate was null will now receive nothing until the chain is repaired. This is the ReactiveUI-compatible behavior.
- Inline binding consumers (`Bind`, `BindOneWay`, `BindTwoWay`, `OneWayBind`, `BindCommand`, `BindInteraction`) are deliberately unchanged and still receive the default, so targets are cleared and handlers unregistered.
- Generated snapshots for the affected observation APIs change.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Regression coverage added:

- Compares generated `WhenAnyValue` directly with `RuntimeObservationFallback.WhenAnyValue` over an identical transition trace.
- Protects genuine null leaf emissions.
- Protects genuine default-valued value-type leaves.
- Updates the existing `WhenChanged` null-intermediate expectation.
- Retains the existing deep `BindInteraction` cleanup behavior.
- Updates generated snapshots for the affected observation APIs.

Validation:

- The test-only commit fails in the three expected null-intermediate cases, including the direct generated-versus-fallback comparison.
- With the implementation applied locally, source-generator tests pass: 758/758.
- With the implementation applied locally, generated-code tests pass: 179/179.
- Source-generator Release build succeeds with zero warnings and errors.
