### PR TITLE
chore(deps): update packages to their latest releases

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,21 +6,21 @@
 
   <!-- MAUI version varies by target framework -->
   <PropertyGroup>
-    <MauiVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.90</MauiVersion>
+    <MauiVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.100</MauiVersion>
     <MauiVersion Condition="$(TargetFramework.StartsWith('net11'))">11.0.0-preview.7.26406.9</MauiVersion>
   </PropertyGroup>
 
   <PropertyGroup>
     <!-- StyleSharp.Analyzers, PerformanceSharp.Analyzers and SecuritySharp.Analyzers ship from the
          same release pipeline and always share a version. -->
-    <RoslynCommonAnalyzersVersion>3.45.0</RoslynCommonAnalyzersVersion>
+    <RoslynCommonAnalyzersVersion>3.46.0</RoslynCommonAnalyzersVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- Testing Framework -->
     <PackageVersion Include="NSubstitute" Version="6.2.0"/>
-    <PackageVersion Include="TUnit" Version="1.65.0"/>
-    <PackageVersion Include="Verify.TUnit" Version="31.28.0"/>
+    <PackageVersion Include="TUnit" Version="1.66.8"/>
+    <PackageVersion Include="Verify.TUnit" Version="32.0.0"/>
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0"/>
 
     <!--
@@ -55,8 +55,8 @@
 
     <!-- Dependencies -->
     <PackageVersion Include="Splat" Version="21.0.0"/>
-    <PackageVersion Include="ReactiveUI.Primitives" Version="7.2.0"/>
-    <PackageVersion Include="ReactiveUI.Primitives.Reactive" Version="7.2.0"/>
+    <PackageVersion Include="ReactiveUI.Primitives" Version="7.3.0"/>
+    <PackageVersion Include="ReactiveUI.Primitives.Reactive" Version="7.3.0"/>
     <PackageVersion Include="System.Reactive" Version="7.0.0"/>
 
     <!-- Build Tools -->
@@ -64,9 +64,9 @@
     <PackageVersion Include="StyleSharp.Analyzers" Version="$(RoslynCommonAnalyzersVersion)"/>
     <PackageVersion Include="PerformanceSharp.Analyzers" Version="$(RoslynCommonAnalyzersVersion)"/>
     <PackageVersion Include="SecuritySharp.Analyzers" Version="$(RoslynCommonAnalyzersVersion)"/>
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.16.1"/>
+    <PackageVersion Include="Roslynator.Analyzers" Version="5.0.0"/>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400"/>
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.32.0.713"/>
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.33.0.1635"/>
     <PackageVersion Include="Blazor.Common.Analyzers" Version="2.1.0"/>
 
     <!-- MAUI -->
@@ -78,7 +78,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8"/>
 
     <!-- Test App Dependencies-->
-    <PackageVersion Include="ReactiveUI" Version="24.1.0"/>
+    <PackageVersion Include="ReactiveUI" Version="24.2.0"/>
     <PackageVersion Include="ReactiveUI.SourceGenerators" Version="3.2.0"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Build / dependency maintenance.

## What is the new behavior?

**Every centrally managed package moves to its latest release, except the Roslyn pins that decide which compilers can load the shipped generator.**

- **Runtime and platform dependencies move up.**
  - MAUI net10 heads go to 10.0.100.
  - ReactiveUI goes to 24.2.0, ReactiveUI.Primitives and ReactiveUI.Primitives.Reactive to 7.3.0.
- **The analyzer set moves to its current baseline.**
  - StyleSharp, PerformanceSharp and SecuritySharp go to 3.46.0.
  - Roslynator goes to 5.0.0 and the C# quality analyzer to 10.33.0.1635.
  - No new diagnostics fire, so no source changes were needed.
- **The test stack moves to TUnit 1.66.8 and Verify.TUnit 32.0.0.** Verify 32 accepts the existing snapshots unchanged; no `.verified.cs` file moves.

## What is the current behavior?

The pins predate these releases: MAUI 10.0.90, ReactiveUI 24.1.0, ReactiveUI.Primitives 7.2.0, the 3.45.0 analyzer baseline, Roslynator 4.16.1, TUnit 1.65.0 and Verify.TUnit 31.28.0.

## What might this PR break?

None expected.

- Roslynator and Verify.TUnit each cross a major version. Neither changes anything here, but both are the kind of bump worth knowing about when reading a later failure.
- `Microsoft.CodeAnalysis.CSharp` and `.Workspaces` deliberately stay on 4.14.0, with the shipping generator and analyzer projects still overriding to 4.8.0. That floor is what lets the .NET 8 SDK and Visual Studio 2022 17.8 load the analyzers at all; raising it would drop those consumers.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

The whole diff is nine version strings in `src/Directory.Packages.props`.
