### PR TITLE
fix(binding): apply and report a two-way binding from one pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,6 +514,7 @@ Not all platforms support before-change notifications (WPF DP, WinUI DP, WinForm
 | RXUIBIND007 | Warning | BindCommand control has no bindable event |
 | RXUIBIND008 | Warning | Property does not implement IInteraction |
 | RXUIBIND009 | Warning | Generated binding dispatch is out of reach from this file |
+| RXUIBIND010 | Warning | Observed path passes through a type that raises no notification |
 
 ## Code Style & Quality Requirements
 

--- a/README.md
+++ b/README.md
@@ -413,6 +413,43 @@ The separate analyzer package reports the following diagnostics:
 | RXUIBIND004 | Warning  | Type does not support before-change notifications (WhenChanging). WPF DependencyObjects, WinForms Components, and Android Views only support after-change notifications. |
 | RXUIBIND005 | Info     | Source type implements INotifyDataErrorInfo; validation state propagation is not generated and requires runtime engine or manual ErrorsChanged subscription.             |
 | RXUIBIND006 | Warning  | Expression contains an unsupported path segment (indexer, field, or method call). Only simple property access chains can be observed by the source generator.            |
+| RXUIBIND007 | Warning  | BindCommand control has no bindable event. Specify the `toEvent` parameter explicitly.                                                                                   |
+| RXUIBIND008 | Warning  | The property selected in a BindInteraction expression does not implement `IInteraction<TInput, TOutput>`.                                                                |
+| RXUIBIND009 | Warning  | The generated binding dispatch is out of reach from this file, so the call falls back to the runtime stub.                                                               |
+| RXUIBIND010 | Warning  | The observed path passes through a type that raises no notification, so it is read once and the observation stops following the path there.                              |
+
+## Where this differs from ReactiveUI
+
+Everything below is a deliberate difference from the reflection binding engine, and each one is here because
+generating the equivalent would put reflection back on the path that exists to remove it. Nothing else in the
+binding surface behaves differently.
+
+### `TriggerUpdate` and `signalViewUpdate` are not offered
+
+ReactiveUI's `Bind` accepts both: the first chooses which side wins the first write, the second replaces the
+view's own change stream with one the caller supplies. Neither has a generated overload, so asking for one does
+not compile rather than failing at run time.
+
+A generated binding is resolved from the two lambdas alone. An overload taking a caller-supplied stream has
+nothing to resolve at compile time and would have to hand the call to the runtime expression engine - which
+carries `[RequiresUnreferencedCode]` and breaks a `PublishAot` build for every consumer of that call site.
+
+The first write is instead decided the way ReactiveUI decides it by default: the view model side is applied
+first, and the view's own first value is then weighed against what was just written and dropped when equal.
+
+### A binding call made through a type parameter is not generated
+
+A generated overload has to name the bound types, and a call made through a type parameter names none - the
+type is only known once something closes it. Those call sites are left to the runtime stub, so a generic
+binding helper compiles and throws when it runs rather than emitting an overload naming a type parameter,
+which would fail the consumer's build outright.
+
+### A silent link in a path is reported at compile time, not at run time
+
+ReactiveUI logs a warning the first time it observes a property on a type that raises no notification.
+RXUIBIND010 reports the same thing while the consumer is building, which is the only place a generator can
+say it. The observation itself behaves the same either way: the value is read once and the path stops being
+followed at that link.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -373,17 +373,29 @@ All benchmarks use 1,000 property changes per iteration. Measured on AMD Ryzen 7
 The ReactiveUI expression-tree engine cannot run under NativeAOT due to its use of runtime reflection and expression
 compilation. The source-generated engine runs under NativeAOT with an additional 6x speedup over JIT.
 
-#### Binding (BindOneWay / BindTwoWay)
+#### Binding (BindOneWay / BindTwoWay / Bind)
 
 **Source-Generated:**
 
 | Method        | Runtime        |    Mean | Allocated |
 |---------------|----------------|--------:|----------:|
 | BindOneWay    | .NET 10.0      |  286 us |     64 KB |
-| BindTwoWay    | .NET 10.0      |  387 us |     88 KB |
+| BindTwoWay    | .NET 10.0      |  237 us |   87.8 KB |
+| Bind          | .NET 10.0      |  124 us |   42.2 KB |
 | First Binding | .NET 10.0      | 13.4 us |    1.3 KB |
 | BindOneWay    | NativeAOT 10.0 |   47 us |     65 KB |
-| BindTwoWay    | NativeAOT 10.0 |   58 us |     88 KB |
+| BindTwoWay    | NativeAOT 10.0 |   58 us |   88.4 KB |
+| Bind          | NativeAOT 10.0 |   25 us |   42.7 KB |
+
+Each figure is one binding created and then driven through 1,000 property changes.
+
+Watching a two-way binding costs almost nothing, because a subscriber shares the binding's own upstream
+subscription rather than re-projecting the two observed sides:
+
+| Method                  | Runtime   |    Mean | Allocated |
+|-------------------------|-----------|--------:|----------:|
+| Bind                    | .NET 10.0 |  124 us |   42.2 KB |
+| Bind + observed changes | .NET 10.0 |  125 us |   42.3 KB |
 
 **ReactiveUI Expression-Tree Engine:**
 

--- a/src/ReactiveUI.Binding.Analyzer/AnalyzerReleases.Unshipped.md
+++ b/src/ReactiveUI.Binding.Analyzer/AnalyzerReleases.Unshipped.md
@@ -11,3 +11,4 @@
  RXUIBIND007 | Usage    | Warning  | Control has no bindable event                                                           
  RXUIBIND008 | Usage    | Warning  | Property is not an IInteraction                                                         
  RXUIBIND009 | Usage    | Warning  | Generated binding dispatch is out of reach for this file
+ RXUIBIND010 | Usage    | Warning  | Observed path passes through a type that raises no notification

--- a/src/ReactiveUI.Binding.Analyzer/Analyzers/BindingInvocationAnalyzer.cs
+++ b/src/ReactiveUI.Binding.Analyzer/Analyzers/BindingInvocationAnalyzer.cs
@@ -505,11 +505,7 @@ public class BindingInvocationAnalyzer : DiagnosticAnalyzer
     /// <param name="body">The lambda body naming the observed path.</param>
     private static void ReportSilentLinks(in OperationAnalysisContext context, ExpressionSyntax body)
     {
-        var model = context.Operation.SemanticModel;
-        if (model is null)
-        {
-            return;
-        }
+        var model = context.Operation.SemanticModel!;
 
         // The path is written outermost-first, so walking down it reaches the root last. Every access whose
         // own receiver is itself an access is a link past the first.

--- a/src/ReactiveUI.Binding.Analyzer/Analyzers/BindingInvocationAnalyzer.cs
+++ b/src/ReactiveUI.Binding.Analyzer/Analyzers/BindingInvocationAnalyzer.cs
@@ -518,7 +518,8 @@ public class BindingInvocationAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (model.GetSymbolInfo(parent).Symbol is not IPropertySymbol { Type: INamedTypeSymbol linkType })
+            if (model.GetSymbolInfo(parent, context.CancellationToken).Symbol
+                is not IPropertySymbol { Type: INamedTypeSymbol linkType })
             {
                 continue;
             }

--- a/src/ReactiveUI.Binding.Analyzer/Analyzers/BindingInvocationAnalyzer.cs
+++ b/src/ReactiveUI.Binding.Analyzer/Analyzers/BindingInvocationAnalyzer.cs
@@ -15,12 +15,15 @@ namespace ReactiveUI.Binding.Analyzer.Analyzers;
 /// <summary>
 /// Analyzes binding and observation invocations (WhenChanged, WhenChanging, BindOneWay, BindTwoWay,
 /// OneWayBind, Bind, BindTo, BindCommand, BindInteraction) for common issues. The generic lambda checks
-/// (RXUIBIND001/003/006) apply to every recognized extension method; the remaining checks are
+/// (RXUIBIND001/003/006/010) apply to every recognized extension method; the remaining checks are
 /// method-specific (RXUIBIND004, RXUIBIND005, RXUIBIND007, RXUIBIND008).
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class BindingInvocationAnalyzer : DiagnosticAnalyzer
 {
+    /// <summary>The parameter type a property path arrives as, which marks it out from the other arguments.</summary>
+    private const string ExpressionParameterTypePrefix = "System.Linq.Expressions.Expression<";
+
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
@@ -30,7 +33,8 @@ public class BindingInvocationAnalyzer : DiagnosticAnalyzer
             DiagnosticWarnings.ValidationNotGenerated,
             DiagnosticWarnings.UnsupportedPathSegment,
             DiagnosticWarnings.NoBindableEvent,
-            DiagnosticWarnings.InvalidInteractionType);
+            DiagnosticWarnings.InvalidInteractionType,
+            DiagnosticWarnings.SilentPathLink);
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
@@ -64,6 +68,9 @@ public class BindingInvocationAnalyzer : DiagnosticAnalyzer
 
         // Check RXUIBIND006: Unsupported path segments (indexer, field, method call)
         CheckUnsupportedPathSegment(context, arguments);
+
+        // Check RXUIBIND010: A link in the middle of the path that raises no notification
+        CheckSilentPathLink(context, arguments);
 
         // Check RXUIBIND004: Before-change support
         if (methodName == Constants.WhenChangingMethodName)
@@ -112,7 +119,7 @@ public class BindingInvocationAnalyzer : DiagnosticAnalyzer
             var parameterType = arg.Parameter!.Type;
 
             var typeDisplay = parameterType.ToDisplayString();
-            if (!typeDisplay.StartsWith("System.Linq.Expressions.Expression<", StringComparison.Ordinal))
+            if (!typeDisplay.StartsWith(ExpressionParameterTypePrefix, StringComparison.Ordinal))
             {
                 continue;
             }
@@ -379,7 +386,7 @@ public class BindingInvocationAnalyzer : DiagnosticAnalyzer
             var parameterType = arg.Parameter!.Type;
 
             var typeDisplay = parameterType.ToDisplayString();
-            if (!typeDisplay.StartsWith("System.Linq.Expressions.Expression<", StringComparison.Ordinal))
+            if (!typeDisplay.StartsWith(ExpressionParameterTypePrefix, StringComparison.Ordinal))
             {
                 continue;
             }
@@ -397,6 +404,35 @@ public class BindingInvocationAnalyzer : DiagnosticAnalyzer
             }
 
             WalkForUnsupportedSegments(context, body);
+        }
+    }
+
+    /// <summary>Checks for RXUIBIND010: an observed path passing through a type that raises no notification.</summary>
+    /// <param name="context">The operation analysis context.</param>
+    /// <param name="arguments">The invocation arguments to inspect.</param>
+    /// <remarks>
+    /// Only links past the first are reported. The type the call site is made on is already answered for by the
+    /// warning on the type itself, whereas a type reached part way along a path is never named at the call site
+    /// and is where an observation silently stops following.
+    /// </remarks>
+    internal static void CheckSilentPathLink(
+        in OperationAnalysisContext context,
+        ImmutableArray<IArgumentOperation> arguments)
+    {
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            if (!IsExpressionArgument(arguments[i], out var lambda))
+            {
+                continue;
+            }
+
+            var body = GetLambdaBody(lambda!);
+            if (body is null)
+            {
+                continue;
+            }
+
+            ReportSilentLinks(context, body);
         }
     }
 
@@ -463,6 +499,60 @@ public class BindingInvocationAnalyzer : DiagnosticAnalyzer
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     internal static ExpressionSyntax? GetLambdaBody(LambdaExpressionSyntax lambda) =>
         lambda.Body as ExpressionSyntax;
+
+    /// <summary>Reports every link past the first whose declaring type raises no notification.</summary>
+    /// <param name="context">The operation analysis context.</param>
+    /// <param name="body">The lambda body naming the observed path.</param>
+    private static void ReportSilentLinks(in OperationAnalysisContext context, ExpressionSyntax body)
+    {
+        var model = context.Operation.SemanticModel;
+        if (model is null)
+        {
+            return;
+        }
+
+        // The path is written outermost-first, so walking down it reaches the root last. Every access whose
+        // own receiver is itself an access is a link past the first.
+        for (var current = body as MemberAccessExpressionSyntax;
+            current is not null;
+            current = current.Expression as MemberAccessExpressionSyntax)
+        {
+            if (current.Expression is not MemberAccessExpressionSyntax parent)
+            {
+                continue;
+            }
+
+            if (model.GetSymbolInfo(parent).Symbol is not IPropertySymbol { Type: INamedTypeSymbol linkType })
+            {
+                continue;
+            }
+
+            if (TypeAnalyzer.HasObservableMechanism(linkType, context.Compilation))
+            {
+                continue;
+            }
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    DiagnosticWarnings.SilentPathLink,
+                    parent.GetLocation(),
+                    linkType.Name,
+                    parent.ToString()));
+        }
+    }
+
+    /// <summary>Determines whether an argument is an inline lambda passed as an expression tree.</summary>
+    /// <param name="argument">The argument to inspect.</param>
+    /// <param name="lambda">The lambda, when the argument is one.</param>
+    /// <returns><see langword="true"/> when the argument is an expression-tree lambda.</returns>
+    private static bool IsExpressionArgument(IArgumentOperation argument, out LambdaExpressionSyntax? lambda)
+    {
+        lambda = null;
+
+        return argument.Parameter!.Type.ToDisplayString()
+                .StartsWith(ExpressionParameterTypePrefix, StringComparison.Ordinal)
+            && (lambda = argument.Value.Syntax as LambdaExpressionSyntax) is not null;
+    }
 
     /// <summary>Determines whether a non-empty constant <c>toEvent</c> argument was explicitly supplied.</summary>
     /// <param name="arguments">The invocation arguments to inspect.</param>

--- a/src/ReactiveUI.Binding.Shared/Observables/AppliedChangeObservable.cs
+++ b/src/ReactiveUI.Binding.Shared/Observables/AppliedChangeObservable.cs
@@ -59,7 +59,11 @@ public sealed class AppliedChangeObservable : IObservable<BindingChange>
 
     /// <summary>Drops one observer without disturbing a change already being delivered.</summary>
     /// <param name="observer">The observer to drop.</param>
-    private void Remove(IObserver<BindingChange> observer)
+    /// <remarks>
+    /// An observer that is not there is left alone. A subscription drops its own place once and no other path
+    /// reaches here, so that is a guard against a future caller rather than something the current ones do.
+    /// </remarks>
+    internal void Remove(IObserver<BindingChange> observer)
     {
         IObserver<BindingChange>[] current;
         IObserver<BindingChange>[] updated;

--- a/src/ReactiveUI.Binding.Shared/Observables/AppliedChangeObservable.cs
+++ b/src/ReactiveUI.Binding.Shared/Observables/AppliedChangeObservable.cs
@@ -1,0 +1,102 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive.Observables;
+#else
+namespace ReactiveUI.Binding.Observables;
+#endif
+
+/// <summary>The changes a two-way binding actually wrote, handed to whoever subscribes to the binding.</summary>
+/// <remarks>
+/// A two-way binding applies each change once and reports the same change to its subscribers, so both have to
+/// come from one place. Projecting the two observed sides a second time instead would attach another set of
+/// property handlers for every subscriber, and would report values the binding weighed and refused to write -
+/// the echo of a write is exactly what a subscriber is trying to tell apart from an edit.
+/// <para>
+/// Observers are kept in an array that is replaced rather than mutated, so a change already being delivered
+/// walks the set it started with and a subscription taken during delivery cannot disturb it.
+/// </para>
+/// </remarks>
+[DebuggerDisplay("AppliedChangeObservable: {_observers.Length} observer(s)")]
+public sealed class AppliedChangeObservable : IObservable<BindingChange>
+{
+    /// <summary>The observers a change is delivered to, replaced whenever the set changes.</summary>
+    private IObserver<BindingChange>[] _observers = [];
+
+    /// <summary>Reports a change the binding has written.</summary>
+    /// <param name="value">The change that was written.</param>
+    public void OnNext(BindingChange value)
+    {
+        var observers = Volatile.Read(ref _observers);
+        for (var i = 0; i < observers.Length; i++)
+        {
+            observers[i].OnNext(value);
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <exception cref="ArgumentNullException"><paramref name="observer"/> is null.</exception>
+    public IDisposable Subscribe(IObserver<BindingChange> observer)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(observer);
+
+        IObserver<BindingChange>[] updated;
+        IObserver<BindingChange>[] current;
+
+        do
+        {
+            current = Volatile.Read(ref _observers);
+            updated = new IObserver<BindingChange>[current.Length + 1];
+            Array.Copy(current, updated, current.Length);
+            updated[current.Length] = observer;
+        }
+        while (!ReferenceEquals(Interlocked.CompareExchange(ref _observers, updated, current), current));
+
+        return new Subscription(this, observer);
+    }
+
+    /// <summary>Drops one observer without disturbing a change already being delivered.</summary>
+    /// <param name="observer">The observer to drop.</param>
+    private void Remove(IObserver<BindingChange> observer)
+    {
+        IObserver<BindingChange>[] current;
+        IObserver<BindingChange>[] updated;
+
+        do
+        {
+            current = Volatile.Read(ref _observers);
+            var index = Array.IndexOf(current, observer);
+            if (index < 0)
+            {
+                return;
+            }
+
+            updated = new IObserver<BindingChange>[current.Length - 1];
+            Array.Copy(current, updated, index);
+            Array.Copy(current, index + 1, updated, index, current.Length - index - 1);
+        }
+        while (!ReferenceEquals(Interlocked.CompareExchange(ref _observers, updated, current), current));
+    }
+
+    /// <summary>Releases one observer's place in the change stream.</summary>
+    /// <param name="parent">The stream subscribed to.</param>
+    /// <param name="observer">The observer to drop on disposal.</param>
+    private sealed class Subscription(AppliedChangeObservable parent, IObserver<BindingChange> observer) : IDisposable
+    {
+        /// <summary>The observer to drop, cleared once dropped so disposing twice drops one place.</summary>
+        private IObserver<BindingChange>? _observer = observer;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _observer, null) is not { } dropped)
+            {
+                return;
+            }
+
+            parent.Remove(dropped);
+        }
+    }
+}

--- a/src/ReactiveUI.Binding.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/src/ReactiveUI.Binding.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -11,3 +11,4 @@
  RXUIBIND007 | Usage    | Warning  | Control has no bindable event                                                           
  RXUIBIND008 | Usage    | Warning  | Property is not an IInteraction                                                         
  RXUIBIND009 | Usage    | Warning  | Generated binding dispatch is out of reach for this file
+ RXUIBIND010 | Usage    | Warning  | Observed path passes through a type that raises no notification

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindCodeGenerator.cs
@@ -108,7 +108,6 @@ internal static class BindCodeGenerator
 
         var (viewModelVar, viewVar) = BindingEmitterHelpers.EmitDualStreamStages(sb, DispatchApi, inv);
         (viewModelVar, viewVar) = EmitRegistryConversionStages(sb, inv, viewModelVar, viewVar);
-        viewModelVar = BindingEmitterHelpers.EmitViewThreadStage(sb, inv, viewModelVar, "viewThreadObs");
 
         EmitTwoWaySubscription(sb, inv, viewModelVar, viewVar, viewPropertyAccess, viewModelSetAccess);
     }
@@ -146,36 +145,71 @@ internal static class BindCodeGenerator
     internal static string FormatMethodReturnType(BindingInvocationInfo inv) =>
         $"global::ReactiveUI.Binding.IReactiveBinding<{inv.TargetTypeFullName}, {BindingChange}>";
 
-    /// <summary>Emits the two-way subscription, change-stream merge, and <c>ReactiveBinding</c> return block.</summary>
+    /// <summary>Emits the two-way pipeline and the <c>ReactiveBinding</c> return block.</summary>
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="inv">The binding invocation info.</param>
-    /// <param name="viewModelVar">The view model observable variable name to subscribe to.</param>
-    /// <param name="viewVar">The view observable variable name to subscribe to.</param>
+    /// <param name="viewModelVar">The view model observable variable name.</param>
+    /// <param name="viewVar">The view observable variable name.</param>
     /// <param name="viewPropertyAccess">The view property setter access chain.</param>
     /// <param name="viewModelSetAccess">The view model property setter access chain.</param>
+    /// <remarks>
+    /// Both directions become one stream, which is then routed once and applied once. Three things follow from
+    /// that, and none of them hold when each direction is wired on its own.
+    /// <para>
+    /// The view model side is merged first, so its value reaches the view before the view's own first value is
+    /// weighed - and the guard, seeing them equal, drops that one. Dropping the view's first value by position
+    /// would eat a real change wherever the view reports nothing to begin with, which a chain through a null
+    /// intermediate does.
+    /// </para>
+    /// <para>
+    /// Routing the merged stream carries the view's read and the view model's write, not just the write to the
+    /// view. Routing one direction leaves the other running wherever its notification was raised.
+    /// </para>
+    /// <para>
+    /// What was applied is published to a subject the caller subscribes to, so a subscriber shares the one
+    /// upstream subscription rather than attaching another set of handlers, and never sees a value the guard
+    /// refused to write.
+    /// </para>
+    /// </remarks>
     private static void EmitTwoWaySubscription(
         StringBuilder sb,
         BindingInvocationInfo inv,
         string viewModelVar,
         string viewVar,
         string viewPropertyAccess,
-        string viewModelSetAccess) => _ = sb.AppendLine().Append("            var d1 = ").Append(BindingErrors).Append(".Subscribe(")
-            .Append(viewModelVar).AppendLine(", value =>").AppendLine(GeneratedSyntax.StatementBlockOpen).Append("                ").Append(viewPropertyAccess)
-            .AppendLine().Append("            }, \"").Append(CodeGeneratorHelpers.EscapeString(inv.TargetExpressionText)).AppendLine("\");")
-            .AppendLine().Append("            var __viewSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(").Append(viewVar)
-            .AppendLine(", 1);").Append("            var d2 = ").Append(BindingErrors).AppendLine(".Subscribe(__viewSkipped, value =>")
-            .AppendLine(GeneratedSyntax.StatementBlockOpen).Append("                ").Append(viewModelSetAccess).AppendLine().Append("            }, \"")
-            .Append(CodeGeneratorHelpers.EscapeString(inv.SourceExpressionText)).AppendLine("\");").AppendLine()
+        string viewModelSetAccess)
+    {
+        _ = sb.AppendLine()
             .Append("            var __vmTagged = new ").Append(MapSignal).Append('<').Append(inv.TargetPropertyTypeFullName).Append(", ")
             .Append(BindingChange).Append(">(").Append(viewModelVar).Append(", v => new ").Append(BindingChange).AppendLine("(v, true));")
             .Append("            var __viewTagged = new ").Append(MapSignal).Append('<').Append(inv.SourcePropertyTypeFullName).Append(", ")
-            .Append(BindingChange).Append(">(__viewSkipped, v => new ").Append(BindingChange).AppendLine("(v, false));")
-            .Append("            var changed = new ").Append(MergeSignal).Append('<').Append(BindingChange).AppendLine(">(__vmTagged, __viewTagged);")
-            .AppendLine().AppendLine("            var disposable = new global::ReactiveUI.Primitives.Disposables.MultipleDisposable(d1, d2);")
+            .Append(BindingChange).Append(">(").Append(viewVar).Append(", v => new ").Append(BindingChange).AppendLine("(v, false));")
+            .Append("            var __sides = new ").Append(MergeSignal).Append('<').Append(BindingChange).AppendLine(">(__vmTagged, __viewTagged);");
+
+        var routedVar = BindingEmitterHelpers.EmitViewThreadStage(sb, inv, "__sides", "__routed");
+
+        _ = sb.AppendLine("            var changed = new global::ReactiveUI.Binding.Observables.AppliedChangeObservable();")
+            .AppendLine().Append("            var disposable = ").Append(BindingErrors).Append(".Subscribe(").Append(routedVar).AppendLine(", __change =>")
+            .AppendLine(GeneratedSyntax.StatementBlockOpen)
+            .AppendLine("                if (__change.FromViewModel)")
+            .AppendLine("                {")
+            .Append("                    var value = (").Append(inv.TargetPropertyTypeFullName).AppendLine(")__change.Value;")
+            .Append("                    ").Append(viewPropertyAccess).AppendLine()
+            .AppendLine("                }")
+            .AppendLine("                else")
+            .AppendLine("                {")
+            .Append("                    var value = (").Append(inv.SourcePropertyTypeFullName).AppendLine(")__change.Value;")
+            .Append("                    ").Append(viewModelSetAccess).AppendLine()
+            .AppendLine("                }")
+            .AppendLine()
+            .AppendLine("                changed.OnNext(__change);")
+            .Append("            }, \"").Append(CodeGeneratorHelpers.EscapeString(inv.SourceExpressionText)).Append(" / ")
+            .Append(CodeGeneratorHelpers.EscapeString(inv.TargetExpressionText)).AppendLine("\");")
             .AppendLine().Append("            return new global::ReactiveUI.Binding.ReactiveBinding<").Append(inv.TargetTypeFullName).Append(", ")
             .Append(BindingChange).AppendLine(">(").AppendLine("                view,").AppendLine("                changed,")
             .AppendLine("                global::ReactiveUI.Binding.BindingDirection.TwoWay,").AppendLine("                disposable);")
             .AppendLine("        }").AppendLine();
+    }
 
     /// <summary>Emits the stages that convert each direction to the type the other side declares.</summary>
     /// <param name="sb">The string builder to append to.</param>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindTwoWayCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindTwoWayCodeGenerator.cs
@@ -107,7 +107,11 @@ internal static class BindTwoWayCodeGenerator
             TargetObservableName);
 
         var (sourceVar, targetVar) = BindingEmitterHelpers.EmitDualStreamStages(sb, DispatchApi, inv);
+
+        // Both directions are routed, and the source direction first, so its initial value is queued ahead of
+        // the target's. That ordering is what seeds the target before the target's own first value is weighed.
         sourceVar = BindingEmitterHelpers.EmitViewThreadStage(sb, inv, sourceVar, "targetThreadObs");
+        targetVar = BindingEmitterHelpers.EmitViewThreadStage(sb, inv, targetVar, "sourceThreadObs");
 
         EmitTwoWaySubscription(sb, inv, sourceVar, targetVar, targetAccess, sourceSetAccess);
     }
@@ -140,6 +144,13 @@ internal static class BindTwoWayCodeGenerator
     /// <param name="targetVar">The target observable variable name to subscribe to.</param>
     /// <param name="targetAccess">The target property setter access chain.</param>
     /// <param name="sourceSetAccess">The source property setter access chain.</param>
+    /// <remarks>
+    /// The target's own first value is weighed rather than dropped by position. Both observations report what
+    /// they hold when subscribed, and the source is subscribed first, so by the time the target reports the
+    /// target already carries the source's value and the equality guard drops it. Dropping the first value
+    /// positionally instead would eat a real change wherever the target reports nothing to begin with - a chain
+    /// through a null intermediate does exactly that.
+    /// </remarks>
     private static void EmitTwoWaySubscription(
         StringBuilder sb,
         BindingInvocationInfo inv,
@@ -149,8 +160,8 @@ internal static class BindTwoWayCodeGenerator
         string sourceSetAccess) => _ = sb.AppendLine().Append("            var d1 = ").Append(BindingErrors).Append(".Subscribe(").Append(sourceVar)
             .AppendLine(", value =>").AppendLine(GeneratedSyntax.StatementBlockOpen).Append("                ").Append(targetAccess).AppendLine()
             .Append("            }, \"").Append(CodeGeneratorHelpers.EscapeString(inv.TargetExpressionText)).AppendLine("\");").AppendLine()
-            .Append("            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(").Append(targetVar).AppendLine(", 1);")
-            .Append("            var d2 = ").Append(BindingErrors).AppendLine(".Subscribe(__targetSkipped, value =>").AppendLine(GeneratedSyntax.StatementBlockOpen)
+            .Append("            var d2 = ").Append(BindingErrors).Append(".Subscribe(").Append(targetVar).AppendLine(", value =>")
+            .AppendLine(GeneratedSyntax.StatementBlockOpen)
             .Append("                ").Append(sourceSetAccess).AppendLine().Append("            }, \"")
             .Append(CodeGeneratorHelpers.EscapeString(inv.SourceExpressionText)).AppendLine("\");").AppendLine()
             .AppendLine("            return new global::ReactiveUI.Primitives.Disposables.MultipleDisposable(d1, d2);").AppendLine("        }")

--- a/src/ReactiveUI.Binding.SourceGenerators/DiagnosticWarnings.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/DiagnosticWarnings.cs
@@ -38,6 +38,16 @@ internal static class DiagnosticWarnings
         true,
         NoObservablePropertiesDescription);
 
+    /// <summary>RXUIBIND010: A type in the middle of an observed path raises no notification.</summary>
+    internal static readonly DiagnosticDescriptor SilentPathLink = new(
+        "RXUIBIND010",
+        "Observed path passes through a type that raises no notification",
+        "Type '{0}' raises no notification, so '{1}' is read once and the observation stops following the path there",
+        UsageCategory,
+        DiagnosticSeverity.Warning,
+        true,
+        SilentPathLinkDescription);
+
     /// <summary>RXUIBIND003: Expression contains private/protected member.</summary>
     internal static readonly DiagnosticDescriptor PrivateMember = new(
         "RXUIBIND003",
@@ -158,4 +168,10 @@ internal static class DiagnosticWarnings
     /// <summary>The string description of the invalid interaction type warning.</summary>
     private const string InvalidInteractionTypeDescription =
         "The property selected in the BindInteraction expression must implement IInteraction<TInput, TOutput>.";
+
+    /// <summary>The string description of the silent path link warning.</summary>
+    private const string SilentPathLinkDescription =
+        "A type in the middle of an observed path that raises no notification is read once and never again, "
+        + "so the observation stops following the path at that link and never sees a later value. "
+        + "Give the type a notification mechanism, or observe a path that does not pass through it.";
 }

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/TypeDetectionExtractor.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/TypeDetectionExtractor.cs
@@ -83,9 +83,10 @@ internal static class TypeDetectionExtractor
         const int TypicalObservablePropertyCount = 16;
 
         var properties = new List<ObservablePropertyInfo>(TypicalObservablePropertyCount);
-        var members = typeSymbol.GetMembers();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var members = CollectMembersThroughOwnBases(typeSymbol, ct);
 
-        for (var i = 0; i < members.Length; i++)
+        for (var i = 0; i < members.Count; i++)
         {
             ct.ThrowIfCancellationRequested();
             if (members[i] is not IPropertySymbol property)
@@ -93,45 +94,98 @@ internal static class TypeDetectionExtractor
                 continue;
             }
 
-            if (property.IsStatic || property.IsWriteOnly)
+            if (property.IsStatic || property.IsWriteOnly || !seen.Add(property.Name))
             {
                 continue;
             }
 
-            var hasPublicGetter = property.GetMethod!.DeclaredAccessibility == Accessibility.Public;
-            var isIndexer = property.IsIndexer;
-
-            // A mechanism the type carries does not settle how any one property notifies: the dependency
-            // property field and the change event are declared per property, so record both here.
-            var isDependencyProperty = false;
-            var hasChangeEvent = false;
-            var dependencyPropertyName = $"{property.Name}Property";
-            var changeEventName = $"{property.Name}Changed";
-
-            for (var j = 0; j < members.Length; j++)
-            {
-                var member = members[j];
-
-                if (member is IFieldSymbol { IsStatic: true } && member.Name == dependencyPropertyName)
-                {
-                    isDependencyProperty = true;
-                }
-                else if (member is IEventSymbol && member.Name == changeEventName)
-                {
-                    hasChangeEvent = true;
-                }
-            }
+            FindCompanionMembers(members, property.Name, out var isDependencyProperty, out var hasChangeEvent);
 
             properties.Add(new(
                 property.Name,
                 property.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                hasPublicGetter,
-                isIndexer,
+                property.GetMethod!.DeclaredAccessibility == Accessibility.Public,
+                property.IsIndexer,
                 isDependencyProperty,
-                hasChangeEvent));
+                hasChangeEvent,
+                SymbolEqualityComparer.Default.Equals(property.ContainingType, typeSymbol)));
         }
 
         return new([.. properties]);
+    }
+
+    /// <summary>Finds the dependency-property field and change event a property notifies through.</summary>
+    /// <param name="members">The members of the type and of the bases its own assembly declares.</param>
+    /// <param name="propertyName">The property being described.</param>
+    /// <param name="isDependencyProperty">Set when a companion <c>{PropertyName}Property</c> field is declared.</param>
+    /// <param name="hasChangeEvent">Set when a companion <c>{PropertyName}Changed</c> event is declared.</param>
+    /// <remarks>
+    /// A mechanism the type carries does not settle how any one property notifies: the dependency property
+    /// field and the change event are declared per property, so both are recorded per property.
+    /// </remarks>
+    private static void FindCompanionMembers(
+        List<ISymbol> members,
+        string propertyName,
+        out bool isDependencyProperty,
+        out bool hasChangeEvent)
+    {
+        isDependencyProperty = false;
+        hasChangeEvent = false;
+
+        var dependencyPropertyName = $"{propertyName}Property";
+        var changeEventName = $"{propertyName}Changed";
+
+        for (var i = 0; i < members.Count; i++)
+        {
+            var member = members[i];
+
+            if (member is IFieldSymbol { IsStatic: true } && member.Name == dependencyPropertyName)
+            {
+                isDependencyProperty = true;
+            }
+            else if (member is IEventSymbol && member.Name == changeEventName)
+            {
+                hasChangeEvent = true;
+            }
+        }
+    }
+
+    /// <summary>Collects the members of a type and of the bases its own assembly declares.</summary>
+    /// <param name="typeSymbol">The type to collect from.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The members, most-derived first.</returns>
+    /// <remarks>
+    /// A property a type inherits is still a property a call site can name, and whether it notifies is settled
+    /// by the base that declares it. Reading only the type's own members leaves every inherited property
+    /// unknown, which the mechanism predicates have to treat as reachable - so a plain property inherited from
+    /// a base with no dependency-property field and no change event would still be observed as though it had
+    /// one.
+    /// <para>
+    /// The walk stops at the assembly boundary. A base the consumer wrote is worth reading and cheap; a
+    /// platform base is neither, and its properties genuinely are backed by the mechanism the type advertises,
+    /// which is what the unknown answer already assumes.
+    /// </para>
+    /// </remarks>
+    private static List<ISymbol> CollectMembersThroughOwnBases(INamedTypeSymbol typeSymbol, CancellationToken ct)
+    {
+        const int TypicalMemberCount = 32;
+
+        var members = new List<ISymbol>(TypicalMemberCount);
+        var assembly = typeSymbol.ContainingAssembly;
+
+        for (var type = typeSymbol; type is not null; type = type.BaseType)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (!SymbolEqualityComparer.Default.Equals(type.ContainingAssembly, assembly))
+            {
+                break;
+            }
+
+            members.AddRange(type.GetMembers());
+        }
+
+        return members;
     }
 
     /// <summary>Walks <c>AllInterfaces</c> to detect notification interfaces.</summary>

--- a/src/ReactiveUI.Binding.SourceGenerators/Models/ObservablePropertyInfo.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Models/ObservablePropertyInfo.cs
@@ -17,10 +17,17 @@ namespace ReactiveUI.Binding.SourceGenerators.Models;
 /// Whether the declaring type also declares a <c>{PropertyName}Changed</c> event, which is the convention the
 /// component mechanism observes a property through.
 /// </param>
+/// <param name="IsDeclaredByType">
+/// Whether the type this record was collected for declares the property itself, rather than inheriting it from
+/// a base in the same assembly. Key-value observing turns on this question - the Obj-C runtime backs what its
+/// own frameworks declare, not what an application adds to a subclass - so an inherited property has to stay
+/// distinguishable from a declared one even though both are now recorded.
+/// </param>
 internal sealed record ObservablePropertyInfo(
     string PropertyName,
     string PropertyTypeFullName,
     bool HasPublicGetter,
     bool IsIndexer,
     bool IsDependencyProperty,
-    bool HasChangeEvent);
+    bool HasChangeEvent,
+    bool IsDeclaredByType = true);

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/CommandBinding/CommandPropertyBindingPlugin.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/CommandBinding/CommandPropertyBindingPlugin.cs
@@ -119,6 +119,11 @@ internal sealed class CommandPropertyBindingPlugin : ICommandBindingPlugin
     /// <param name="inv">The BindCommand invocation info.</param>
     /// <param name="controlAccess">The access chain to the bound control.</param>
     /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
+    /// <remarks>
+    /// The parameter is written before the command. Assigning the command is what makes a control ask whether
+    /// it can execute, and it asks with whatever parameter it is holding at that moment, so setting the command
+    /// first decides the control's enabled state from the parameter belonging to the command it just replaced.
+    /// </remarks>
     private static void EmitObservableParameterBinding(
         StringBuilder sb,
         BindCommandInvocationInfo inv,
@@ -140,9 +145,9 @@ internal sealed class CommandPropertyBindingPlugin : ICommandBindingPlugin
             .AppendLine("            var __cmdSub = global::ReactiveUI.Primitives.SubscribeExtensions.Subscribe(commandObs, cmd =>")
             .AppendLine("            {")
             .AppendLine("                serial.Disposable = global::ReactiveUI.Primitives.Disposables.EmptyDisposable.Instance;")
-            .Append("                ").Append(controlAccess).AppendLine(".Command = cmd;")
             .Append("                var param = ").Append(CommandBindingSyntax.ReadLatestParameter(inv)).AppendLine(";")
             .Append("                ").Append(controlAccess).AppendLine(".CommandParameter = param;")
+            .Append("                ").Append(controlAccess).AppendLine(".Command = cmd;")
             .AppendLine("                if (cmd != null)")
             .AppendLine("                {")
             .AppendLine("                    serial.Disposable = global::ReactiveUI.Primitives.SubscribeExtensions.Subscribe(")

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/AfterChangeObservationPlugin.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/AfterChangeObservationPlugin.cs
@@ -11,9 +11,9 @@ namespace ReactiveUI.Binding.SourceGenerators.Plugins.Observation;
 /// <summary>The base for a mechanism that reports a property change only once it has happened.</summary>
 /// <remarks>
 /// A dependency property, a component's change event and an Android widget's event all raise after the value
-/// has already moved, so none of them can say what a property is about to become. Asking any of them for a
-/// before-change observation reads the value once and stays open - the same answer in every case, which is why
-/// it is decided here rather than in each plugin.
+/// has already moved, so none of them can say what a property is about to become. What they do about being
+/// asked anyway is the one thing that differs, so the shape is decided here and the answer is left to
+/// <see cref="AnswersBeforeChangeWithLiveStream"/>.
 /// </remarks>
 internal abstract class AfterChangeObservationPlugin
 {
@@ -26,6 +26,17 @@ internal abstract class AfterChangeObservationPlugin
 
     /// <summary>Gets a value indicating whether this mechanism can report a change before it happens.</summary>
     public bool SupportsBeforeChanged => false;
+
+    /// <summary>Gets a value indicating whether a before-change request is answered with the live change stream.</summary>
+    /// <remarks>
+    /// None of these mechanisms can say what a property is about to become, but they do not all decline the
+    /// question the same way. A dependency property hands back the stream it always has, so the caller keeps
+    /// tracking and merely receives the value after each change rather than before it. A component's change
+    /// event scores nothing for a before-change request instead, which withdraws the mechanism and leaves the
+    /// property read once. Following whichever the platform does is what keeps a before-change observation
+    /// behaving the same here as it does through the runtime engine.
+    /// </remarks>
+    protected virtual bool AnswersBeforeChangeWithLiveStream => false;
 
     /// <summary>Emits the observation of a property read directly off the object a call site named.</summary>
     /// <param name="sb">The string builder to append to.</param>
@@ -42,7 +53,7 @@ internal abstract class AfterChangeObservationPlugin
         bool isBeforeChange,
         bool includeStartWith)
     {
-        if (isBeforeChange)
+        if (isBeforeChange && !AnswersBeforeChangeWithLiveStream)
         {
             _ = UnchangingObservationEmitter.AppendExpression(sb, rootVar, segment, castTypeName);
             return;
@@ -66,7 +77,7 @@ internal abstract class AfterChangeObservationPlugin
         bool isBeforeChange,
         string varName)
     {
-        if (isBeforeChange)
+        if (isBeforeChange && !AnswersBeforeChangeWithLiveStream)
         {
             _ = UnchangingObservationEmitter.AppendVariable(sb, rootVar, segment, castTypeName, varName);
             return;
@@ -90,7 +101,7 @@ internal abstract class AfterChangeObservationPlugin
         bool isBeforeChange,
         string obsVarName)
     {
-        if (isBeforeChange)
+        if (isBeforeChange && !AnswersBeforeChangeWithLiveStream)
         {
             _ = UnchangingObservationEmitter.AppendTypedVariable(sb, rootVar, segment, castTypeName, obsVarName)
                 .AppendLine();
@@ -131,7 +142,7 @@ internal abstract class AfterChangeObservationPlugin
             .Append(GeneratedTypeNames.OpenChainSwitchMap(segment, segType, prevVar)).AppendLine().Append("            ").Append(lambdaParam)
             .Append(" => ").Append(lambdaParam).AppendLine(" != null");
 
-        if (isBeforeChange)
+        if (isBeforeChange && !AnswersBeforeChangeWithLiveStream)
         {
             _ = sb.Append("                ? (global::System.IObservable<").Append(segType);
             AppendUnchangingChainSegment(sb, lambdaParam, segment);

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/WpfObservationPlugin.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/WpfObservationPlugin.cs
@@ -60,6 +60,15 @@ internal sealed class WpfObservationPlugin : AfterChangeObservationPlugin, IObse
     public bool RequiresHelperClasses => false;
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// A dependency property has one change stream and hands it over whatever the caller asked for, so a
+    /// before-change observation keeps tracking the property and receives each value once it has settled. It
+    /// does not withdraw the mechanism the way a component's change event does, and reading the property once
+    /// instead would leave the observation silent for every change after the first.
+    /// </remarks>
+    protected override bool AnswersBeforeChangeWithLiveStream => true;
+
+    /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsAMatch(ClassBindingInfo classInfo) =>
         classInfo.InheritsWpfDependencyObject;

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/ObservedProperties.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/ObservedProperties.cs
@@ -8,9 +8,14 @@ namespace ReactiveUI.Binding.SourceGenerators.Plugins;
 
 /// <summary>Answers what a mechanism can reach on one property of a type that carries it.</summary>
 /// <remarks>
-/// A property the type does not declare is unknown, not absent: <see cref="ClassBindingInfo.Properties"/> lists
-/// declared members only, so an inherited property is missing from it. Treating unknown as observable keeps the
-/// mechanism the type advertises rather than silently withdrawing it over a question this cannot answer.
+/// <see cref="ClassBindingInfo.Properties"/> records what the type declares and what it inherits from bases in
+/// its own assembly, so a property the consumer wrote anywhere in its own hierarchy is answered from what that
+/// declaration actually carries.
+/// <para>
+/// A property still missing from it comes from somewhere the scan cannot see - a platform base - and is unknown
+/// rather than absent. Treating unknown as observable keeps the mechanism the type advertises, which is right
+/// for a platform base: that is exactly where a dependency property or a change event it declares would live.
+/// </para>
 /// </remarks>
 internal static class ObservedProperties
 {
@@ -46,7 +51,7 @@ internal static class ObservedProperties
     /// application adds to a subclass of them.
     /// </remarks>
     internal static bool IsDeclaredByConsumer(ClassBindingInfo classInfo, string propertyName) =>
-        Find(classInfo, propertyName) is not null;
+        Find(classInfo, propertyName) is { IsDeclaredByType: true };
 
     /// <summary>Finds the declared property of that name.</summary>
     /// <param name="classInfo">The declaring type's binding info.</param>

--- a/src/benchmarks/ReactiveUI.Binding.Benchmarks/BindBenchmark.cs
+++ b/src/benchmarks/ReactiveUI.Binding.Benchmarks/BindBenchmark.cs
@@ -1,0 +1,110 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+
+namespace ReactiveUI.Binding.Benchmarks;
+
+/// <summary>
+/// Source-generated view-first two-way binding. Both directions run through one pipeline that is routed once
+/// and applied once, and the changes it wrote are published to whoever subscribes to the binding - so the cost
+/// of making one, of driving it from either side, and of watching what it did are all measured here.
+/// </summary>
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+[SimpleJob(RuntimeMoniker.NativeAot10_0, id: nameof(RuntimeMoniker.NativeAot10_0))]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[MarkdownExporterAttribute.GitHub]
+public class BindBenchmark
+{
+    /// <summary>Represents the number of property change events to be triggered during the benchmark tests.</summary>
+    private const int PropertyChangeCount = 1_000;
+
+    /// <summary>The modulus used to alternate updates between the view model and the view each iteration.</summary>
+    private const int AlternationModulus = 2;
+
+    /// <summary>The view model used for binding benchmarks.</summary>
+    private BenchmarkViewModel _viewModel = null!;
+
+    /// <summary>The view used for binding benchmarks.</summary>
+    private BenchmarkView _view = null!;
+
+    /// <summary>Sets up a fresh view model and view before each benchmark iteration.</summary>
+    [IterationSetup]
+    public void Setup()
+    {
+        _viewModel = new() { Name = "Initial", Age = 0 };
+        _view = new() { ViewModel = null };
+    }
+
+    /// <summary>Binding once and driving it from the view model, which is the ordinary direction.</summary>
+    [Benchmark(Description = "Bind")]
+    public void Standard()
+    {
+        using var binding = _view.Bind(_viewModel, x => x.Name, x => x.DisplayName);
+
+        for (var i = 0; i < PropertyChangeCount; i++)
+        {
+            _viewModel.Name = $"Name_{i}";
+        }
+    }
+
+    /// <summary>Driving the binding from both sides, which is what the merged pipeline exists to order.</summary>
+    [Benchmark(Description = "Bind bidirectional")]
+    public void Bidirectional()
+    {
+        using var binding = _view.Bind(_viewModel, x => x.Name, x => x.DisplayName);
+
+        for (var i = 0; i < PropertyChangeCount; i++)
+        {
+            if (i % AlternationModulus == 0)
+            {
+                _viewModel.Name = $"FromViewModel_{i}";
+            }
+            else
+            {
+                _view.DisplayName = $"FromView_{i}";
+            }
+        }
+    }
+
+    /// <summary>
+    /// Watching what the binding wrote. A subscriber shares the binding's own upstream subscription, so this
+    /// measures whether observing a binding costs a second set of property handlers.
+    /// </summary>
+    [Benchmark(Description = "Bind + observed changes")]
+    public void WithObservedChanges()
+    {
+        using var binding = _view.Bind(_viewModel, x => x.Name, x => x.DisplayName);
+        using var watching = binding.Changed.Subscribe(new CountingObserver());
+
+        for (var i = 0; i < PropertyChangeCount; i++)
+        {
+            _viewModel.Name = $"Name_{i}";
+        }
+    }
+
+    /// <summary>Counts what a binding reported without allocating per change.</summary>
+    private sealed class CountingObserver : IObserver<BindingChange>
+    {
+        /// <summary>Gets how many changes were reported.</summary>
+        public int Count { get; private set; }
+
+        /// <inheritdoc/>
+        public void OnNext(BindingChange value) => Count++;
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Analyzer.Tests/BindingInvocationAnalyzerTests.RXUIBIND010.cs
+++ b/src/tests/ReactiveUI.Binding.Analyzer.Tests/BindingInvocationAnalyzerTests.RXUIBIND010.cs
@@ -1,0 +1,130 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Binding.Analyzer.Analyzers;
+using ReactiveUI.Binding.Analyzer.Tests.Helpers;
+
+namespace ReactiveUI.Binding.Analyzer.Tests;
+
+/// <summary>Tests for <see cref="BindingInvocationAnalyzer"/> — RXUIBIND010 (silent path link).</summary>
+public partial class BindingInvocationAnalyzerTests
+{
+    /// <summary>The diagnostic id reported for an observed path through a type that raises no notification.</summary>
+    private const string SilentPathLinkDiagnosticId = "RXUIBIND010";
+
+    /// <summary>
+    /// A type part way along the path that raises nothing is reported. The observation reads it once and stops
+    /// following the path there, which nothing at the call site would otherwise say.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RXUIBIND010_SilentIntermediate_InPropertyPath_ReportsDiagnostic()
+    {
+        const string Source = Preamble + """
+
+                                         namespace TestApp
+                                         {
+                                             public class Address
+                                             {
+                                                 public string City { get; set; } = "";
+                                             }
+
+                                             public class MyViewModel : INotifyPropertyChanged
+                                             {
+                                                 public event PropertyChangedEventHandler? PropertyChanged;
+
+                                                 public Address Address { get; set; } = new();
+                                             }
+
+                                             public class Usage
+                                             {
+                                                 public void Test()
+                                                 {
+                                                     var vm = new MyViewModel();
+                                                     ReactiveUI.Binding.__ReactiveUIGeneratedBindings.WhenChanged(vm, x => x.Address.City);
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<BindingInvocationAnalyzer>(Source);
+        var silentDiags = diagnostics.Where(static d => d.Id == SilentPathLinkDiagnosticId).ToArray();
+
+        await Assert.That(silentDiags.Length).IsEqualTo(1);
+    }
+
+    /// <summary>An intermediate that notifies is followed, so nothing is reported for it.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RXUIBIND010_NotifyingIntermediate_InPropertyPath_ReportsNothing()
+    {
+        const string Source = Preamble + """
+
+                                         namespace TestApp
+                                         {
+                                             public class Address : INotifyPropertyChanged
+                                             {
+                                                 public event PropertyChangedEventHandler? PropertyChanged;
+
+                                                 public string City { get; set; } = "";
+                                             }
+
+                                             public class MyViewModel : INotifyPropertyChanged
+                                             {
+                                                 public event PropertyChangedEventHandler? PropertyChanged;
+
+                                                 public Address Address { get; set; } = new();
+                                             }
+
+                                             public class Usage
+                                             {
+                                                 public void Test()
+                                                 {
+                                                     var vm = new MyViewModel();
+                                                     ReactiveUI.Binding.__ReactiveUIGeneratedBindings.WhenChanged(vm, x => x.Address.City);
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<BindingInvocationAnalyzer>(Source);
+        var silentDiags = diagnostics.Where(static d => d.Id == SilentPathLinkDiagnosticId).ToArray();
+
+        await Assert.That(silentDiags.Length).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// A shallow path reports nothing here. The only type it names is the one the call was made on, which is
+    /// already answered for where that type is declared.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RXUIBIND010_ShallowPath_ReportsNothing()
+    {
+        const string Source = Preamble + """
+
+                                         namespace TestApp
+                                         {
+                                             public class MyViewModel
+                                             {
+                                                 public string Name { get; set; } = "";
+                                             }
+
+                                             public class Usage
+                                             {
+                                                 public void Test()
+                                                 {
+                                                     var vm = new MyViewModel();
+                                                     ReactiveUI.Binding.__ReactiveUIGeneratedBindings.WhenChanged(vm, x => x.Name);
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<BindingInvocationAnalyzer>(Source);
+        var silentDiags = diagnostics.Where(static d => d.Id == SilentPathLinkDiagnosticId).ToArray();
+
+        await Assert.That(silentDiags.Length).IsEqualTo(0);
+    }
+}

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BCG.CommandPropertyObsParam#BindCommandDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BCG.CommandPropertyObsParam#BindCommandDispatch.g.verified.cs
@@ -99,9 +99,9 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             var __cmdSub = global::ReactiveUI.Primitives.SubscribeExtensions.Subscribe(commandObs, cmd =>
             {
                 serial.Disposable = global::ReactiveUI.Primitives.Disposables.EmptyDisposable.Instance;
-                view.SaveButton.Command = cmd;
                 var param = global::System.Threading.Volatile.Read(ref __latestParam);
                 view.SaveButton.CommandParameter = param;
+                view.SaveButton.Command = cmd;
                 if (cmd != null)
                 {
                     serial.Disposable = global::ReactiveUI.Primitives.SubscribeExtensions.Subscribe(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BG.2STB_GEI#BindDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BG.2STB_GEI#BindDispatch.g.verified.cs
@@ -88,34 +88,38 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 (object __o) => ((global::SharedScenarios.Bind.TwoSameTypeBindings.MyView)__o).FirstNameText,
                 false,
                 true);
-            var viewThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(vmObs);
 
-            var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(viewThreadObs, value =>
+            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(vmObs, v => new global::ReactiveUI.Binding.BindingChange(v, true));
+            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(viewObs, v => new global::ReactiveUI.Binding.BindingChange(v, false));
+            var __sides = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
+            var __routed = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(__sides);
+            var changed = new global::ReactiveUI.Binding.Observables.AppliedChangeObservable();
+
+            var disposable = global::ReactiveUI.Binding.BindingErrors.Subscribe(__routed, __change =>
             {
-                if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(view.FirstNameText, value))
+                if (__change.FromViewModel)
+                {
+                    var value = (string)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(view.FirstNameText, value))
                 {
                     return;
                 }
 
                 view.FirstNameText = value;
-            }, "x => x.FirstNameText");
-
-            var __viewSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(viewObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__viewSkipped, value =>
-            {
-                if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(viewModel.FirstName, value))
+                }
+                else
+                {
+                    var value = (string)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(viewModel.FirstName, value))
                 {
                     return;
                 }
 
                 viewModel.FirstName = value;
-            }, "x => x.FirstName");
+                }
 
-            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(viewThreadObs, v => new global::ReactiveUI.Binding.BindingChange(v, true));
-            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(__viewSkipped, v => new global::ReactiveUI.Binding.BindingChange(v, false));
-            var changed = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
-
-            var disposable = new global::ReactiveUI.Primitives.Disposables.MultipleDisposable(d1, d2);
+                changed.OnNext(__change);
+            }, "x => x.FirstName / x => x.FirstNameText");
 
             return new global::ReactiveUI.Binding.ReactiveBinding<global::SharedScenarios.Bind.TwoSameTypeBindings.MyView, global::ReactiveUI.Binding.BindingChange>(
                 view,
@@ -175,34 +179,38 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 (object __o) => ((global::SharedScenarios.Bind.TwoSameTypeBindings.MyView)__o).LastNameText,
                 false,
                 true);
-            var viewThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(vmObs);
 
-            var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(viewThreadObs, value =>
+            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(vmObs, v => new global::ReactiveUI.Binding.BindingChange(v, true));
+            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(viewObs, v => new global::ReactiveUI.Binding.BindingChange(v, false));
+            var __sides = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
+            var __routed = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(__sides);
+            var changed = new global::ReactiveUI.Binding.Observables.AppliedChangeObservable();
+
+            var disposable = global::ReactiveUI.Binding.BindingErrors.Subscribe(__routed, __change =>
             {
-                if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(view.LastNameText, value))
+                if (__change.FromViewModel)
+                {
+                    var value = (string)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(view.LastNameText, value))
                 {
                     return;
                 }
 
                 view.LastNameText = value;
-            }, "x => x.LastNameText");
-
-            var __viewSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(viewObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__viewSkipped, value =>
-            {
-                if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(viewModel.LastName, value))
+                }
+                else
+                {
+                    var value = (string)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(viewModel.LastName, value))
                 {
                     return;
                 }
 
                 viewModel.LastName = value;
-            }, "x => x.LastName");
+                }
 
-            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(viewThreadObs, v => new global::ReactiveUI.Binding.BindingChange(v, true));
-            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(__viewSkipped, v => new global::ReactiveUI.Binding.BindingChange(v, false));
-            var changed = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
-
-            var disposable = new global::ReactiveUI.Primitives.Disposables.MultipleDisposable(d1, d2);
+                changed.OnNext(__change);
+            }, "x => x.LastName / x => x.LastNameText");
 
             return new global::ReactiveUI.Binding.ReactiveBinding<global::SharedScenarios.Bind.TwoSameTypeBindings.MyView, global::ReactiveUI.Binding.BindingChange>(
                 view,

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BG.MB#BindDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BG.MB#BindDispatch.g.verified.cs
@@ -83,34 +83,38 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 (object __o) => ((global::SharedScenarios.Bind.MultipleBindings.MyView)__o).NameText,
                 false,
                 true);
-            var viewThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(vmObs);
 
-            var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(viewThreadObs, value =>
+            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(vmObs, v => new global::ReactiveUI.Binding.BindingChange(v, true));
+            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(viewObs, v => new global::ReactiveUI.Binding.BindingChange(v, false));
+            var __sides = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
+            var __routed = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(__sides);
+            var changed = new global::ReactiveUI.Binding.Observables.AppliedChangeObservable();
+
+            var disposable = global::ReactiveUI.Binding.BindingErrors.Subscribe(__routed, __change =>
             {
-                if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(view.NameText, value))
+                if (__change.FromViewModel)
+                {
+                    var value = (string)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(view.NameText, value))
                 {
                     return;
                 }
 
                 view.NameText = value;
-            }, "x => x.NameText");
-
-            var __viewSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(viewObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__viewSkipped, value =>
-            {
-                if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(viewModel.Name, value))
+                }
+                else
+                {
+                    var value = (string)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(viewModel.Name, value))
                 {
                     return;
                 }
 
                 viewModel.Name = value;
-            }, "x => x.Name");
+                }
 
-            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(viewThreadObs, v => new global::ReactiveUI.Binding.BindingChange(v, true));
-            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(__viewSkipped, v => new global::ReactiveUI.Binding.BindingChange(v, false));
-            var changed = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
-
-            var disposable = new global::ReactiveUI.Primitives.Disposables.MultipleDisposable(d1, d2);
+                changed.OnNext(__change);
+            }, "x => x.Name / x => x.NameText");
 
             return new global::ReactiveUI.Binding.ReactiveBinding<global::SharedScenarios.Bind.MultipleBindings.MyView, global::ReactiveUI.Binding.BindingChange>(
                 view,
@@ -193,34 +197,38 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 (object __o) => ((global::SharedScenarios.Bind.MultipleBindings.MyView)__o).AgeText,
                 false,
                 true);
-            var viewThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(vmObs);
 
-            var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(viewThreadObs, value =>
+            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<int, global::ReactiveUI.Binding.BindingChange>(vmObs, v => new global::ReactiveUI.Binding.BindingChange(v, true));
+            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<int, global::ReactiveUI.Binding.BindingChange>(viewObs, v => new global::ReactiveUI.Binding.BindingChange(v, false));
+            var __sides = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
+            var __routed = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(__sides);
+            var changed = new global::ReactiveUI.Binding.Observables.AppliedChangeObservable();
+
+            var disposable = global::ReactiveUI.Binding.BindingErrors.Subscribe(__routed, __change =>
             {
-                if (global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(view.AgeText, value))
+                if (__change.FromViewModel)
+                {
+                    var value = (int)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(view.AgeText, value))
                 {
                     return;
                 }
 
                 view.AgeText = value;
-            }, "x => x.AgeText");
-
-            var __viewSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(viewObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__viewSkipped, value =>
-            {
-                if (global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(viewModel.Age, value))
+                }
+                else
+                {
+                    var value = (int)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(viewModel.Age, value))
                 {
                     return;
                 }
 
                 viewModel.Age = value;
-            }, "x => x.Age");
+                }
 
-            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<int, global::ReactiveUI.Binding.BindingChange>(viewThreadObs, v => new global::ReactiveUI.Binding.BindingChange(v, true));
-            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<int, global::ReactiveUI.Binding.BindingChange>(__viewSkipped, v => new global::ReactiveUI.Binding.BindingChange(v, false));
-            var changed = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
-
-            var disposable = new global::ReactiveUI.Primitives.Disposables.MultipleDisposable(d1, d2);
+                changed.OnNext(__change);
+            }, "x => x.Age / x => x.AgeText");
 
             return new global::ReactiveUI.Binding.ReactiveBinding<global::SharedScenarios.Bind.MultipleBindings.MyView, global::ReactiveUI.Binding.BindingChange>(
                 view,

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BG.SP_S2S#BindDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BG.SP_S2S#BindDispatch.g.verified.cs
@@ -83,34 +83,38 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 (object __o) => ((global::SharedScenarios.Bind.SinglePropertyStringToString.MyView)__o).NameText,
                 false,
                 true);
-            var viewThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(vmObs);
 
-            var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(viewThreadObs, value =>
+            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(vmObs, v => new global::ReactiveUI.Binding.BindingChange(v, true));
+            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(viewObs, v => new global::ReactiveUI.Binding.BindingChange(v, false));
+            var __sides = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
+            var __routed = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(__sides);
+            var changed = new global::ReactiveUI.Binding.Observables.AppliedChangeObservable();
+
+            var disposable = global::ReactiveUI.Binding.BindingErrors.Subscribe(__routed, __change =>
             {
-                if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(view.NameText, value))
+                if (__change.FromViewModel)
+                {
+                    var value = (string)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(view.NameText, value))
                 {
                     return;
                 }
 
                 view.NameText = value;
-            }, "x => x.NameText");
-
-            var __viewSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(viewObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__viewSkipped, value =>
-            {
-                if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(viewModel.Name, value))
+                }
+                else
+                {
+                    var value = (string)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(viewModel.Name, value))
                 {
                     return;
                 }
 
                 viewModel.Name = value;
-            }, "x => x.Name");
+                }
 
-            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(viewThreadObs, v => new global::ReactiveUI.Binding.BindingChange(v, true));
-            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(__viewSkipped, v => new global::ReactiveUI.Binding.BindingChange(v, false));
-            var changed = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
-
-            var disposable = new global::ReactiveUI.Primitives.Disposables.MultipleDisposable(d1, d2);
+                changed.OnNext(__change);
+            }, "x => x.Name / x => x.NameText");
 
             return new global::ReactiveUI.Binding.ReactiveBinding<global::SharedScenarios.Bind.SinglePropertyStringToString.MyView, global::ReactiveUI.Binding.BindingChange>(
                 view,

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BG.SP_S2S_CFP#BindDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BG.SP_S2S_CFP#BindDispatch.g.verified.cs
@@ -83,34 +83,38 @@ namespace ReactiveUI.Binding
                 (object __o) => ((global::SharedScenarios.Bind.SinglePropertyStringToString.MyView)__o).NameText,
                 false,
                 true);
-            var viewThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(vmObs);
 
-            var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(viewThreadObs, value =>
+            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(vmObs, v => new global::ReactiveUI.Binding.BindingChange(v, true));
+            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(viewObs, v => new global::ReactiveUI.Binding.BindingChange(v, false));
+            var __sides = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
+            var __routed = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(__sides);
+            var changed = new global::ReactiveUI.Binding.Observables.AppliedChangeObservable();
+
+            var disposable = global::ReactiveUI.Binding.BindingErrors.Subscribe(__routed, __change =>
             {
-                if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(view.NameText, value))
+                if (__change.FromViewModel)
+                {
+                    var value = (string)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(view.NameText, value))
                 {
                     return;
                 }
 
                 view.NameText = value;
-            }, "x => x.NameText");
-
-            var __viewSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(viewObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__viewSkipped, value =>
-            {
-                if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(viewModel.Name, value))
+                }
+                else
+                {
+                    var value = (string)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(viewModel.Name, value))
                 {
                     return;
                 }
 
                 viewModel.Name = value;
-            }, "x => x.Name");
+                }
 
-            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(viewThreadObs, v => new global::ReactiveUI.Binding.BindingChange(v, true));
-            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(__viewSkipped, v => new global::ReactiveUI.Binding.BindingChange(v, false));
-            var changed = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
-
-            var disposable = new global::ReactiveUI.Primitives.Disposables.MultipleDisposable(d1, d2);
+                changed.OnNext(__change);
+            }, "x => x.Name / x => x.NameText");
 
             return new global::ReactiveUI.Binding.ReactiveBinding<global::SharedScenarios.Bind.SinglePropertyStringToString.MyView, global::ReactiveUI.Binding.BindingChange>(
                 view,

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BG.SP_WC#BindDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BG.SP_WC#BindDispatch.g.verified.cs
@@ -87,34 +87,38 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 true);
         var vmBind = new global::ReactiveUI.Primitives.Signals.MapSignal<int, string>(vmObs, viewModelToViewConverter);
         var viewBind = new global::ReactiveUI.Primitives.Signals.MapSignal<string, int>(viewObs, viewToViewModelConverter);
-            var viewThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(vmBind);
 
-            var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(viewThreadObs, value =>
+            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(vmBind, v => new global::ReactiveUI.Binding.BindingChange(v, true));
+            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<int, global::ReactiveUI.Binding.BindingChange>(viewBind, v => new global::ReactiveUI.Binding.BindingChange(v, false));
+            var __sides = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
+            var __routed = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(__sides);
+            var changed = new global::ReactiveUI.Binding.Observables.AppliedChangeObservable();
+
+            var disposable = global::ReactiveUI.Binding.BindingErrors.Subscribe(__routed, __change =>
             {
-                if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(view.CountText, value))
+                if (__change.FromViewModel)
+                {
+                    var value = (string)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(view.CountText, value))
                 {
                     return;
                 }
 
                 view.CountText = value;
-            }, "x => x.CountText");
-
-            var __viewSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(viewBind, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__viewSkipped, value =>
-            {
-                if (global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(viewModel.Count, value))
+                }
+                else
+                {
+                    var value = (int)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(viewModel.Count, value))
                 {
                     return;
                 }
 
                 viewModel.Count = value;
-            }, "x => x.Count");
+                }
 
-            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(viewThreadObs, v => new global::ReactiveUI.Binding.BindingChange(v, true));
-            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<int, global::ReactiveUI.Binding.BindingChange>(__viewSkipped, v => new global::ReactiveUI.Binding.BindingChange(v, false));
-            var changed = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
-
-            var disposable = new global::ReactiveUI.Primitives.Disposables.MultipleDisposable(d1, d2);
+                changed.OnNext(__change);
+            }, "x => x.Count / x => x.CountText");
 
             return new global::ReactiveUI.Binding.ReactiveBinding<global::SharedScenarios.Bind.SinglePropertyWithConverters.MyView, global::ReactiveUI.Binding.BindingChange>(
                 view,

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BG.SP_WCSched#BindDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BG.SP_WCSched#BindDispatch.g.verified.cs
@@ -91,32 +91,36 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
         var vmBind = global::ReactiveUI.Primitives.LinqExtensions.ObserveOn<string>(__vmSelected, scheduler);
         var viewBind = global::ReactiveUI.Primitives.LinqExtensions.ObserveOn<int>(__viewSelected, scheduler);
 
-            var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(vmBind, value =>
+            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(vmBind, v => new global::ReactiveUI.Binding.BindingChange(v, true));
+            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<int, global::ReactiveUI.Binding.BindingChange>(viewBind, v => new global::ReactiveUI.Binding.BindingChange(v, false));
+            var __sides = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
+            var changed = new global::ReactiveUI.Binding.Observables.AppliedChangeObservable();
+
+            var disposable = global::ReactiveUI.Binding.BindingErrors.Subscribe(__sides, __change =>
             {
-                if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(view.CountText, value))
+                if (__change.FromViewModel)
+                {
+                    var value = (string)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(view.CountText, value))
                 {
                     return;
                 }
 
                 view.CountText = value;
-            }, "x => x.CountText");
-
-            var __viewSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(viewBind, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__viewSkipped, value =>
-            {
-                if (global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(viewModel.Count, value))
+                }
+                else
+                {
+                    var value = (int)__change.Value;
+                    if (global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(viewModel.Count, value))
                 {
                     return;
                 }
 
                 viewModel.Count = value;
-            }, "x => x.Count");
+                }
 
-            var __vmTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<string, global::ReactiveUI.Binding.BindingChange>(vmBind, v => new global::ReactiveUI.Binding.BindingChange(v, true));
-            var __viewTagged = new global::ReactiveUI.Primitives.Signals.MapSignal<int, global::ReactiveUI.Binding.BindingChange>(__viewSkipped, v => new global::ReactiveUI.Binding.BindingChange(v, false));
-            var changed = new global::ReactiveUI.Primitives.Advanced.MergeSignal<global::ReactiveUI.Binding.BindingChange>(__vmTagged, __viewTagged);
-
-            var disposable = new global::ReactiveUI.Primitives.Disposables.MultipleDisposable(d1, d2);
+                changed.OnNext(__change);
+            }, "x => x.Count / x => x.CountText");
 
             return new global::ReactiveUI.Binding.ReactiveBinding<global::SharedScenarios.Bind.SinglePropertyWithConvertersAndScheduler.MyView, global::ReactiveUI.Binding.BindingChange>(
                 view,

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.KVO_NSObject_Target#BindTwoWayDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.KVO_NSObject_Target#BindTwoWayDispatch.g.verified.cs
@@ -92,6 +92,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 false,
                 true);
             var targetThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(sourceObs);
+            var sourceThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(targetObs);
 
             var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetThreadObs, value =>
             {
@@ -103,8 +104,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 target.Text = value;
             }, "x => x.Text");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(sourceThreadObs, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(source.Name, value))
                 {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.MB#BindTwoWayDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.MB#BindTwoWayDispatch.g.verified.cs
@@ -91,6 +91,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 false,
                 true);
             var targetThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(sourceObs);
+            var sourceThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(targetObs);
 
             var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetThreadObs, value =>
             {
@@ -102,8 +103,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 target.NameText = value;
             }, "x => x.NameText");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(sourceThreadObs, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(source.Name, value))
                 {
@@ -198,6 +198,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 false,
                 true);
             var targetThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(sourceObs);
+            var sourceThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(targetObs);
 
             var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetThreadObs, value =>
             {
@@ -209,8 +210,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 target.AgeDisplay = value;
             }, "x => x.AgeDisplay");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(sourceThreadObs, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(source.Age, value))
                 {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.MSTB#BindTwoWayDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.MSTB#BindTwoWayDispatch.g.verified.cs
@@ -96,6 +96,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 false,
                 true);
             var targetThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(sourceObs);
+            var sourceThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(targetObs);
 
             var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetThreadObs, value =>
             {
@@ -107,8 +108,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 target.FirstNameText = value;
             }, "x => x.FirstNameText");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(sourceThreadObs, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(source.FirstName, value))
                 {
@@ -173,6 +173,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 false,
                 true);
             var targetThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(sourceObs);
+            var sourceThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(targetObs);
 
             var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetThreadObs, value =>
             {
@@ -184,8 +185,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 target.LastNameText = value;
             }, "x => x.LastNameText");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(sourceThreadObs, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(source.LastName, value))
                 {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.MSTB_CFP#BindTwoWayDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.MSTB_CFP#BindTwoWayDispatch.g.verified.cs
@@ -89,6 +89,7 @@ namespace ReactiveUI.Binding
                 false,
                 true);
             var targetThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(sourceObs);
+            var sourceThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(targetObs);
 
             var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetThreadObs, value =>
             {
@@ -100,8 +101,7 @@ namespace ReactiveUI.Binding
                 target.FirstNameText = value;
             }, "x => x.FirstNameText");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(sourceThreadObs, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(source.FirstName, value))
                 {
@@ -166,6 +166,7 @@ namespace ReactiveUI.Binding
                 false,
                 true);
             var targetThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(sourceObs);
+            var sourceThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(targetObs);
 
             var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetThreadObs, value =>
             {
@@ -177,8 +178,7 @@ namespace ReactiveUI.Binding
                 target.LastNameText = value;
             }, "x => x.LastNameText");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(sourceThreadObs, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(source.LastName, value))
                 {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.MixedWithBindOneWay#BindTwoWayDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.MixedWithBindOneWay#BindTwoWayDispatch.g.verified.cs
@@ -91,6 +91,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 false,
                 true);
             var targetThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(sourceObs);
+            var sourceThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(targetObs);
 
             var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetThreadObs, value =>
             {
@@ -102,8 +103,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 target.NameText = value;
             }, "x => x.NameText");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(sourceThreadObs, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(source.Name, value))
                 {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.ReactiveObject_Both#BindTwoWayDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.ReactiveObject_Both#BindTwoWayDispatch.g.verified.cs
@@ -91,6 +91,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 false,
                 true);
             var targetThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(sourceObs);
+            var sourceThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(targetObs);
 
             var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetThreadObs, value =>
             {
@@ -102,8 +103,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 target.NameText = value;
             }, "x => x.NameText");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(sourceThreadObs, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(source.Name, value))
                 {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.SP_I2I#BindTwoWayDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.SP_I2I#BindTwoWayDispatch.g.verified.cs
@@ -91,6 +91,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 false,
                 true);
             var targetThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(sourceObs);
+            var sourceThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(targetObs);
 
             var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetThreadObs, value =>
             {
@@ -102,8 +103,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 target.DisplayCount = value;
             }, "x => x.DisplayCount");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(sourceThreadObs, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(source.Count, value))
                 {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.SP_S2S#BindTwoWayDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.SP_S2S#BindTwoWayDispatch.g.verified.cs
@@ -91,6 +91,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 false,
                 true);
             var targetThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(sourceObs);
+            var sourceThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(targetObs);
 
             var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetThreadObs, value =>
             {
@@ -102,8 +103,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 target.NameText = value;
             }, "x => x.NameText");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(sourceThreadObs, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(source.Name, value))
                 {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.SP_S2S_CFP#BindTwoWayDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.SP_S2S_CFP#BindTwoWayDispatch.g.verified.cs
@@ -84,6 +84,7 @@ namespace ReactiveUI.Binding
                 false,
                 true);
             var targetThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(sourceObs);
+            var sourceThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(targetObs);
 
             var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetThreadObs, value =>
             {
@@ -95,8 +96,7 @@ namespace ReactiveUI.Binding
                 target.NameText = value;
             }, "x => x.NameText");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetObs, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(sourceThreadObs, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(source.Name, value))
                 {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.SP_WC#BindTwoWayDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.SP_WC#BindTwoWayDispatch.g.verified.cs
@@ -95,6 +95,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
         var sourceBind = new global::ReactiveUI.Primitives.Signals.MapSignal<int, string>(sourceObs, sourceToTargetConv);
         var targetBind = new global::ReactiveUI.Primitives.Signals.MapSignal<string, int>(targetObs, targetToSourceConv);
             var targetThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(sourceBind);
+            var sourceThreadObs = global::ReactiveUI.Binding.BindingSchedulers.ObserveOnMainThread(targetBind);
 
             var d1 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetThreadObs, value =>
             {
@@ -106,8 +107,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 target.CountText = value;
             }, "x => x.CountText");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetBind, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(sourceThreadObs, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(source.Count, value))
                 {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.SP_WCSched#BindTwoWayDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.SP_WCSched#BindTwoWayDispatch.g.verified.cs
@@ -108,8 +108,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 target.CountText = value;
             }, "x => x.CountText");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetBind, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetBind, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(source.Count, value))
                 {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.SP_WithScheduler#BindTwoWayDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BTG.SP_WithScheduler#BindTwoWayDispatch.g.verified.cs
@@ -104,8 +104,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 target.NameText = value;
             }, "x => x.NameText");
 
-            var __targetSkipped = global::ReactiveUI.Primitives.LinqExtensions.Skip(targetBind, 1);
-            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(__targetSkipped, value =>
+            var d2 = global::ReactiveUI.Binding.BindingErrors.Subscribe(targetBind, value =>
             {
                 if (global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(source.Name, value))
                 {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/CodeGeneration/BindCodeGeneratorHelperTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/CodeGeneration/BindCodeGeneratorHelperTests.cs
@@ -308,7 +308,7 @@ public class BindCodeGeneratorHelperTests
         await Assert.That(result).Contains("ReactiveBinding");
         await Assert.That(result).Contains("view.Text = value");
         await Assert.That(result).Contains("viewModel.Name = value");
-        await Assert.That(result).Contains("Skip");
+        await Assert.That(result).DoesNotContain("Skip");
     }
 
     /// <summary>Verifies AppendExtraParameters appends conversion parameters.</summary>

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/CodeGeneration/BindTwoWayCodeGeneratorHelperTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/CodeGeneration/BindTwoWayCodeGeneratorHelperTests.cs
@@ -350,10 +350,14 @@ public class BindTwoWayCodeGeneratorHelperTests
         await Assert.That(result).Contains("scheduler");
     }
 
-    /// <summary>Verifies GenerateBindTwoWayMethod generates Skip(1) on target observable.</summary>
+    /// <summary>
+    /// The target's first value is weighed rather than dropped by position, and both directions are routed.
+    /// Dropping the first value positionally eats a real change wherever the target reports nothing to begin
+    /// with, and routing only the source direction leaves the write back running wherever the view raised it.
+    /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task GenerateBindTwoWayMethod_AlwaysGeneratesSkipOne()
+    public async Task GenerateBindTwoWayMethod_RoutesBothDirectionsAndWeighsTheTargetsFirstValue()
     {
         var sb = new StringBuilder();
         var inv = ModelFactory.CreateBindingInvocationInfo(isTwoWay: true, methodName: BindTwoWayName);
@@ -366,7 +370,9 @@ public class BindTwoWayCodeGeneratorHelperTests
         BindTwoWayCodeGenerator.GenerateBindTwoWayMethod(sb, inv, sourceClassInfo, targetClassInfo, TEST00000000TESTName);
 
         var result = sb.ToString();
-        await Assert.That(result).Contains("Skip");
+        await Assert.That(result).DoesNotContain("Skip");
+        await Assert.That(result).Contains("targetThreadObs");
+        await Assert.That(result).Contains("sourceThreadObs");
     }
 
     /// <summary>Verifies AppendExtraParameters appends conversion parameters with correct types.</summary>

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Plugins/ObservationPluginTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Plugins/ObservationPluginTests.cs
@@ -109,10 +109,13 @@ public class ObservationPluginTests
         await Assert.That(result).Contains("TextProperty");
     }
 
-    /// <summary>Verifies WPF plugin shallow observation before-change emits ImmediateReturnSignal.</summary>
+    /// <summary>
+    /// A dependency property has one change stream and hands it over whatever the caller asked for, so a
+    /// before-change observation keeps tracking rather than reading the property once.
+    /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task WpfPlugin_EmitShallowObservation_BeforeChange_EmitsTheUnchangingValue()
+    public async Task WpfPlugin_EmitShallowObservation_BeforeChange_KeepsReportingFromTheLiveStream()
     {
         var plugin = new WpfObservationPlugin();
         var sb = new StringBuilder();
@@ -120,7 +123,9 @@ public class ObservationPluginTests
 
         plugin.EmitShallowObservation(sb, "obj", segment, MyControlTypeName, true, true);
 
-        await Assert.That(sb.ToString()).Contains(UnchangingPropertyObservableName);
+        var result = sb.ToString();
+        await Assert.That(result).Contains(EventObservableName);
+        await Assert.That(result).DoesNotContain(UnchangingPropertyObservableName);
     }
 
     /// <summary>Verifies WPF plugin shallow observation variable emits EventObservable.</summary>
@@ -139,10 +144,10 @@ public class ObservationPluginTests
         await Assert.That(result).Contains(EventObservableName);
     }
 
-    /// <summary>Verifies WPF plugin shallow observation variable before-change emits ImmediateReturnSignal.</summary>
+    /// <summary>The same holds when the observation is assigned to a local.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task WpfPlugin_EmitShallowObservationVariable_BeforeChange_EmitsTheUnchangingValue()
+    public async Task WpfPlugin_EmitShallowObservationVariable_BeforeChange_KeepsReportingFromTheLiveStream()
     {
         var plugin = new WpfObservationPlugin();
         var sb = new StringBuilder();
@@ -150,7 +155,9 @@ public class ObservationPluginTests
 
         plugin.EmitShallowObservationVariable(sb, "obj", segment, MyControlTypeName, true, Obs0Local);
 
-        await Assert.That(sb.ToString()).Contains(UnchangingPropertyObservableName);
+        var result = sb.ToString();
+        await Assert.That(result).Contains(EventObservableName);
+        await Assert.That(result).DoesNotContain(UnchangingPropertyObservableName);
     }
 
     /// <summary>Verifies WPF plugin deep chain root segment after-change emits EventObservable.</summary>
@@ -169,10 +176,10 @@ public class ObservationPluginTests
         await Assert.That(result).Contains(Obs0Declaration);
     }
 
-    /// <summary>Verifies WPF plugin deep chain root segment before-change emits ImmediateReturnSignal.</summary>
+    /// <summary>The chain's first link keeps reporting too, so the links below it keep switching.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task WpfPlugin_EmitDeepChainRootSegment_BeforeChange_EmitsTheUnchangingValue()
+    public async Task WpfPlugin_EmitDeepChainRootSegment_BeforeChange_KeepsReportingFromTheLiveStream()
     {
         var plugin = new WpfObservationPlugin();
         var sb = new StringBuilder();
@@ -180,7 +187,9 @@ public class ObservationPluginTests
 
         plugin.EmitDeepChainRootSegment(sb, "obj", segment, MyControlTypeName, true, Obs0Local);
 
-        await Assert.That(sb.ToString()).Contains(UnchangingPropertyObservableName);
+        var result = sb.ToString();
+        await Assert.That(result).Contains(EventObservableName);
+        await Assert.That(result).DoesNotContain(UnchangingPropertyObservableName);
     }
 
     /// <summary>Verifies WPF plugin deep chain inner segment after-change emits EventObservable with Switch.</summary>
@@ -199,10 +208,10 @@ public class ObservationPluginTests
         await Assert.That(result).Contains(SwitchName);
     }
 
-    /// <summary>Verifies WPF plugin deep chain inner segment before-change emits ImmediateReturnSignal.</summary>
+    /// <summary>An inner link keeps reporting as well, so a change below the root is still seen.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task WpfPlugin_EmitDeepChainInnerSegment_BeforeChange_EmitsImmediateReturnSignal()
+    public async Task WpfPlugin_EmitDeepChainInnerSegment_BeforeChange_KeepsReportingFromTheLiveStream()
     {
         var plugin = new WpfObservationPlugin();
         var sb = new StringBuilder();
@@ -210,7 +219,9 @@ public class ObservationPluginTests
 
         plugin.EmitDeepChainInnerSegment(sb, Obs0Local, Obs1Local, "__p1", segment, true, NullParentObservationBehavior.SuppressEmission);
 
-        await Assert.That(sb.ToString()).Contains(ImmediateReturnSignalName);
+        var result = sb.ToString();
+        await Assert.That(result).Contains(EventObservableName);
+        await Assert.That(result).Contains(SwitchName);
     }
 
     /// <summary>A WPF inner segment that is not the leaf pushes the leaf's default value down the chain.</summary>

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/PropertyObservationCapabilityTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/PropertyObservationCapabilityTests.cs
@@ -113,6 +113,52 @@ public class PropertyObservationCapabilityTests
                                                              }
                                                              """;
 
+    /// <summary>A dependency object inheriting a plain CLR property from a base the consumer wrote.</summary>
+    private const string InheritedClrPropertySource = """
+                                                      using System;
+                                                      using ReactiveUI.Binding;
+
+                                                      namespace System.Windows
+                                                      {
+                                                          public class DependencyObject { }
+                                                      }
+
+                                                      namespace Consumer
+                                                      {
+                                                          public class BaseControl : System.Windows.DependencyObject
+                                                          {
+                                                              public string Caption { get; set; }
+                                                          }
+
+                                                          public class DerivedControl : BaseControl
+                                                          {
+                                                          }
+
+                                                          public static class Usage
+                                                          {
+                                                              public static IObservable<string> Observe(DerivedControl control)
+                                                              {
+                                                                  return control.WhenChanged(x => x.Caption);
+                                                              }
+                                                          }
+                                                      }
+                                                      """;
+
+    /// <summary>
+    /// A plain property inherited from a base the consumer wrote does not take the dependency-property path.
+    /// The base is readable, so whether the property has a companion field is a question with an answer, and
+    /// emitting the field name anyway names one that was never declared.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnAnInheritedClrProperty_DoesNotTakeTheDependencyPropertyPath()
+    {
+        var result = TestHelper.RunGenerator(InheritedClrPropertySource, LanguageVersion.CSharp10);
+
+        await result.CompilationSucceeds();
+        await result.GeneratedSourceDoesNotContain("WhenChangedDispatch.g.cs", "CaptionProperty");
+    }
+
     /// <summary>
     /// An inherited property stays observable. The observed type lists only what it declares, so a property it
     /// inherits is unknown to that list rather than absent from the mechanism, and withdrawing observation over

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/RuntimeExecution/TwoWayBindingRuntimeTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/RuntimeExecution/TwoWayBindingRuntimeTests.cs
@@ -1,0 +1,252 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Microsoft.CodeAnalysis.CSharp;
+using ReactiveUI.Binding.SourceGenerators.Tests.Helpers;
+
+namespace ReactiveUI.Binding.SourceGenerators.Tests.RuntimeExecution;
+
+/// <summary>
+/// Covers what a two-way binding seeds, writes and reports. Both directions run through one pipeline, so the
+/// order the initial values arrive in, the values the equality guard refuses, and what a subscriber to the
+/// binding sees are all decided together.
+/// </summary>
+public class TwoWayBindingRuntimeTests
+{
+    /// <summary>The value the view produces once its intermediate exists.</summary>
+    private const string ValueFromView = "edited";
+
+    /// <summary>A view whose bound property sits behind an intermediate that is null when the binding is made.</summary>
+    private const string LateIntermediateSource = """
+                                                  using System;
+                                                  using System.ComponentModel;
+                                                  using ReactiveUI.Binding;
+
+                                                  namespace TestApp
+                                                  {
+                                                      public class Inner : INotifyPropertyChanged
+                                                      {
+                                                          private string _text = "";
+
+                                                          public event PropertyChangedEventHandler PropertyChanged;
+
+                                                          public string Text
+                                                          {
+                                                              get { return _text; }
+                                                              set
+                                                              {
+                                                                  _text = value;
+                                                                  var handler = PropertyChanged;
+                                                                  if (handler != null)
+                                                                  {
+                                                                      handler(this, new PropertyChangedEventArgs("Text"));
+                                                                  }
+                                                              }
+                                                          }
+                                                      }
+
+                                                      public class MyViewModel : INotifyPropertyChanged
+                                                      {
+                                                          private string _name = "";
+
+                                                          public event PropertyChangedEventHandler PropertyChanged;
+
+                                                          public string Name
+                                                          {
+                                                              get { return _name; }
+                                                              set
+                                                              {
+                                                                  _name = value;
+                                                                  var handler = PropertyChanged;
+                                                                  if (handler != null)
+                                                                  {
+                                                                      handler(this, new PropertyChangedEventArgs("Name"));
+                                                                  }
+                                                              }
+                                                          }
+                                                      }
+
+                                                      public class MyView : INotifyPropertyChanged
+                                                      {
+                                                          private Inner _inner;
+
+                                                          public event PropertyChangedEventHandler PropertyChanged;
+
+                                                          public Inner Inner
+                                                          {
+                                                              get { return _inner; }
+                                                              set
+                                                              {
+                                                                  _inner = value;
+                                                                  var handler = PropertyChanged;
+                                                                  if (handler != null)
+                                                                  {
+                                                                      handler(this, new PropertyChangedEventArgs("Inner"));
+                                                                  }
+                                                              }
+                                                          }
+                                                      }
+
+                                                      public static class Usage
+                                                      {
+                                                          public static string Run()
+                                                          {
+                                                              var viewModel = new MyViewModel { Name = "start" };
+                                                              var view = new MyView();
+
+                                                              var binding = viewModel.BindTwoWay(view, x => x.Name, x => x.Inner.Text);
+
+                                                              // The intermediate arrives already carrying the edit, so the chain's
+                                                              // very first emission is the change itself.
+                                                              view.Inner = new Inner { Text = "edited" };
+
+                                                              return viewModel.Name;
+                                                          }
+                                                      }
+                                                  }
+                                                  """;
+
+    /// <summary>A two-way binding whose change stream is subscribed to after it is made.</summary>
+    private const string ReportedChangeSource = """
+                                                using System;
+                                                using System.Collections.Generic;
+                                                using System.ComponentModel;
+                                                using ReactiveUI.Binding;
+
+                                                namespace TestApp
+                                                {
+                                                    public class MyViewModel : INotifyPropertyChanged
+                                                    {
+                                                        private string _name = "";
+
+                                                        public event PropertyChangedEventHandler PropertyChanged;
+
+                                                        public string Name
+                                                        {
+                                                            get { return _name; }
+                                                            set
+                                                            {
+                                                                _name = value;
+                                                                var handler = PropertyChanged;
+                                                                if (handler != null)
+                                                                {
+                                                                    handler(this, new PropertyChangedEventArgs("Name"));
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+
+                                                    public class MyView : INotifyPropertyChanged, IViewFor<MyViewModel>
+                                                    {
+                                                        private string _text = "";
+
+                                                        public event PropertyChangedEventHandler PropertyChanged;
+
+                                                        public MyViewModel ViewModel { get; set; }
+
+                                                        object IViewFor.ViewModel
+                                                        {
+                                                            get { return ViewModel; }
+                                                            set { ViewModel = (MyViewModel)value; }
+                                                        }
+
+                                                        public string Text
+                                                        {
+                                                            get { return _text; }
+                                                            set
+                                                            {
+                                                                _text = value;
+                                                                var handler = PropertyChanged;
+                                                                if (handler != null)
+                                                                {
+                                                                    handler(this, new PropertyChangedEventArgs("Text"));
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+
+                                                    public static class Usage
+                                                    {
+                                                        public static string Run()
+                                                        {
+                                                            var viewModel = new MyViewModel { Name = "start" };
+                                                            var view = new MyView();
+                                                            view.ViewModel = viewModel;
+
+                                                            var binding = view.Bind(viewModel, x => x.Name, x => x.Text);
+
+                                                            var reported = new List<string>();
+                                                            using (binding.Changed.Subscribe(new Recorder(reported)))
+                                                            {
+                                                                viewModel.Name = "start";
+                                                                viewModel.Name = "moved";
+                                                            }
+
+                                                            return string.Join(",", reported);
+                                                        }
+                                                    }
+
+                                                    public class Recorder : IObserver<BindingChange>
+                                                    {
+                                                        private readonly List<string> _reported;
+
+                                                        public Recorder(List<string> reported)
+                                                        {
+                                                            _reported = reported;
+                                                        }
+
+                                                        public void OnNext(BindingChange value)
+                                                        {
+                                                            _reported.Add(value.Value == null ? "null" : value.Value.ToString());
+                                                        }
+
+                                                        public void OnError(Exception error)
+                                                        {
+                                                        }
+
+                                                        public void OnCompleted()
+                                                        {
+                                                        }
+                                                    }
+                                                }
+                                                """;
+
+    /// <summary>
+    /// A target behind an intermediate that arrives after the binding still writes back. The target's own
+    /// first value is weighed against what the source already put there rather than dropped by position, so
+    /// nothing depends on how many values the chain happened to produce before the edit.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTwoWay_WhenTheTargetsIntermediateArrivesLate_WritesTheEditBack() =>
+        await Assert.That(await RunScenarioAsync(LateIntermediateSource)).IsEqualTo(ValueFromView);
+
+    /// <summary>
+    /// The change stream reports what the binding wrote, and only that. A value equal to the one already held
+    /// is refused by the guard, so reporting it would tell a subscriber about a write that never happened.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Bind_SubscribingToChanged_ReportsOnlyTheValuesItWrote() =>
+        await Assert.That(await RunScenarioAsync(ReportedChangeSource)).IsEqualTo("moved");
+
+    /// <summary>Generates, compiles and runs a scenario, returning what its entry point reports.</summary>
+    /// <param name="source">The scenario source.</param>
+    /// <returns>The value the scenario's entry point returned.</returns>
+    private static async Task<string?> RunScenarioAsync(string source)
+    {
+        var result = TestHelper.RunGenerator(source, LanguageVersion.CSharp10);
+        await result.CompilationSucceeds();
+
+        var (assembly, context) = TestHelper.EmitAndLoad(result);
+        var run = assembly.GetType("TestApp.Usage")!.GetMethod("Run", BindingFlags.Public | BindingFlags.Static)!;
+
+        var outcome = (string?)run.Invoke(null, null);
+
+        context.Unload();
+
+        return outcome;
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Observables/AppliedChangeObservableTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Observables/AppliedChangeObservableTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using ReactiveUI.Binding.Observables;
+
+namespace ReactiveUI.Binding.Tests.Observables;
+
+/// <summary>Tests for <see cref="AppliedChangeObservable"/>, the changes a two-way binding wrote.</summary>
+public class AppliedChangeObservableTests
+{
+    /// <summary>A value a binding reports having written.</summary>
+    private const string FirstValue = "first";
+
+    /// <summary>A second value, used where the order changes arrive in matters.</summary>
+    private const string SecondValue = "second";
+
+    /// <summary>What an observer present for the first change alone receives.</summary>
+    private static readonly string[] FirstOnly = [FirstValue];
+
+    /// <summary>What an observer present for both changes receives.</summary>
+    private static readonly string[] FirstThenSecond = [FirstValue, SecondValue];
+
+    /// <summary>What an observer that joined after the first change receives.</summary>
+    private static readonly string[] SecondOnly = [SecondValue];
+
+    /// <summary>Reporting a change with nobody watching is what a binding usually does.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OnNext_WithNoObservers_ReportsToNobodyAndDoesNotThrow()
+    {
+        var changes = new AppliedChangeObservable();
+
+        await Assert.That(() => changes.OnNext(new(FirstValue, true))).ThrowsNothing();
+    }
+
+    /// <summary>Every observer sees the change, which is what sharing one upstream subscription is for.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OnNext_WithTwoObservers_ReportsToBoth()
+    {
+        var changes = new AppliedChangeObservable();
+        var first = new RecordingObserver();
+        var second = new RecordingObserver();
+
+        using (changes.Subscribe(first))
+        using (changes.Subscribe(second))
+        {
+            changes.OnNext(new(FirstValue, true));
+        }
+
+        await Assert.That(first.Received).IsEquivalentTo(FirstOnly);
+        await Assert.That(second.Received).IsEquivalentTo(FirstOnly);
+    }
+
+    /// <summary>An observer that has unsubscribed hears nothing further, and the others carry on.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Dispose_OfOneSubscription_LeavesTheOthersReporting()
+    {
+        var changes = new AppliedChangeObservable();
+        var dropped = new RecordingObserver();
+        var kept = new RecordingObserver();
+
+        var droppedSubscription = changes.Subscribe(dropped);
+        using var keptSubscription = changes.Subscribe(kept);
+
+        changes.OnNext(new(FirstValue, true));
+        droppedSubscription.Dispose();
+        changes.OnNext(new(SecondValue, false));
+
+        await Assert.That(dropped.Received).IsEquivalentTo(FirstOnly);
+        await Assert.That(kept.Received).IsEquivalentTo(FirstThenSecond);
+    }
+
+    /// <summary>Disposing twice drops one place, not two.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Dispose_CalledTwice_DropsOnePlace()
+    {
+        var changes = new AppliedChangeObservable();
+        var kept = new RecordingObserver();
+
+        var droppedSubscription = changes.Subscribe(new RecordingObserver());
+        using var keptSubscription = changes.Subscribe(kept);
+
+        droppedSubscription.Dispose();
+        droppedSubscription.Dispose();
+        changes.OnNext(new(FirstValue, true));
+
+        await Assert.That(kept.Received).IsEquivalentTo(FirstOnly);
+    }
+
+    /// <summary>
+    /// A change already being delivered walks the observers it started with, so a subscription taken from
+    /// inside a delivery joins the next one rather than disturbing this one.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Subscribe_DuringDelivery_JoinsTheNextChange()
+    {
+        var changes = new AppliedChangeObservable();
+        var joining = new RecordingObserver();
+        var subscriptions = new List<IDisposable>();
+
+        using var first = changes.Subscribe(new DelegateObserver(() => subscriptions.Add(changes.Subscribe(joining))));
+
+        changes.OnNext(new(FirstValue, true));
+        changes.OnNext(new(SecondValue, false));
+
+        foreach (var subscription in subscriptions)
+        {
+            subscription.Dispose();
+        }
+
+        await Assert.That(joining.Received).IsEquivalentTo(SecondOnly);
+    }
+
+    /// <summary>Dropping an observer that was never watching leaves the ones that are alone.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Remove_OfAnObserverThatNeverSubscribed_LeavesTheOthersReporting()
+    {
+        var changes = new AppliedChangeObservable();
+        var kept = new RecordingObserver();
+
+        using var keptSubscription = changes.Subscribe(kept);
+
+        changes.Remove(new RecordingObserver());
+        changes.OnNext(new(FirstValue, true));
+
+        await Assert.That(kept.Received).IsEquivalentTo(FirstOnly);
+    }
+
+    /// <summary>An observer is required, so asking to watch without one is refused.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Subscribe_WithNoObserver_ThrowsArgumentNullException()
+    {
+        var changes = new AppliedChangeObservable();
+
+        await Assert.That(() => changes.Subscribe(null!)).ThrowsExactly<ArgumentNullException>();
+    }
+
+    /// <summary>Records the values a binding reported having written.</summary>
+    private sealed class RecordingObserver : IObserver<BindingChange>
+    {
+        /// <summary>Gets the values reported, in order.</summary>
+        public List<string> Received { get; } = [];
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void OnNext(BindingChange value) => Received.Add((string)value.Value!);
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+    }
+
+    /// <summary>Runs an action on every change, used to subscribe from inside a delivery.</summary>
+    /// <param name="onNext">The action to run.</param>
+    private sealed class DelegateObserver(Action onNext) : IObserver<BindingChange>
+    {
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void OnNext(BindingChange value) => onNext();
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

**A two-way binding is applied and reported from one pipeline.**

- Both directions of `Bind` merge into one stream that is routed once and applied once, so routing carries the view's read and the view model's write.
- What the binding wrote is published to a change stream the caller subscribes to. A subscriber shares the binding's own upstream subscription and sees only the values the equality guard passed.
- The target's first value is weighed against what the source wrote rather than dropped by position. The view model side merges first, so the target carries the source's value by the time it reports and the guard drops that one.
- `BindTwoWay` routes both directions. It has no change stream to multicast, so it keeps its two subscriptions and its unboxed values.

**Each platform's own answer to a before-change request is followed.**

- A dependency property hands back the one stream it has, so `WhenChanging` on one keeps reporting.
- A component's change event withdraws the mechanism instead, leaving the property read once.

**Inherited properties are read from the bases a type's own assembly declares.** A plain property inherited from a base the consumer wrote is not treated as carrying a dependency-property field or a change event. The walk stops at the assembly boundary, where a platform base does back the mechanism the type advertises.

**A command's parameter is written before its command,** so a control evaluates whether it can execute against the parameter belonging to the command being assigned.

**RXUIBIND010 reports an observed path that passes through a type raising no notification,** which is where an observation reads once and stops following the path.

## What is the current behavior?

- `Bind` routes only the view model direction, re-projects the two observed sides to produce its change stream - so each subscriber attaches another set of property handlers and sees values that were never written - and drops the view's first value by position.
- `WhenChanging` on a dependency property reads the value once and reports nothing after it.
- An inherited property is treated as carrying whatever mechanism its type advertises, so a plain inherited property emits a `{Name}Property` field reference.
- The observable-parameter command binding assigns `Command` before `CommandParameter`.
- A silent link in an observed path is reported nowhere.

## What might this PR break?

- `WhenChanging` on a WPF dependency property reports each change rather than completing after one value. RXUIBIND004 warns that the platform cannot report before a change.
- RXUIBIND010 is a new warning.
- A plain property inherited from a base in the same assembly is not observed through a dependency-property field that was never declared.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

`TriggerUpdate` and `signalViewUpdate` have no generated overload. A binding is resolved from its two lambdas alone, and an overload taking a caller-supplied stream would have to hand the call to the runtime expression engine, which carries `[RequiresUnreferencedCode]` and breaks a `PublishAot` build for every consumer of that call site. The readme's "Where this differs from ReactiveUI" section covers this, a binding call made through a type parameter, and RXUIBIND010.

### Benchmarks

One binding created, then 1,000 property changes, with `MemoryDiagnoser` and the EventPipe `GcVerbose` diagnoser.

| Case                                   | `main` |  this branch | `main` allocated | this branch allocated |
|----------------------------------------|-------:|-------------:|-----------------:|----------------------:|
| Bind (.NET 10)                         | 129.6 us | 124.2 us   |         41.61 KB |              42.16 KB |
| Bind bidirectional (.NET 10)           | 240.3 us | 237.0 us   |         65.05 KB |              65.59 KB |
| Bind + observed changes (.NET 10)      | 133.0 us | 125.1 us   |         43.57 KB |              42.27 KB |
| BindTwoWay (.NET 10)                   | 270.7 us | 236.8 us   |         87.86 KB |              87.79 KB |
| BindTwoWay bidirectional (.NET 10)     | 338.3 us | 326.7 us   |         102.7 KB |              102.7 KB |
| Bind (NativeAOT 10)                    |  25.9 us |  25.2 us   |         42.24 KB |              42.71 KB |
| Bind + observed changes (NativeAOT 10) |  26.5 us |  24.5 us   |         43.98 KB |              42.82 KB |

- Watching a binding costs 0.11 KB per 1,000 changes against 1.96 KB on `main`, which is what the shared upstream subscription buys.
- `Bind` allocates 0.55 KB more per binding *created*, for the merge and the change stream. Over 1,000 changes that is 0.56 bytes per change, below a single allocation, so it does not scale with traffic.
