### PR TITLE
feat(observation): add WhenAnyDynamic and cover the runtime overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Platform-specific packages provide DependencyProperty observation and other plat
 | `WhenChanging`      | Observe property changes (before value changes, requires `INotifyPropertyChanging`) |
 | `WhenAnyValue`      | ReactiveUI compatibility shim -- same semantics as `WhenChanged`                    |
 | `WhenAny`           | Multi-property observation with selector                                            |
+| `WhenAnyDynamic`    | Observe a chain given as an `Expression` built at run time (reflection, not AOT-safe) |
 | `WhenAnyObservable` | Observe and switch between observable properties                                    |
 | `BindOneWay`        | One-way binding from source to target                                               |
 | `BindTwoWay`        | Two-way binding between source and target                                           |
@@ -177,6 +178,28 @@ IObservable<string> fullName = vm.WhenChanged(
 // Before-change observation (requires INotifyPropertyChanging)
 IObservable<string> nameChanging = vm.WhenChanging(x => x.Name);
 ```
+
+### Observing a Chain Named at Run Time
+
+`WhenAnyDynamic` takes the chain as a `System.Linq.Expressions.Expression` the caller built, rather than as a
+lambda the compiler could read. Arities 1 to 12 are available, each with and without the distinct gate.
+
+```csharp
+// The chain is a value, so it can be assembled from a property name, a configuration entry, or a caller.
+Expression chain = ((Expression<Func<MyViewModel, string>>)(x => x.Address.City)).Body;
+
+IObservable<string?> cityObs = vm.WhenAnyDynamic(chain, static c => (string?)c.Value);
+
+IObservable<string> fullName = vm.WhenAnyDynamic(
+    firstNameChain,
+    lastNameChain,
+    static (first, last) => $"{first.Value} {last.Value}");
+```
+
+There is nothing for a generator to resolve in an expression built at run time, so the chain is walked by
+reflection. Every overload carries `[RequiresUnreferencedCode]`, which makes this the one part of the observation
+surface that is not trimming- or AOT-safe and reports each call site in a `PublishAot` build. Where the chain is
+known at compile time, `WhenChanged` and `WhenAny` observe the same thing with no reflection.
 
 ### One-Way Binding
 
@@ -412,6 +435,36 @@ subscription rather than re-projecting the two observed sides:
 | One-Way Binding (.NET 10.0) | 8.9x faster |            8.2x less |
 | Two-Way Binding (.NET 10.0) | 8.1x faster |            8.5x less |
 | First Binding (.NET 10.0)   | 4.1x faster |            9.6x less |
+
+#### Chains Named at Run Time (WhenAnyDynamic)
+
+| Method            | Runtime   |   Mean | Allocated |
+|-------------------|-----------|-------:|----------:|
+| Single Chain      | .NET 10.0 | 278 us |  102.7 KB |
+| Two Chains        | .NET 10.0 | 595 us |  190.2 KB |
+| Deep Chain        | .NET 10.0 | 354 us |  103.3 KB |
+| First Observation | .NET 10.0 | 7.3 us |    1.1 KB |
+| Single Chain      | .NET 8.0  | 347 us |  102.7 KB |
+| Two Chains        | .NET 8.0  | 691 us |  190.1 KB |
+| Deep Chain        | .NET 8.0  | 419 us |  103.3 KB |
+| First Observation | .NET 8.0  | 7.9 us |    1.1 KB |
+
+This is the one part of the surface where the two engines are level. Both walk the chain by reflection and
+allocate the same objects doing it, so the numbers land on top of each other; the gain is in resolving the chain
+at compile time instead:
+
+| Single chain, .NET 10.0     |   Mean | Allocated |
+|-----------------------------|-------:|----------:|
+| Generated (`WhenChanged`)   | 175 us |   63.4 KB |
+| `WhenAnyDynamic`            | 278 us |  102.7 KB |
+| ReactiveUI `WhenAnyDynamic` | 299 us |  102.6 KB |
+
+Most of the gap to the generated path is the `IObservedChange` handed to the selector - 40 bytes per
+notification, which the signature has to produce, against a generated observation that emits the value itself.
+
+Two chains fire twice the notifications of one, so their 190 KB is 95 bytes per notification against a single
+chain's 103: combining a higher arity costs one subscription, not a per-notification charge. Every arity observes
+each of its chains through the same walk and differs only in how many it combines.
 
 ## Diagnostics
 

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyDynamic.WideArity.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyDynamic.WideArity.cs
@@ -61,10 +61,8 @@ public static partial class ReactiveUIBindingExtensions
         bool isDistinct)
         where TSender : class
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        return ObserveDynamicChain(sender, property1, isDistinct).Select(selector);
+        var chains = Chains(sender, selector, isDistinct, property1);
+        return chains[0].Select(selector);
     }
 
     /// <summary>Observes 2 dynamically-typed property chains and combines them with a selector.</summary>
@@ -103,13 +101,8 @@ public static partial class ReactiveUIBindingExtensions
         bool isDistinct)
         where TSender : class
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        return CombineLatestObservable.Create(
-            ObserveDynamicChain(sender, property1, isDistinct),
-            ObserveDynamicChain(sender, property2, isDistinct),
-            selector);
+        var chains = Chains(sender, selector, isDistinct, property1, property2);
+        return CombineLatestObservable.Create(chains[0], chains[1], selector);
     }
 
     /// <summary>Observes 3 dynamically-typed property chains and combines them with a selector.</summary>
@@ -152,14 +145,8 @@ public static partial class ReactiveUIBindingExtensions
         bool isDistinct)
         where TSender : class
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        return CombineLatestObservable.Create(
-            ObserveDynamicChain(sender, property1, isDistinct),
-            ObserveDynamicChain(sender, property2, isDistinct),
-            ObserveDynamicChain(sender, property3, isDistinct),
-            selector);
+        var chains = Chains(sender, selector, isDistinct, property1, property2, property3);
+        return CombineLatestObservable.Create(chains[0], chains[1], chains[2], selector);
     }
 
     /// <summary>Observes 4 dynamically-typed property chains and combines them with a selector.</summary>
@@ -216,15 +203,8 @@ public static partial class ReactiveUIBindingExtensions
         bool isDistinct)
         where TSender : class
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        return CombineLatestObservable.Create(
-            ObserveDynamicChain(sender, property1, isDistinct),
-            ObserveDynamicChain(sender, property2, isDistinct),
-            ObserveDynamicChain(sender, property3, isDistinct),
-            ObserveDynamicChain(sender, property4, isDistinct),
-            selector);
+        var chains = Chains(sender, selector, isDistinct, property1, property2, property3, property4);
+        return CombineLatestObservable.Create(chains[0], chains[1], chains[2], chains[3], selector);
     }
 
     /// <summary>Observes 5 dynamically-typed property chains and combines them with a selector.</summary>
@@ -287,16 +267,8 @@ public static partial class ReactiveUIBindingExtensions
         bool isDistinct)
         where TSender : class
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        return CombineLatestObservable.Create(
-            ObserveDynamicChain(sender, property1, isDistinct),
-            ObserveDynamicChain(sender, property2, isDistinct),
-            ObserveDynamicChain(sender, property3, isDistinct),
-            ObserveDynamicChain(sender, property4, isDistinct),
-            ObserveDynamicChain(sender, property5, isDistinct),
-            selector);
+        var chains = Chains(sender, selector, isDistinct, property1, property2, property3, property4, property5);
+        return CombineLatestObservable.Create(chains[0], chains[1], chains[2], chains[3], chains[4], selector);
     }
 
     /// <summary>Observes 6 dynamically-typed property chains and combines them with a selector.</summary>
@@ -366,17 +338,8 @@ public static partial class ReactiveUIBindingExtensions
         bool isDistinct)
         where TSender : class
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        return CombineLatestObservable.Create(
-            ObserveDynamicChain(sender, property1, isDistinct),
-            ObserveDynamicChain(sender, property2, isDistinct),
-            ObserveDynamicChain(sender, property3, isDistinct),
-            ObserveDynamicChain(sender, property4, isDistinct),
-            ObserveDynamicChain(sender, property5, isDistinct),
-            ObserveDynamicChain(sender, property6, isDistinct),
-            selector);
+        var chains = Chains(sender, selector, isDistinct, property1, property2, property3, property4, property5, property6);
+        return CombineLatestObservable.Create(chains[0], chains[1], chains[2], chains[3], chains[4], chains[5], selector);
     }
 
     /// <summary>Observes 7 dynamically-typed property chains and combines them with a selector.</summary>
@@ -453,18 +416,8 @@ public static partial class ReactiveUIBindingExtensions
         bool isDistinct)
         where TSender : class
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        return CombineLatestObservable.Create(
-            ObserveDynamicChain(sender, property1, isDistinct),
-            ObserveDynamicChain(sender, property2, isDistinct),
-            ObserveDynamicChain(sender, property3, isDistinct),
-            ObserveDynamicChain(sender, property4, isDistinct),
-            ObserveDynamicChain(sender, property5, isDistinct),
-            ObserveDynamicChain(sender, property6, isDistinct),
-            ObserveDynamicChain(sender, property7, isDistinct),
-            selector);
+        var chains = Chains(sender, selector, isDistinct, property1, property2, property3, property4, property5, property6, property7);
+        return CombineLatestObservable.Create(chains[0], chains[1], chains[2], chains[3], chains[4], chains[5], chains[6], selector);
     }
 
     /// <summary>Observes 8 dynamically-typed property chains and combines them with a selector.</summary>
@@ -547,19 +500,8 @@ public static partial class ReactiveUIBindingExtensions
         bool isDistinct)
         where TSender : class
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        return CombineLatestObservable.Create(
-            ObserveDynamicChain(sender, property1, isDistinct),
-            ObserveDynamicChain(sender, property2, isDistinct),
-            ObserveDynamicChain(sender, property3, isDistinct),
-            ObserveDynamicChain(sender, property4, isDistinct),
-            ObserveDynamicChain(sender, property5, isDistinct),
-            ObserveDynamicChain(sender, property6, isDistinct),
-            ObserveDynamicChain(sender, property7, isDistinct),
-            ObserveDynamicChain(sender, property8, isDistinct),
-            selector);
+        var chains = Chains(sender, selector, isDistinct, property1, property2, property3, property4, property5, property6, property7, property8);
+        return CombineLatestObservable.Create(chains[0], chains[1], chains[2], chains[3], chains[4], chains[5], chains[6], chains[7], selector);
     }
 
     /// <summary>Observes 9 dynamically-typed property chains and combines them with a selector.</summary>
@@ -648,20 +590,8 @@ public static partial class ReactiveUIBindingExtensions
         bool isDistinct)
         where TSender : class
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        return CombineLatestObservable.Create(
-            ObserveDynamicChain(sender, property1, isDistinct),
-            ObserveDynamicChain(sender, property2, isDistinct),
-            ObserveDynamicChain(sender, property3, isDistinct),
-            ObserveDynamicChain(sender, property4, isDistinct),
-            ObserveDynamicChain(sender, property5, isDistinct),
-            ObserveDynamicChain(sender, property6, isDistinct),
-            ObserveDynamicChain(sender, property7, isDistinct),
-            ObserveDynamicChain(sender, property8, isDistinct),
-            ObserveDynamicChain(sender, property9, isDistinct),
-            selector);
+        var chains = Chains(sender, selector, isDistinct, property1, property2, property3, property4, property5, property6, property7, property8, property9);
+        return CombineLatestObservable.Create(chains[0], chains[1], chains[2], chains[3], chains[4], chains[5], chains[6], chains[7], chains[8], selector);
     }
 
     /// <summary>Observes 10 dynamically-typed property chains and combines them with a selector.</summary>
@@ -756,21 +686,8 @@ public static partial class ReactiveUIBindingExtensions
         bool isDistinct)
         where TSender : class
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        return CombineLatestObservable.Create(
-            ObserveDynamicChain(sender, property1, isDistinct),
-            ObserveDynamicChain(sender, property2, isDistinct),
-            ObserveDynamicChain(sender, property3, isDistinct),
-            ObserveDynamicChain(sender, property4, isDistinct),
-            ObserveDynamicChain(sender, property5, isDistinct),
-            ObserveDynamicChain(sender, property6, isDistinct),
-            ObserveDynamicChain(sender, property7, isDistinct),
-            ObserveDynamicChain(sender, property8, isDistinct),
-            ObserveDynamicChain(sender, property9, isDistinct),
-            ObserveDynamicChain(sender, property10, isDistinct),
-            selector);
+        var chains = Chains(sender, selector, isDistinct, property1, property2, property3, property4, property5, property6, property7, property8, property9, property10);
+        return CombineLatestObservable.Create(chains[0], chains[1], chains[2], chains[3], chains[4], chains[5], chains[6], chains[7], chains[8], chains[9], selector);
     }
 
     /// <summary>Observes 11 dynamically-typed property chains and combines them with a selector.</summary>
@@ -871,22 +788,8 @@ public static partial class ReactiveUIBindingExtensions
         bool isDistinct)
         where TSender : class
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        return CombineLatestObservable.Create(
-            ObserveDynamicChain(sender, property1, isDistinct),
-            ObserveDynamicChain(sender, property2, isDistinct),
-            ObserveDynamicChain(sender, property3, isDistinct),
-            ObserveDynamicChain(sender, property4, isDistinct),
-            ObserveDynamicChain(sender, property5, isDistinct),
-            ObserveDynamicChain(sender, property6, isDistinct),
-            ObserveDynamicChain(sender, property7, isDistinct),
-            ObserveDynamicChain(sender, property8, isDistinct),
-            ObserveDynamicChain(sender, property9, isDistinct),
-            ObserveDynamicChain(sender, property10, isDistinct),
-            ObserveDynamicChain(sender, property11, isDistinct),
-            selector);
+        var chains = Chains(sender, selector, isDistinct, property1, property2, property3, property4, property5, property6, property7, property8, property9, property10, property11);
+        return CombineLatestObservable.Create(chains[0], chains[1], chains[2], chains[3], chains[4], chains[5], chains[6], chains[7], chains[8], chains[9], chains[10], selector);
     }
 
     /// <summary>Observes 12 dynamically-typed property chains and combines them with a selector.</summary>
@@ -993,23 +896,40 @@ public static partial class ReactiveUIBindingExtensions
         bool isDistinct)
         where TSender : class
     {
+        var chains = Chains(sender, selector, isDistinct, property1, property2, property3, property4, property5, property6, property7, property8, property9, property10, property11, property12);
+        return CombineLatestObservable.Create(chains[0], chains[1], chains[2], chains[3], chains[4], chains[5], chains[6], chains[7], chains[8], chains[9], chains[10], chains[11], selector);
+    }
+
+    /// <summary>Subscribes to every chain an overload was handed, after refusing a missing argument.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="selector">The projection the caller supplied, which is required.</param>
+    /// <param name="isDistinct">Whether a chain reports only when its value changes.</param>
+    /// <param name="properties">The expressions naming the chains.</param>
+    /// <returns>One observation per chain, in the order the chains were given.</returns>
+    /// <remarks>
+    /// Every arity funnels its argument checks and its subscriptions through here, so each overload is the
+    /// signature and nothing else. The array is built once when the observable is created rather than per
+    /// notification, so a higher arity costs one allocation at subscription and nothing while it reports.
+    /// </remarks>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    private static IObservable<IObservedChange<TSender, object?>>[] Chains<TSender>(
+        TSender sender,
+        object selector,
+        bool isDistinct,
+        params Expression?[] properties)
+        where TSender : class
+    {
         ArgumentExceptionHelper.ThrowIfNull(sender);
         ArgumentExceptionHelper.ThrowIfNull(selector);
 
-        return CombineLatestObservable.Create(
-            ObserveDynamicChain(sender, property1, isDistinct),
-            ObserveDynamicChain(sender, property2, isDistinct),
-            ObserveDynamicChain(sender, property3, isDistinct),
-            ObserveDynamicChain(sender, property4, isDistinct),
-            ObserveDynamicChain(sender, property5, isDistinct),
-            ObserveDynamicChain(sender, property6, isDistinct),
-            ObserveDynamicChain(sender, property7, isDistinct),
-            ObserveDynamicChain(sender, property8, isDistinct),
-            ObserveDynamicChain(sender, property9, isDistinct),
-            ObserveDynamicChain(sender, property10, isDistinct),
-            ObserveDynamicChain(sender, property11, isDistinct),
-            ObserveDynamicChain(sender, property12, isDistinct),
-            selector);
+        var chains = new IObservable<IObservedChange<TSender, object?>>[properties.Length];
+        for (var i = 0; i < properties.Length; i++)
+        {
+            chains[i] = ObserveDynamicChain(sender, properties[i], isDistinct);
+        }
+
+        return chains;
     }
 
     /// <summary>Subscribes to one property chain named by a run-time expression.</summary>

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyDynamic.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyDynamic.cs
@@ -1,0 +1,1030 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+
+/// <summary>Observes property chains that are only known as expressions at run time.</summary>
+/// <remarks>
+/// Every other observation in this library is resolved at compile time, which is what keeps it free of
+/// reflection. These overloads take an <see cref="Expression"/> the caller built rather than a lambda the
+/// compiler could read, so there is nothing for a generator to resolve and the chain has to be walked by
+/// reflection. They are the one part of the observation surface that is not trim- or AOT-safe, and they
+/// say so.
+/// <para>
+/// The walking itself is the engine the runtime observation fallback already uses, so resolving a link,
+/// re-subscribing a deeper one when an intermediate moves, and filtering duplicates are not written twice.
+/// Each arity differs only in how many chains it combines.
+/// </para>
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>Why every overload here is unsafe to trim.</summary>
+    private const string DynamicChainRequiresUnreferencedCode =
+        "Evaluates expression-based member chains via reflection; members may be trimmed.";
+
+    /// <summary>Observes 1 dynamically-typed property chain and projects it with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Func<IObservedChange<TSender, object?>, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyDynamic(property1, selector, true);
+
+    /// <summary>Observes 1 dynamically-typed property chain and projects it with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <param name="isDistinct">Whether a chain reports only when its value changes.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Func<IObservedChange<TSender, object?>, TRet> selector,
+        bool isDistinct)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        return ObserveDynamicChain(sender, property1, isDistinct).Select(selector);
+    }
+
+    /// <summary>Observes 2 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Func<IObservedChange<TSender, object?>, IObservedChange<TSender, object?>, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyDynamic(property1, property2, selector, true);
+
+    /// <summary>Observes 2 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <param name="isDistinct">Whether a chain reports only when its value changes.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Func<IObservedChange<TSender, object?>, IObservedChange<TSender, object?>, TRet> selector,
+        bool isDistinct)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        return CombineLatestObservable.Create(
+            ObserveDynamicChain(sender, property1, isDistinct),
+            ObserveDynamicChain(sender, property2, isDistinct),
+            selector);
+    }
+
+    /// <summary>Observes 3 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Func<IObservedChange<TSender, object?>, IObservedChange<TSender, object?>, IObservedChange<TSender, object?>, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyDynamic(property1, property2, property3, selector, true);
+
+    /// <summary>Observes 3 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <param name="isDistinct">Whether a chain reports only when its value changes.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Func<IObservedChange<TSender, object?>, IObservedChange<TSender, object?>, IObservedChange<TSender, object?>, TRet> selector,
+        bool isDistinct)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        return CombineLatestObservable.Create(
+            ObserveDynamicChain(sender, property1, isDistinct),
+            ObserveDynamicChain(sender, property2, isDistinct),
+            ObserveDynamicChain(sender, property3, isDistinct),
+            selector);
+    }
+
+    /// <summary>Observes 4 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector)
+        where TSender : class
+        => sender.WhenAnyDynamic(property1, property2, property3, property4, selector, true);
+
+    /// <summary>Observes 4 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <param name="isDistinct">Whether a chain reports only when its value changes.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector,
+        bool isDistinct)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        return CombineLatestObservable.Create(
+            ObserveDynamicChain(sender, property1, isDistinct),
+            ObserveDynamicChain(sender, property2, isDistinct),
+            ObserveDynamicChain(sender, property3, isDistinct),
+            ObserveDynamicChain(sender, property4, isDistinct),
+            selector);
+    }
+
+    /// <summary>Observes 5 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector)
+        where TSender : class
+        => sender.WhenAnyDynamic(property1, property2, property3, property4, property5, selector, true);
+
+    /// <summary>Observes 5 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <param name="isDistinct">Whether a chain reports only when its value changes.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector,
+        bool isDistinct)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        return CombineLatestObservable.Create(
+            ObserveDynamicChain(sender, property1, isDistinct),
+            ObserveDynamicChain(sender, property2, isDistinct),
+            ObserveDynamicChain(sender, property3, isDistinct),
+            ObserveDynamicChain(sender, property4, isDistinct),
+            ObserveDynamicChain(sender, property5, isDistinct),
+            selector);
+    }
+
+    /// <summary>Observes 6 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="property6">An expression naming property 6.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Expression? property6,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector)
+        where TSender : class
+        => sender.WhenAnyDynamic(property1, property2, property3, property4, property5, property6, selector, true);
+
+    /// <summary>Observes 6 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="property6">An expression naming property 6.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <param name="isDistinct">Whether a chain reports only when its value changes.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [SuppressMessage("Design", "SST1472", Justification = "one expression per observed chain; the parameter count is the shape of this overload")]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Expression? property6,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector,
+        bool isDistinct)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        return CombineLatestObservable.Create(
+            ObserveDynamicChain(sender, property1, isDistinct),
+            ObserveDynamicChain(sender, property2, isDistinct),
+            ObserveDynamicChain(sender, property3, isDistinct),
+            ObserveDynamicChain(sender, property4, isDistinct),
+            ObserveDynamicChain(sender, property5, isDistinct),
+            ObserveDynamicChain(sender, property6, isDistinct),
+            selector);
+    }
+
+    /// <summary>Observes 7 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="property6">An expression naming property 6.</param>
+    /// <param name="property7">An expression naming property 7.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SuppressMessage("Design", "SST1472", Justification = "one expression per observed chain; the parameter count is the shape of this overload")]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Expression? property6,
+        Expression? property7,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector)
+        where TSender : class
+        => sender.WhenAnyDynamic(property1, property2, property3, property4, property5, property6, property7, selector, true);
+
+    /// <summary>Observes 7 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="property6">An expression naming property 6.</param>
+    /// <param name="property7">An expression naming property 7.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <param name="isDistinct">Whether a chain reports only when its value changes.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [SuppressMessage("Design", "SST1472", Justification = "one expression per observed chain; the parameter count is the shape of this overload")]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Expression? property6,
+        Expression? property7,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector,
+        bool isDistinct)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        return CombineLatestObservable.Create(
+            ObserveDynamicChain(sender, property1, isDistinct),
+            ObserveDynamicChain(sender, property2, isDistinct),
+            ObserveDynamicChain(sender, property3, isDistinct),
+            ObserveDynamicChain(sender, property4, isDistinct),
+            ObserveDynamicChain(sender, property5, isDistinct),
+            ObserveDynamicChain(sender, property6, isDistinct),
+            ObserveDynamicChain(sender, property7, isDistinct),
+            selector);
+    }
+
+    /// <summary>Observes 8 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="property6">An expression naming property 6.</param>
+    /// <param name="property7">An expression naming property 7.</param>
+    /// <param name="property8">An expression naming property 8.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SuppressMessage("Design", "SST1472", Justification = "one expression per observed chain; the parameter count is the shape of this overload")]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Expression? property6,
+        Expression? property7,
+        Expression? property8,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector)
+        where TSender : class
+        => sender.WhenAnyDynamic(property1, property2, property3, property4, property5, property6, property7, property8, selector, true);
+
+    /// <summary>Observes 8 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="property6">An expression naming property 6.</param>
+    /// <param name="property7">An expression naming property 7.</param>
+    /// <param name="property8">An expression naming property 8.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <param name="isDistinct">Whether a chain reports only when its value changes.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [SuppressMessage("Design", "SST1472", Justification = "one expression per observed chain; the parameter count is the shape of this overload")]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Expression? property6,
+        Expression? property7,
+        Expression? property8,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector,
+        bool isDistinct)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        return CombineLatestObservable.Create(
+            ObserveDynamicChain(sender, property1, isDistinct),
+            ObserveDynamicChain(sender, property2, isDistinct),
+            ObserveDynamicChain(sender, property3, isDistinct),
+            ObserveDynamicChain(sender, property4, isDistinct),
+            ObserveDynamicChain(sender, property5, isDistinct),
+            ObserveDynamicChain(sender, property6, isDistinct),
+            ObserveDynamicChain(sender, property7, isDistinct),
+            ObserveDynamicChain(sender, property8, isDistinct),
+            selector);
+    }
+
+    /// <summary>Observes 9 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="property6">An expression naming property 6.</param>
+    /// <param name="property7">An expression naming property 7.</param>
+    /// <param name="property8">An expression naming property 8.</param>
+    /// <param name="property9">An expression naming property 9.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SuppressMessage("Design", "SST1472", Justification = "one expression per observed chain; the parameter count is the shape of this overload")]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Expression? property6,
+        Expression? property7,
+        Expression? property8,
+        Expression? property9,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector)
+        where TSender : class
+        => sender.WhenAnyDynamic(property1, property2, property3, property4, property5, property6, property7, property8, property9, selector, true);
+
+    /// <summary>Observes 9 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="property6">An expression naming property 6.</param>
+    /// <param name="property7">An expression naming property 7.</param>
+    /// <param name="property8">An expression naming property 8.</param>
+    /// <param name="property9">An expression naming property 9.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <param name="isDistinct">Whether a chain reports only when its value changes.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [SuppressMessage("Design", "SST1472", Justification = "one expression per observed chain; the parameter count is the shape of this overload")]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Expression? property6,
+        Expression? property7,
+        Expression? property8,
+        Expression? property9,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector,
+        bool isDistinct)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        return CombineLatestObservable.Create(
+            ObserveDynamicChain(sender, property1, isDistinct),
+            ObserveDynamicChain(sender, property2, isDistinct),
+            ObserveDynamicChain(sender, property3, isDistinct),
+            ObserveDynamicChain(sender, property4, isDistinct),
+            ObserveDynamicChain(sender, property5, isDistinct),
+            ObserveDynamicChain(sender, property6, isDistinct),
+            ObserveDynamicChain(sender, property7, isDistinct),
+            ObserveDynamicChain(sender, property8, isDistinct),
+            ObserveDynamicChain(sender, property9, isDistinct),
+            selector);
+    }
+
+    /// <summary>Observes 10 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="property6">An expression naming property 6.</param>
+    /// <param name="property7">An expression naming property 7.</param>
+    /// <param name="property8">An expression naming property 8.</param>
+    /// <param name="property9">An expression naming property 9.</param>
+    /// <param name="property10">An expression naming property 10.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SuppressMessage("Design", "SST1472", Justification = "one expression per observed chain; the parameter count is the shape of this overload")]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Expression? property6,
+        Expression? property7,
+        Expression? property8,
+        Expression? property9,
+        Expression? property10,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector)
+        where TSender : class
+        => sender.WhenAnyDynamic(property1, property2, property3, property4, property5, property6, property7, property8, property9, property10, selector, true);
+
+    /// <summary>Observes 10 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="property6">An expression naming property 6.</param>
+    /// <param name="property7">An expression naming property 7.</param>
+    /// <param name="property8">An expression naming property 8.</param>
+    /// <param name="property9">An expression naming property 9.</param>
+    /// <param name="property10">An expression naming property 10.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <param name="isDistinct">Whether a chain reports only when its value changes.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [SuppressMessage("Design", "SST1472", Justification = "one expression per observed chain; the parameter count is the shape of this overload")]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Expression? property6,
+        Expression? property7,
+        Expression? property8,
+        Expression? property9,
+        Expression? property10,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector,
+        bool isDistinct)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        return CombineLatestObservable.Create(
+            ObserveDynamicChain(sender, property1, isDistinct),
+            ObserveDynamicChain(sender, property2, isDistinct),
+            ObserveDynamicChain(sender, property3, isDistinct),
+            ObserveDynamicChain(sender, property4, isDistinct),
+            ObserveDynamicChain(sender, property5, isDistinct),
+            ObserveDynamicChain(sender, property6, isDistinct),
+            ObserveDynamicChain(sender, property7, isDistinct),
+            ObserveDynamicChain(sender, property8, isDistinct),
+            ObserveDynamicChain(sender, property9, isDistinct),
+            ObserveDynamicChain(sender, property10, isDistinct),
+            selector);
+    }
+
+    /// <summary>Observes 11 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="property6">An expression naming property 6.</param>
+    /// <param name="property7">An expression naming property 7.</param>
+    /// <param name="property8">An expression naming property 8.</param>
+    /// <param name="property9">An expression naming property 9.</param>
+    /// <param name="property10">An expression naming property 10.</param>
+    /// <param name="property11">An expression naming property 11.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SuppressMessage("Design", "SST1472", Justification = "one expression per observed chain; the parameter count is the shape of this overload")]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Expression? property6,
+        Expression? property7,
+        Expression? property8,
+        Expression? property9,
+        Expression? property10,
+        Expression? property11,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector)
+        where TSender : class
+        => sender.WhenAnyDynamic(property1, property2, property3, property4, property5, property6, property7, property8, property9, property10, property11, selector, true);
+
+    /// <summary>Observes 11 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="property6">An expression naming property 6.</param>
+    /// <param name="property7">An expression naming property 7.</param>
+    /// <param name="property8">An expression naming property 8.</param>
+    /// <param name="property9">An expression naming property 9.</param>
+    /// <param name="property10">An expression naming property 10.</param>
+    /// <param name="property11">An expression naming property 11.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <param name="isDistinct">Whether a chain reports only when its value changes.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [SuppressMessage("Design", "SST1472", Justification = "one expression per observed chain; the parameter count is the shape of this overload")]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Expression? property6,
+        Expression? property7,
+        Expression? property8,
+        Expression? property9,
+        Expression? property10,
+        Expression? property11,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector,
+        bool isDistinct)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        return CombineLatestObservable.Create(
+            ObserveDynamicChain(sender, property1, isDistinct),
+            ObserveDynamicChain(sender, property2, isDistinct),
+            ObserveDynamicChain(sender, property3, isDistinct),
+            ObserveDynamicChain(sender, property4, isDistinct),
+            ObserveDynamicChain(sender, property5, isDistinct),
+            ObserveDynamicChain(sender, property6, isDistinct),
+            ObserveDynamicChain(sender, property7, isDistinct),
+            ObserveDynamicChain(sender, property8, isDistinct),
+            ObserveDynamicChain(sender, property9, isDistinct),
+            ObserveDynamicChain(sender, property10, isDistinct),
+            ObserveDynamicChain(sender, property11, isDistinct),
+            selector);
+    }
+
+    /// <summary>Observes 12 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="property6">An expression naming property 6.</param>
+    /// <param name="property7">An expression naming property 7.</param>
+    /// <param name="property8">An expression naming property 8.</param>
+    /// <param name="property9">An expression naming property 9.</param>
+    /// <param name="property10">An expression naming property 10.</param>
+    /// <param name="property11">An expression naming property 11.</param>
+    /// <param name="property12">An expression naming property 12.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SuppressMessage("Design", "SST1472", Justification = "one expression per observed chain; the parameter count is the shape of this overload")]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Expression? property6,
+        Expression? property7,
+        Expression? property8,
+        Expression? property9,
+        Expression? property10,
+        Expression? property11,
+        Expression? property12,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector)
+        where TSender : class
+        => sender.WhenAnyDynamic(property1, property2, property3, property4, property5, property6, property7, property8, property9, property10, property11, property12, selector, true);
+
+    /// <summary>Observes 12 dynamically-typed property chains and combines them with a selector.</summary>
+    /// <typeparam name="TSender">The type of the object the chains are rooted on.</typeparam>
+    /// <typeparam name="TRet">The type of the projected result.</typeparam>
+    /// <param name="sender">The object the chains are rooted on.</param>
+    /// <param name="property1">An expression naming property 1.</param>
+    /// <param name="property2">An expression naming property 2.</param>
+    /// <param name="property3">An expression naming property 3.</param>
+    /// <param name="property4">An expression naming property 4.</param>
+    /// <param name="property5">An expression naming property 5.</param>
+    /// <param name="property6">An expression naming property 6.</param>
+    /// <param name="property7">An expression naming property 7.</param>
+    /// <param name="property8">An expression naming property 8.</param>
+    /// <param name="property9">An expression naming property 9.</param>
+    /// <param name="property10">An expression naming property 10.</param>
+    /// <param name="property11">An expression naming property 11.</param>
+    /// <param name="property12">An expression naming property 12.</param>
+    /// <param name="selector">Projects the observed changes into a result.</param>
+    /// <param name="isDistinct">Whether a chain reports only when its value changes.</param>
+    /// <returns>An observable of the projected result.</returns>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [SuppressMessage("Design", "SST1472", Justification = "one expression per observed chain; the parameter count is the shape of this overload")]
+    public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(
+        this TSender sender,
+        Expression? property1,
+        Expression? property2,
+        Expression? property3,
+        Expression? property4,
+        Expression? property5,
+        Expression? property6,
+        Expression? property7,
+        Expression? property8,
+        Expression? property9,
+        Expression? property10,
+        Expression? property11,
+        Expression? property12,
+        Func<
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            IObservedChange<TSender, object?>,
+            TRet> selector,
+        bool isDistinct)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        return CombineLatestObservable.Create(
+            ObserveDynamicChain(sender, property1, isDistinct),
+            ObserveDynamicChain(sender, property2, isDistinct),
+            ObserveDynamicChain(sender, property3, isDistinct),
+            ObserveDynamicChain(sender, property4, isDistinct),
+            ObserveDynamicChain(sender, property5, isDistinct),
+            ObserveDynamicChain(sender, property6, isDistinct),
+            ObserveDynamicChain(sender, property7, isDistinct),
+            ObserveDynamicChain(sender, property8, isDistinct),
+            ObserveDynamicChain(sender, property9, isDistinct),
+            ObserveDynamicChain(sender, property10, isDistinct),
+            ObserveDynamicChain(sender, property11, isDistinct),
+            ObserveDynamicChain(sender, property12, isDistinct),
+            selector);
+    }
+
+    /// <summary>Subscribes to one property chain named by a run-time expression.</summary>
+    /// <typeparam name="TSender">The type of the object the chain is rooted on.</typeparam>
+    /// <param name="sender">The object the chain is rooted on.</param>
+    /// <param name="property">An expression naming the chain.</param>
+    /// <param name="isDistinct">Whether the chain reports only when its value changes.</param>
+    /// <returns>An observable of the chain's observed changes.</returns>
+    /// <remarks>Every arity funnels through here, so the reflection is written once.</remarks>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static IObservable<IObservedChange<TSender, object?>> ObserveDynamicChain<TSender>(
+        TSender sender,
+        Expression? property,
+        bool isDistinct)
+        where TSender : class =>
+        sender.SubscribeToExpressionChain<TSender, object?>(property, false, false, isDistinct);
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.Binding;
 /// over these generic stubs due to having fewer optional parameters (or matching type specificity).
 /// Supports 1-16 property selectors for observation APIs (WhenChanged, WhenChanging, WhenAnyValue).
 /// </summary>
-[ExcludeFromCodeCoverage]
 public static partial class ReactiveUIBindingExtensions
 {
     /// <summary>

--- a/src/benchmarks/ReactiveUI.Binding.Benchmarks/RxUiDynamicChainBaseline.cs
+++ b/src/benchmarks/ReactiveUI.Binding.Benchmarks/RxUiDynamicChainBaseline.cs
@@ -2,7 +2,9 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
@@ -30,6 +32,9 @@ namespace RxUiDynamicChain;
 [MemoryDiagnoser]
 [EventPipeProfiler(EventPipeProfile.GcVerbose)]
 [MarkdownExporterAttribute.GitHub]
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
+#endif
 public class RxUiDynamicChainBaseline
 {
     /// <summary>Represents the number of property change events to be triggered during the benchmark tests.</summary>
@@ -75,7 +80,6 @@ public class RxUiDynamicChainBaseline
         _vm = new() { Name = "Initial", Age = 0, Child = new() { Value = "ChildInitial" } };
 
     /// <summary>One chain: subscribe, fire N changes, dispose.</summary>
-    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
     [Benchmark(Description = "Single Chain")]
     public void SingleChain()
     {
@@ -90,7 +94,6 @@ public class RxUiDynamicChainBaseline
     }
 
     /// <summary>Two chains combined: subscribe, fire N changes on each, dispose.</summary>
-    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
     [Benchmark(Description = "Two Chains")]
     public void TwoChains()
     {
@@ -106,7 +109,6 @@ public class RxUiDynamicChainBaseline
     }
 
     /// <summary>A chain through an intermediate: subscribe, fire N changes on the leaf, dispose.</summary>
-    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
     [Benchmark(Description = "Deep Chain")]
     public void DeepChain()
     {
@@ -122,7 +124,6 @@ public class RxUiDynamicChainBaseline
 
     /// <summary>Cold start: subscribe, read the initial value, dispose. No property changes.</summary>
     /// <returns>The observed value.</returns>
-    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
     [Benchmark(Description = "First Observation")]
     public object? FirstObservation()
     {

--- a/src/benchmarks/ReactiveUI.Binding.Benchmarks/RxUiDynamicChainBaseline.cs
+++ b/src/benchmarks/ReactiveUI.Binding.Benchmarks/RxUiDynamicChainBaseline.cs
@@ -1,0 +1,142 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+using ReactiveUI;
+using ReactiveUI.Builder;
+using BenchmarkVm = ReactiveUI.Binding.Benchmarks.BenchmarkViewModel;
+
+namespace RxUiDynamicChain;
+
+/// <summary>
+/// The same dynamic-chain scenarios as <c>WhenAnyDynamicBenchmark</c>, run against ReactiveUI's own engine so
+/// the two are read side by side.
+/// </summary>
+/// <remarks>
+/// Declared outside the <c>ReactiveUI.Binding</c> namespace on purpose. Extension lookup walks the enclosing
+/// namespaces from the inside out and stops at the first level offering a candidate, so a class nested under
+/// <c>ReactiveUI.Binding</c> reaches this library's overloads and never consults ReactiveUI's. The view model
+/// arrives through a type alias rather than an import for the same reason: importing its namespace would put
+/// both libraries' overloads at the outermost level and make every call ambiguous.
+/// </remarks>
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[MarkdownExporterAttribute.GitHub]
+public class RxUiDynamicChainBaseline
+{
+    /// <summary>Represents the number of property change events to be triggered during the benchmark tests.</summary>
+    private const int PropertyChangeCount = 1_000;
+
+    /// <summary>Names the chain reaching one property.</summary>
+    private static readonly Expression NameChain = Chain(x => x.Name);
+
+    /// <summary>Names the chain reaching a second property, so an arity above one has something to combine.</summary>
+    private static readonly Expression AgeChain = Chain(x => x.Age);
+
+    /// <summary>Names the chain reaching through an intermediate.</summary>
+    private static readonly Expression ChildValueChain = Chain(x => x.Child.Value);
+
+    /// <summary>Reads one observed change.</summary>
+    /// <remarks>
+    /// Typed rather than inferred so the binding is pinned: the parameter names ReactiveUI's
+    /// <see cref="IObservedChange{TSender, TValue}"/>, so a call that resolved to this library's overload of
+    /// the same name would not compile rather than quietly benchmarking the wrong engine.
+    /// </remarks>
+    private static readonly Func<IObservedChange<BenchmarkVm?, object?>, object?> ReadOne =
+        static c1 => c1.Value;
+
+    /// <summary>Reads whichever of two observed changes carries a value.</summary>
+    private static readonly Func<IObservedChange<BenchmarkVm?, object?>, IObservedChange<BenchmarkVm?, object?>, object?> ReadEither =
+        static (c1, c2) => c1.Value ?? c2.Value;
+
+    /// <summary>The view model instance used for observation benchmarks.</summary>
+    private BenchmarkVm _vm = null!;
+
+    /// <summary>Registers the observation plugins ReactiveUI resolves each link through.</summary>
+    [GlobalSetup]
+    public void Register()
+    {
+        var builder = RxAppBuilder.CreateReactiveUIBuilder();
+        _ = builder.WithCoreServices();
+        _ = builder.BuildApp();
+    }
+
+    /// <summary>Sets up a fresh view model before each benchmark iteration.</summary>
+    [IterationSetup]
+    public void Setup() =>
+        _vm = new() { Name = "Initial", Age = 0, Child = new() { Value = "ChildInitial" } };
+
+    /// <summary>One chain: subscribe, fire N changes, dispose.</summary>
+    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
+    [Benchmark(Description = "Single Chain")]
+    public void SingleChain()
+    {
+        object? last = null;
+        using var sub = _vm.WhenAnyDynamic(NameChain, ReadOne)
+            .Subscribe(v => last = v);
+
+        for (var i = 0; i < PropertyChangeCount; i++)
+        {
+            _vm.Name = $"Name_{i}";
+        }
+    }
+
+    /// <summary>Two chains combined: subscribe, fire N changes on each, dispose.</summary>
+    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
+    [Benchmark(Description = "Two Chains")]
+    public void TwoChains()
+    {
+        object? last = null;
+        using var sub = _vm.WhenAnyDynamic(NameChain, AgeChain, ReadEither)
+            .Subscribe(v => last = v);
+
+        for (var i = 0; i < PropertyChangeCount; i++)
+        {
+            _vm.Name = $"Name_{i}";
+            _vm.Age = i;
+        }
+    }
+
+    /// <summary>A chain through an intermediate: subscribe, fire N changes on the leaf, dispose.</summary>
+    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
+    [Benchmark(Description = "Deep Chain")]
+    public void DeepChain()
+    {
+        object? last = null;
+        using var sub = _vm.WhenAnyDynamic(ChildValueChain, ReadOne)
+            .Subscribe(v => last = v);
+
+        for (var i = 0; i < PropertyChangeCount; i++)
+        {
+            _vm.Child.Value = $"Value_{i}";
+        }
+    }
+
+    /// <summary>Cold start: subscribe, read the initial value, dispose. No property changes.</summary>
+    /// <returns>The observed value.</returns>
+    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
+    [Benchmark(Description = "First Observation")]
+    public object? FirstObservation()
+    {
+        object? result = null;
+        using var sub = _vm.WhenAnyDynamic(NameChain, ReadOne)
+            .Subscribe(v => result = v);
+        return result;
+    }
+
+    /// <summary>Names a property chain the way a caller building one at run time hands it over.</summary>
+    /// <typeparam name="TValue">The type the chain ends at.</typeparam>
+    /// <param name="property">The chain to name.</param>
+    /// <returns>The expression body, which is what these overloads take.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Expression Chain<TValue>(Expression<Func<BenchmarkVm, TValue>> property) =>
+        property.Body;
+}

--- a/src/benchmarks/ReactiveUI.Binding.Benchmarks/WhenAnyDynamicBenchmark.cs
+++ b/src/benchmarks/ReactiveUI.Binding.Benchmarks/WhenAnyDynamicBenchmark.cs
@@ -1,0 +1,140 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+using ReactiveUI.Binding.Builder;
+
+namespace ReactiveUI.Binding.Benchmarks;
+
+/// <summary>
+/// Reflection-walked observation benchmarks, and what the generated observation of the same chain costs.
+/// The pair is the choice a caller actually makes: a chain named by an expression built at run time cannot
+/// be resolved at compile time, and this says what that buys and what it costs.
+/// </summary>
+/// <remarks>
+/// No NativeAOT job: these overloads walk members by reflection and say so with
+/// <see cref="RequiresUnreferencedCodeAttribute"/>, so an ahead-of-time published run is not a
+/// configuration they support.
+/// </remarks>
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[MarkdownExporterAttribute.GitHub]
+public class WhenAnyDynamicBenchmark
+{
+    /// <summary>Represents the number of property change events to be triggered during the benchmark tests.</summary>
+    private const int PropertyChangeCount = 1_000;
+
+    /// <summary>Names the chain reaching one property.</summary>
+    private static readonly Expression NameChain = Chain(x => x.Name);
+
+    /// <summary>Names the chain reaching a second property, so an arity above one has something to combine.</summary>
+    private static readonly Expression AgeChain = Chain(x => x.Age);
+
+    /// <summary>Names the chain reaching through an intermediate.</summary>
+    private static readonly Expression ChildValueChain = Chain(x => x.Child.Value);
+
+    /// <summary>The view model instance used for observation benchmarks.</summary>
+    private BenchmarkViewModel _vm = null!;
+
+    /// <summary>Registers the observation plugins the reflection walk resolves each link through.</summary>
+    [GlobalSetup]
+    public void Register()
+    {
+        var builder = RxBindingBuilder.CreateReactiveUIBindingBuilder();
+        _ = builder.WithCoreServices();
+        _ = builder.BuildApp();
+    }
+
+    /// <summary>Sets up a fresh view model before each benchmark iteration.</summary>
+    [IterationSetup]
+    public void Setup() =>
+        _vm = new() { Name = "Initial", Age = 0, Child = new() { Value = "ChildInitial" } };
+
+    /// <summary>One chain: subscribe, fire N changes, dispose.</summary>
+    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
+    [Benchmark(Description = "Single Chain")]
+    public void SingleChain()
+    {
+        object? last = null;
+        using var sub = _vm.WhenAnyDynamic(NameChain, static c1 => c1.Value)
+            .Subscribe(v => last = v);
+
+        for (var i = 0; i < PropertyChangeCount; i++)
+        {
+            _vm.Name = $"Name_{i}";
+        }
+    }
+
+    /// <summary>Two chains combined: subscribe, fire N changes on each, dispose.</summary>
+    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
+    [Benchmark(Description = "Two Chains")]
+    public void TwoChains()
+    {
+        object? last = null;
+        using var sub = _vm.WhenAnyDynamic(NameChain, AgeChain, static (c1, c2) => c1.Value ?? c2.Value)
+            .Subscribe(v => last = v);
+
+        for (var i = 0; i < PropertyChangeCount; i++)
+        {
+            _vm.Name = $"Name_{i}";
+            _vm.Age = i;
+        }
+    }
+
+    /// <summary>A chain through an intermediate: subscribe, fire N changes on the leaf, dispose.</summary>
+    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
+    [Benchmark(Description = "Deep Chain")]
+    public void DeepChain()
+    {
+        object? last = null;
+        using var sub = _vm.WhenAnyDynamic(ChildValueChain, static c1 => c1.Value)
+            .Subscribe(v => last = v);
+
+        for (var i = 0; i < PropertyChangeCount; i++)
+        {
+            _vm.Child.Value = $"Value_{i}";
+        }
+    }
+
+    /// <summary>Cold start: subscribe, read the initial value, dispose. No property changes.</summary>
+    /// <returns>The observed value.</returns>
+    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
+    [Benchmark(Description = "First Observation")]
+    public object? FirstObservation()
+    {
+        object? result = null;
+        using var sub = _vm.WhenAnyDynamic(NameChain, static c1 => c1.Value)
+            .Subscribe(v => result = v);
+        return result;
+    }
+
+    /// <summary>The same single chain resolved at compile time, which is what the reflection walk is weighed against.</summary>
+    [Benchmark(Description = "Single Chain (generated)", Baseline = true)]
+    public void SingleChainGenerated()
+    {
+        var last = string.Empty;
+        using var sub = _vm.WhenChanged(x => x.Name)
+            .Subscribe(v => last = v);
+
+        for (var i = 0; i < PropertyChangeCount; i++)
+        {
+            _vm.Name = $"Name_{i}";
+        }
+    }
+
+    /// <summary>Names a property chain the way a caller building one at run time hands it over.</summary>
+    /// <typeparam name="TValue">The type the chain ends at.</typeparam>
+    /// <param name="property">The chain to name.</param>
+    /// <returns>The expression body, which is what these overloads take.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Expression Chain<TValue>(Expression<Func<BenchmarkViewModel, TValue>> property) =>
+        property.Body;
+}

--- a/src/benchmarks/ReactiveUI.Binding.Benchmarks/WhenAnyDynamicBenchmark.cs
+++ b/src/benchmarks/ReactiveUI.Binding.Benchmarks/WhenAnyDynamicBenchmark.cs
@@ -2,7 +2,9 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
@@ -19,7 +21,7 @@ namespace ReactiveUI.Binding.Benchmarks;
 /// </summary>
 /// <remarks>
 /// No NativeAOT job: these overloads walk members by reflection and say so with
-/// <see cref="RequiresUnreferencedCodeAttribute"/>, so an ahead-of-time published run is not a
+/// <c>RequiresUnreferencedCode</c>, so an ahead-of-time published run is not a
 /// configuration they support.
 /// </remarks>
 [SimpleJob(RuntimeMoniker.Net80)]
@@ -27,6 +29,9 @@ namespace ReactiveUI.Binding.Benchmarks;
 [MemoryDiagnoser]
 [EventPipeProfiler(EventPipeProfile.GcVerbose)]
 [MarkdownExporterAttribute.GitHub]
+#if NET8_0_OR_GREATER
+[RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
+#endif
 public class WhenAnyDynamicBenchmark
 {
     /// <summary>Represents the number of property change events to be triggered during the benchmark tests.</summary>
@@ -59,7 +64,6 @@ public class WhenAnyDynamicBenchmark
         _vm = new() { Name = "Initial", Age = 0, Child = new() { Value = "ChildInitial" } };
 
     /// <summary>One chain: subscribe, fire N changes, dispose.</summary>
-    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
     [Benchmark(Description = "Single Chain")]
     public void SingleChain()
     {
@@ -74,7 +78,6 @@ public class WhenAnyDynamicBenchmark
     }
 
     /// <summary>Two chains combined: subscribe, fire N changes on each, dispose.</summary>
-    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
     [Benchmark(Description = "Two Chains")]
     public void TwoChains()
     {
@@ -90,7 +93,6 @@ public class WhenAnyDynamicBenchmark
     }
 
     /// <summary>A chain through an intermediate: subscribe, fire N changes on the leaf, dispose.</summary>
-    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
     [Benchmark(Description = "Deep Chain")]
     public void DeepChain()
     {
@@ -106,7 +108,6 @@ public class WhenAnyDynamicBenchmark
 
     /// <summary>Cold start: subscribe, read the initial value, dispose. No property changes.</summary>
     /// <returns>The observed value.</returns>
-    [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
     [Benchmark(Description = "First Observation")]
     public object? FirstObservation()
     {

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/BindingDispatchStubTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/BindingDispatchStubTests.cs
@@ -1,0 +1,221 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Binding.Tests.TestModels;
+
+namespace ReactiveUI.Binding.Tests.Mixins;
+
+/// <summary>Covers the binding overloads that exist only to be replaced by a generated one.</summary>
+/// <remarks>
+/// Unlike the observation surface, a binding has no runtime fallback: resolving one needs the two lambdas at
+/// compile time. Each overload here therefore refuses the call rather than binding something. They are reached
+/// on the declaring class rather than as extension methods, because written as an extension call the generated
+/// dispatch wins overload resolution and the refusal never happens.
+/// </remarks>
+public class BindingDispatchStubTests
+{
+    /// <summary>The source of a binding.</summary>
+    private readonly DispatchStubViewModel _viewModel = new();
+
+    /// <summary>The target of a binding.</summary>
+    private readonly DispatchStubView _view = new();
+
+    /// <summary>The stream a BindTo call writes from.</summary>
+    private readonly ManualObservable<string> _source = new();
+
+    /// <summary>A one-way binding with no generated overload refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindOneWay_WithNoGeneratedOverload_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.BindOneWay(
+                _viewModel,
+                _view,
+                x => x.Caption,
+                x => x.Caption))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>A converting one-way binding with no generated overload refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindOneWay_ConvertingWithNoGeneratedOverload_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.BindOneWay(
+                _viewModel,
+                _view,
+                x => x.Caption,
+                x => x.Caption,
+                static value => value))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>A two-way binding with no generated overload refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTwoWay_WithNoGeneratedOverload_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.BindTwoWay(
+                _viewModel,
+                _view,
+                x => x.Caption,
+                x => x.Caption))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>A converting two-way binding with no generated overload refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTwoWay_ConvertingWithNoGeneratedOverload_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.BindTwoWay(
+                _viewModel,
+                _view,
+                x => x.Caption,
+                x => x.Caption,
+                static value => value,
+                static value => value))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>The view-first spelling of a one-way binding refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OneWayBind_WithNoGeneratedOverload_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.OneWayBind(
+                _view,
+                _viewModel,
+                x => x.Caption,
+                x => x.Caption))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>The converting view-first spelling of a one-way binding refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OneWayBind_ConvertingWithNoGeneratedOverload_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.OneWayBind(
+                _view,
+                _viewModel,
+                x => x.Caption,
+                x => x.Caption,
+                static value => value))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>The view-first spelling of a two-way binding refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Bind_WithNoGeneratedOverload_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.Bind(
+                _view,
+                _viewModel,
+                x => x.Caption,
+                x => x.Caption))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>The converting view-first spelling of a two-way binding refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Bind_ConvertingWithNoGeneratedOverload_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.Bind(
+                _view,
+                _viewModel,
+                x => x.Caption,
+                x => x.Caption,
+                static value => value,
+                static value => value))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>Writing a stream into a property with no generated overload refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTo_WithNoGeneratedOverload_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.BindTo(
+                _source,
+                _view,
+                x => x.Caption))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>Writing a stream into a property with a conversion hint refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTo_WithAConversionHint_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.BindTo(
+                _source,
+                _view,
+                x => x.Caption,
+                conversionHint: null))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>Writing a stream into a property with a converter refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTo_WithAConverter_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.BindTo(
+                _source,
+                _view,
+                x => x.Caption,
+                converterOverride: null))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>Writing a stream into a property with both a hint and a converter refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTo_WithAConversionHintAndAConverter_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.BindTo(
+                _source,
+                _view,
+                x => x.Caption,
+                conversionHint: null,
+                converterOverride: null))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>A command binding with no generated overload refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommand_WithNoGeneratedOverload_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.BindCommand(
+                _view,
+                _viewModel,
+                x => x.Run,
+                x => x.Control))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>A command binding taking its parameter from a stream refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommand_WithAParameterStream_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.BindCommand(
+                _view,
+                _viewModel,
+                x => x.Run,
+                x => x.Control,
+                _source))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>A command binding taking its parameter from a property refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommand_WithAParameterProperty_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.BindCommand(
+                _view,
+                _viewModel,
+                x => x.Run,
+                x => x.Control,
+                x => x.Parameter))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>An interaction binding handled asynchronously refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindInteraction_WithAnAsynchronousHandler_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.BindInteraction(
+                _view,
+                _viewModel,
+                x => x.Confirm,
+                static context => Task.CompletedTask))
+            .ThrowsExactly<InvalidOperationException>();
+
+    /// <summary>An interaction binding handled by a stream refuses the call.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindInteraction_WithAStreamHandler_ThrowsInvalidOperationException() =>
+        await Assert.That(() => ReactiveUIBindingExtensions.BindInteraction(
+                _view,
+                _viewModel,
+                x => x.Confirm,
+                static IObservable<string> (context) => new ManualObservable<string>()))
+            .ThrowsExactly<InvalidOperationException>();
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyDynamicTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyDynamicTests.cs
@@ -1,0 +1,983 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using ReactiveUI.Binding.Tests.TestModels;
+using ReactiveUI.Binding.Tests.WhenAny;
+
+namespace ReactiveUI.Binding.Tests.Mixins;
+
+/// <summary>
+/// Tests for the WhenAnyDynamic overloads, which observe property chains named by an expression the
+/// caller built rather than by a lambda the compiler could read.
+/// </summary>
+public class WhenAnyDynamicTests
+{
+    /// <summary>The value every observed property starts out holding.</summary>
+    private const string InitialValue = "a";
+
+    /// <summary>The value the last observed property is moved to.</summary>
+    private const string MovedValue = "b";
+
+    /// <summary>How many chains the one-chain overloads observe.</summary>
+    private const int OneChain = 1;
+
+    /// <summary>How many chains the two-chain overloads observe.</summary>
+    private const int TwoChains = 2;
+
+    /// <summary>How many chains the three-chain overloads observe.</summary>
+    private const int ThreeChains = 3;
+
+    /// <summary>How many chains the four-chain overloads observe.</summary>
+    private const int FourChains = 4;
+
+    /// <summary>How many chains the five-chain overloads observe.</summary>
+    private const int FiveChains = 5;
+
+    /// <summary>How many chains the six-chain overloads observe.</summary>
+    private const int SixChains = 6;
+
+    /// <summary>How many chains the seven-chain overloads observe.</summary>
+    private const int SevenChains = 7;
+
+    /// <summary>How many chains the eight-chain overloads observe.</summary>
+    private const int EightChains = 8;
+
+    /// <summary>How many chains the nine-chain overloads observe.</summary>
+    private const int NineChains = 9;
+
+    /// <summary>How many chains the ten-chain overloads observe.</summary>
+    private const int TenChains = 10;
+
+    /// <summary>How many chains the eleven-chain overloads observe.</summary>
+    private const int ElevenChains = 11;
+
+    /// <summary>How many chains the twelve-chain overloads observe.</summary>
+    private const int TwelveChains = 12;
+
+    /// <summary>What a chain reports with the distinct gate on: the seed, then the move.</summary>
+    private static readonly string[] SeedThenMove = [InitialValue, MovedValue];
+
+    /// <summary>What a chain reports with the gate off: the seed, the move, and the notification repeating it.</summary>
+    private static readonly string[] SeedThenMoveTwice = [InitialValue, MovedValue, MovedValue];
+
+    /// <summary>Observing 1 chain, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity1_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            static c1 => string.Concat(c1.Value))
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(OneChain));
+
+        fixture.P1 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(OneChain));
+    }
+
+    /// <summary>Observing 1 chain with the distinct gate named, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity1WithDistinctSpecified_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            static c1 => string.Concat(c1.Value),
+            true)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(OneChain));
+
+        fixture.P1 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(OneChain));
+    }
+
+    /// <summary>Observing 2 chains, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity2_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            static (c1, c2) => string.Concat(c1.Value, c2.Value))
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(TwoChains));
+
+        fixture.P2 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(TwoChains));
+    }
+
+    /// <summary>Observing 2 chains with the distinct gate named, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity2WithDistinctSpecified_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            static (c1, c2) => string.Concat(c1.Value, c2.Value),
+            true)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(TwoChains));
+
+        fixture.P2 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(TwoChains));
+    }
+
+    /// <summary>Observing 3 chains, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity3_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            static (c1, c2, c3) => string.Concat(c1.Value, c2.Value, c3.Value))
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(ThreeChains));
+
+        fixture.P3 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(ThreeChains));
+    }
+
+    /// <summary>Observing 3 chains with the distinct gate named, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity3WithDistinctSpecified_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            static (c1, c2, c3) => string.Concat(c1.Value, c2.Value, c3.Value),
+            true)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(ThreeChains));
+
+        fixture.P3 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(ThreeChains));
+    }
+
+    /// <summary>Observing 4 chains, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity4_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            static (c1, c2, c3, c4) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value))
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(FourChains));
+
+        fixture.P4 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(FourChains));
+    }
+
+    /// <summary>Observing 4 chains with the distinct gate named, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity4WithDistinctSpecified_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            static (c1, c2, c3, c4) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value),
+            true)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(FourChains));
+
+        fixture.P4 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(FourChains));
+    }
+
+    /// <summary>Observing 5 chains, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity5_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            static (c1, c2, c3, c4, c5) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value))
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(FiveChains));
+
+        fixture.P5 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(FiveChains));
+    }
+
+    /// <summary>Observing 5 chains with the distinct gate named, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity5WithDistinctSpecified_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            static (c1, c2, c3, c4, c5) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value),
+            true)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(FiveChains));
+
+        fixture.P5 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(FiveChains));
+    }
+
+    /// <summary>Observing 6 chains, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity6_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            Body(x => x.P6),
+            static (c1, c2, c3, c4, c5, c6) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value,
+                c6.Value))
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(SixChains));
+
+        fixture.P6 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(SixChains));
+    }
+
+    /// <summary>Observing 6 chains with the distinct gate named, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity6WithDistinctSpecified_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            Body(x => x.P6),
+            static (c1, c2, c3, c4, c5, c6) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value,
+                c6.Value),
+            true)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(SixChains));
+
+        fixture.P6 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(SixChains));
+    }
+
+    /// <summary>Observing 7 chains, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity7_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            Body(x => x.P6),
+            Body(x => x.P7),
+            static (c1, c2, c3, c4, c5, c6, c7) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value,
+                c6.Value,
+                c7.Value))
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(SevenChains));
+
+        fixture.P7 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(SevenChains));
+    }
+
+    /// <summary>Observing 7 chains with the distinct gate named, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity7WithDistinctSpecified_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            Body(x => x.P6),
+            Body(x => x.P7),
+            static (c1, c2, c3, c4, c5, c6, c7) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value,
+                c6.Value,
+                c7.Value),
+            true)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(SevenChains));
+
+        fixture.P7 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(SevenChains));
+    }
+
+    /// <summary>Observing 8 chains, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity8_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            Body(x => x.P6),
+            Body(x => x.P7),
+            Body(x => x.P8),
+            static (c1, c2, c3, c4, c5, c6, c7, c8) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value,
+                c6.Value,
+                c7.Value,
+                c8.Value))
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(EightChains));
+
+        fixture.P8 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(EightChains));
+    }
+
+    /// <summary>Observing 8 chains with the distinct gate named, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity8WithDistinctSpecified_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            Body(x => x.P6),
+            Body(x => x.P7),
+            Body(x => x.P8),
+            static (c1, c2, c3, c4, c5, c6, c7, c8) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value,
+                c6.Value,
+                c7.Value,
+                c8.Value),
+            true)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(EightChains));
+
+        fixture.P8 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(EightChains));
+    }
+
+    /// <summary>Observing 9 chains, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity9_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            Body(x => x.P6),
+            Body(x => x.P7),
+            Body(x => x.P8),
+            Body(x => x.P9),
+            static (c1, c2, c3, c4, c5, c6, c7, c8, c9) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value,
+                c6.Value,
+                c7.Value,
+                c8.Value,
+                c9.Value))
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(NineChains));
+
+        fixture.P9 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(NineChains));
+    }
+
+    /// <summary>Observing 9 chains with the distinct gate named, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity9WithDistinctSpecified_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            Body(x => x.P6),
+            Body(x => x.P7),
+            Body(x => x.P8),
+            Body(x => x.P9),
+            static (c1, c2, c3, c4, c5, c6, c7, c8, c9) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value,
+                c6.Value,
+                c7.Value,
+                c8.Value,
+                c9.Value),
+            true)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(NineChains));
+
+        fixture.P9 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(NineChains));
+    }
+
+    /// <summary>Observing 10 chains, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity10_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            Body(x => x.P6),
+            Body(x => x.P7),
+            Body(x => x.P8),
+            Body(x => x.P9),
+            Body(x => x.P10),
+            static (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value,
+                c6.Value,
+                c7.Value,
+                c8.Value,
+                c9.Value,
+                c10.Value))
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(TenChains));
+
+        fixture.P10 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(TenChains));
+    }
+
+    /// <summary>Observing 10 chains with the distinct gate named, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity10WithDistinctSpecified_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            Body(x => x.P6),
+            Body(x => x.P7),
+            Body(x => x.P8),
+            Body(x => x.P9),
+            Body(x => x.P10),
+            static (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value,
+                c6.Value,
+                c7.Value,
+                c8.Value,
+                c9.Value,
+                c10.Value),
+            true)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(TenChains));
+
+        fixture.P10 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(TenChains));
+    }
+
+    /// <summary>Observing 11 chains, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity11_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            Body(x => x.P6),
+            Body(x => x.P7),
+            Body(x => x.P8),
+            Body(x => x.P9),
+            Body(x => x.P10),
+            Body(x => x.P11),
+            static (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value,
+                c6.Value,
+                c7.Value,
+                c8.Value,
+                c9.Value,
+                c10.Value,
+                c11.Value))
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(ElevenChains));
+
+        fixture.P11 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(ElevenChains));
+    }
+
+    /// <summary>Observing 11 chains with the distinct gate named, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity11WithDistinctSpecified_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            Body(x => x.P6),
+            Body(x => x.P7),
+            Body(x => x.P8),
+            Body(x => x.P9),
+            Body(x => x.P10),
+            Body(x => x.P11),
+            static (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value,
+                c6.Value,
+                c7.Value,
+                c8.Value,
+                c9.Value,
+                c10.Value,
+                c11.Value),
+            true)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(ElevenChains));
+
+        fixture.P11 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(ElevenChains));
+    }
+
+    /// <summary>Observing 12 chains, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity12_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            Body(x => x.P6),
+            Body(x => x.P7),
+            Body(x => x.P8),
+            Body(x => x.P9),
+            Body(x => x.P10),
+            Body(x => x.P11),
+            Body(x => x.P12),
+            static (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value,
+                c6.Value,
+                c7.Value,
+                c8.Value,
+                c9.Value,
+                c10.Value,
+                c11.Value,
+                c12.Value))
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(TwelveChains));
+
+        fixture.P12 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(TwelveChains));
+    }
+
+    /// <summary>Observing 12 chains with the distinct gate named, reporting the combined value and each change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Arity12WithDistinctSpecified_ReportsTheCombinedValueAndEachChange()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture.WhenAnyDynamic(
+            Body(x => x.P1),
+            Body(x => x.P2),
+            Body(x => x.P3),
+            Body(x => x.P4),
+            Body(x => x.P5),
+            Body(x => x.P6),
+            Body(x => x.P7),
+            Body(x => x.P8),
+            Body(x => x.P9),
+            Body(x => x.P10),
+            Body(x => x.P11),
+            Body(x => x.P12),
+            static (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12) => string.Concat(
+                c1.Value,
+                c2.Value,
+                c3.Value,
+                c4.Value,
+                c5.Value,
+                c6.Value,
+                c7.Value,
+                c8.Value,
+                c9.Value,
+                c10.Value,
+                c11.Value,
+                c12.Value),
+            true)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(Initial(TwelveChains));
+
+        fixture.P12 = MovedValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(LastMoved(TwelveChains));
+    }
+
+    /// <summary>The distinct gate suppresses a notification that leaves the value where it was.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyDynamic_WithTheDistinctGateOn_SuppressesADuplicate()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture
+            .WhenAnyDynamic(Body(x => x.P1), static c1 => string.Concat(c1.Value), true)
+            .Subscribe(seen.Add);
+
+        fixture.P1 = MovedValue;
+        fixture.P1 = MovedValue;
+
+        await Assert.That(seen).IsEquivalentTo(SeedThenMove);
+    }
+
+    /// <summary>With the gate off, a notification is reported even where the value did not move.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyDynamic_WithTheDistinctGateOff_ReportsADuplicate()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture
+            .WhenAnyDynamic(Body(x => x.P1), static c1 => string.Concat(c1.Value), false)
+            .Subscribe(seen.Add);
+
+        fixture.P1 = MovedValue;
+        fixture.P1 = MovedValue;
+
+        await Assert.That(seen).IsEquivalentTo(SeedThenMoveTwice);
+    }
+
+    /// <summary>A chain through an intermediate follows the intermediate when it is replaced.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyDynamic_ThroughAnIntermediate_FollowsTheReplacement()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new DynamicChainFixture();
+        var seen = new List<string>();
+
+        using var subscription = fixture
+            .WhenAnyDynamic(Body(x => x.Child!.Name), static c1 => string.Concat(c1.Value))
+            .Subscribe(seen.Add);
+
+        fixture.Child = new DynamicChainChild { Name = MovedValue };
+
+        await Assert.That(seen[^1]).IsEqualTo(MovedValue);
+    }
+
+    /// <summary>An object to observe is required.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyDynamic_WithNoSender_ThrowsArgumentNullException()
+    {
+        DynamicChainFixture? fixture = null;
+
+        await Assert.That(() => fixture!.WhenAnyDynamic(Body(x => x.P1), static c1 => string.Concat(c1.Value)))
+            .ThrowsExactly<ArgumentNullException>();
+    }
+
+    /// <summary>A selector is required.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyDynamic_WithNoSelector_ThrowsArgumentNullException()
+    {
+        var fixture = new DynamicChainFixture();
+
+        await Assert.That(() => fixture.WhenAnyDynamic<DynamicChainFixture, string>(Body(x => x.P1), null!))
+            .ThrowsExactly<ArgumentNullException>();
+    }
+
+    /// <summary>The combined value while every observed chain still holds its initial value.</summary>
+    /// <param name="count">How many chains were observed.</param>
+    /// <returns>What the selector concatenates.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string Initial(int count) => string.Concat(Enumerable.Repeat(InitialValue, count));
+
+    /// <summary>The combined value once the last of the observed chains has moved.</summary>
+    /// <param name="count">How many chains were observed.</param>
+    /// <returns>What the selector concatenates.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string LastMoved(int count) => Initial(count - 1) + MovedValue;
+
+    /// <summary>Names a property chain the way a caller builds one at run time.</summary>
+    /// <typeparam name="TValue">The type the chain ends at.</typeparam>
+    /// <param name="property">The chain to name.</param>
+    /// <returns>The expression body, which is what these overloads take.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static System.Linq.Expressions.Expression Body<TValue>(
+        Expression<Func<DynamicChainFixture, TValue>> property) =>
+        property.Body;
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyObservableWideArityTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyObservableWideArityTests.cs
@@ -1,0 +1,740 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using ReactiveUI.Binding.Tests.TestModels;
+using ReactiveUI.Binding.Tests.WhenAny;
+
+namespace ReactiveUI.Binding.Tests.Mixins;
+
+/// <summary>Reaches every arity of the runtime WhenAnyObservable overloads, which follow the observable a property holds.</summary>
+/// <remarks>
+/// Each overload is called on the declaring class rather than as an extension method. Written as an
+/// extension call the generated dispatch wins overload resolution, and the runtime overload these
+/// assertions are about would never run.
+/// </remarks>
+public class WhenAnyObservableWideArityTests
+{
+    /// <summary>The value each stream is driven with.</summary>
+    private const string EmittedValue = "a";
+
+    /// <summary>The first and last stream's values read together, which is what the selectors project.</summary>
+    private const string BothEnds = EmittedValue + EmittedValue;
+
+    /// <summary>Following one stream reports what it emits.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_FollowingOneStream_ReportsTheEmittedValue()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(EmittedValue);
+    }
+
+    /// <summary>Following two streams reports what they emit.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_FollowingTwoStreams_ReportsTheEmittedValue()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(EmittedValue);
+    }
+
+    /// <summary>Following three streams reports what they emit.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_FollowingThreeStreams_ReportsTheEmittedValue()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(EmittedValue);
+    }
+
+    /// <summary>Following four streams reports what they emit.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_FollowingFourStreams_ReportsTheEmittedValue()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(EmittedValue);
+    }
+
+    /// <summary>Following five streams reports what they emit.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_FollowingFiveStreams_ReportsTheEmittedValue()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(EmittedValue);
+    }
+
+    /// <summary>Following six streams reports what they emit.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_FollowingSixStreams_ReportsTheEmittedValue()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                x => x.Stream6)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(EmittedValue);
+    }
+
+    /// <summary>Following seven streams reports what they emit.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_FollowingSevenStreams_ReportsTheEmittedValue()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                x => x.Stream6,
+                x => x.Stream7)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(EmittedValue);
+    }
+
+    /// <summary>Following eight streams reports what they emit.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_FollowingEightStreams_ReportsTheEmittedValue()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                x => x.Stream6,
+                x => x.Stream7,
+                x => x.Stream8)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(EmittedValue);
+    }
+
+    /// <summary>Following nine streams reports what they emit.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_FollowingNineStreams_ReportsTheEmittedValue()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                x => x.Stream6,
+                x => x.Stream7,
+                x => x.Stream8,
+                x => x.Stream9)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(EmittedValue);
+    }
+
+    /// <summary>Following ten streams reports what they emit.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_FollowingTenStreams_ReportsTheEmittedValue()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                x => x.Stream6,
+                x => x.Stream7,
+                x => x.Stream8,
+                x => x.Stream9,
+                x => x.Stream10)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(EmittedValue);
+    }
+
+    /// <summary>Following eleven streams reports what they emit.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_FollowingElevenStreams_ReportsTheEmittedValue()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                x => x.Stream6,
+                x => x.Stream7,
+                x => x.Stream8,
+                x => x.Stream9,
+                x => x.Stream10,
+                x => x.Stream11)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(EmittedValue);
+    }
+
+    /// <summary>Following twelve streams reports what they emit.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_FollowingTwelveStreams_ReportsTheEmittedValue()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                x => x.Stream6,
+                x => x.Stream7,
+                x => x.Stream8,
+                x => x.Stream9,
+                x => x.Stream10,
+                x => x.Stream11,
+                x => x.Stream12)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(EmittedValue);
+    }
+
+    /// <summary>Combining two streams reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_CombiningTwoStreams_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                static (v1, v2) => v1 + v2)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Combining three streams reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_CombiningThreeStreams_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                static (v1, v2, v3) => v1 + v3)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Combining four streams reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_CombiningFourStreams_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                static (v1, v2, v3, v4) => v1 + v4)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Combining five streams reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_CombiningFiveStreams_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                static (v1, v2, v3, v4, v5) => v1 + v5)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Combining six streams reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_CombiningSixStreams_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                x => x.Stream6,
+                static (v1, v2, v3, v4, v5, v6) => v1 + v6)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Combining seven streams reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_CombiningSevenStreams_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                x => x.Stream6,
+                x => x.Stream7,
+                static (v1, v2, v3, v4, v5, v6, v7) => v1 + v7)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Combining eight streams reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_CombiningEightStreams_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                x => x.Stream6,
+                x => x.Stream7,
+                x => x.Stream8,
+                static (v1, v2, v3, v4, v5, v6, v7, v8) => v1 + v8)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Combining nine streams reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_CombiningNineStreams_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                x => x.Stream6,
+                x => x.Stream7,
+                x => x.Stream8,
+                x => x.Stream9,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9) => v1 + v9)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Combining ten streams reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_CombiningTenStreams_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                x => x.Stream6,
+                x => x.Stream7,
+                x => x.Stream8,
+                x => x.Stream9,
+                x => x.Stream10,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) => v1 + v10)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Combining eleven streams reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_CombiningElevenStreams_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                x => x.Stream6,
+                x => x.Stream7,
+                x => x.Stream8,
+                x => x.Stream9,
+                x => x.Stream10,
+                x => x.Stream11,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) => v1 + v11)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Combining twelve streams reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_CombiningTwelveStreams_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityObservableFixture();
+        var streams = fixture.FillStreams();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+                fixture,
+                x => x.Stream1,
+                x => x.Stream2,
+                x => x.Stream3,
+                x => x.Stream4,
+                x => x.Stream5,
+                x => x.Stream6,
+                x => x.Stream7,
+                x => x.Stream8,
+                x => x.Stream9,
+                x => x.Stream10,
+                x => x.Stream11,
+                x => x.Stream12,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) => v1 + v12)
+            .Subscribe(seen.Add);
+
+        foreach (var stream in streams)
+        {
+            // Only the streams this arity observes were subscribed to, so the rest have no observer.
+            stream.Observer?.OnNext(EmittedValue);
+        }
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyValueWideArityTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyValueWideArityTests.cs
@@ -1,0 +1,854 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using ReactiveUI.Binding.Tests.TestModels;
+using ReactiveUI.Binding.Tests.WhenAny;
+
+namespace ReactiveUI.Binding.Tests.Mixins;
+
+/// <summary>Reaches every arity of the runtime WhenAnyValue overloads, the ReactiveUI-compatible spelling of WhenChanged.</summary>
+/// <remarks>
+/// Each overload is called on the declaring class rather than as an extension method. Written as an
+/// extension call the generated dispatch wins overload resolution, and the runtime overload these
+/// assertions are about would never run.
+/// </remarks>
+public class WhenAnyValueWideArityTests
+{
+    /// <summary>The value every observed property starts out holding.</summary>
+    private const string InitialValue = "a";
+
+    /// <summary>The first and last observed values read together, which is what each test projects.</summary>
+    private const string BothEnds = InitialValue + InitialValue;
+
+    /// <summary>Observing one property reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnOneProperty_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(InitialValue);
+    }
+
+    /// <summary>Observing two properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnTwoProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property2));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing three properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnThreeProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property3));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing four properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnFourProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property4));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing five properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnFiveProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property5));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing six properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnSixProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property6));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing seven properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnSevenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property7));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing eight properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnEightProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property8));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing nine properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnNineProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property9));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing ten properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnTenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property10));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing eleven properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnElevenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property11));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing twelve properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnTwelveProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property12));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing thirteen properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnThirteenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property13));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing fourteen properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnFourteenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property14));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing fifteen properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnFifteenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                x => x.Value15)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property15));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing sixteen properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_OnSixteenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                x => x.Value15,
+                x => x.Value16)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property16));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting one observed property reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingOneProperty_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                static (string v1) => v1)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(InitialValue);
+    }
+
+    /// <summary>Projecting two observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingTwoProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                static (v1, v2) => v1 + v2)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting three observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingThreeProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                static (v1, v2, v3) => v1 + v3)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting four observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingFourProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                static (v1, v2, v3, v4) => v1 + v4)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting five observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingFiveProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                static (v1, v2, v3, v4, v5) => v1 + v5)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting six observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingSixProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                static (v1, v2, v3, v4, v5, v6) => v1 + v6)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting seven observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingSevenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                static (v1, v2, v3, v4, v5, v6, v7) => v1 + v7)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting eight observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingEightProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                static (v1, v2, v3, v4, v5, v6, v7, v8) => v1 + v8)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting nine observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingNineProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9) => v1 + v9)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting ten observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingTenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) => v1 + v10)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting eleven observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingElevenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) => v1 + v11)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting twelve observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingTwelveProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) => v1 + v12)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting thirteen observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingThirteenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) => v1 + v13)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting fourteen observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingFourteenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) => v1 + v14)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting fifteen observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingFifteenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                x => x.Value15,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) => v1 + v15)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting sixteen observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyValue_ProjectingSixteenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                x => x.Value15,
+                x => x.Value16,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) => v1 + v16)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyWideArityTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyWideArityTests.cs
@@ -1,0 +1,316 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using ReactiveUI.Binding.Tests.TestModels;
+using ReactiveUI.Binding.Tests.WhenAny;
+
+namespace ReactiveUI.Binding.Tests.Mixins;
+
+/// <summary>Reaches every arity of the runtime WhenAny overloads, which hand the selector an observed change rather than a bare value.</summary>
+/// <remarks>
+/// Each overload is called on the declaring class rather than as an extension method. Written as an
+/// extension call the generated dispatch wins overload resolution, and the runtime overload these
+/// assertions are about would never run.
+/// </remarks>
+public class WhenAnyWideArityTests
+{
+    /// <summary>The value every observed property starts out holding.</summary>
+    private const string InitialValue = "a";
+
+    /// <summary>The first and last observed values read together, which is what each test projects.</summary>
+    private const string BothEnds = InitialValue + InitialValue;
+
+    /// <summary>Observing one property hands the selector each observed change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAny_OnOneProperty_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+                fixture,
+                x => x.Value1,
+                static c1 => c1.Value)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(InitialValue);
+    }
+
+    /// <summary>Observing two properties hands the selector each observed change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAny_OnTwoProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                static (c1, c2) => c1.Value + c2.Value)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing three properties hands the selector each observed change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAny_OnThreeProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                static (c1, c2, c3) => c1.Value + c3.Value)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing four properties hands the selector each observed change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAny_OnFourProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                static (c1, c2, c3, c4) => c1.Value + c4.Value)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing five properties hands the selector each observed change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAny_OnFiveProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                static (c1, c2, c3, c4, c5) => c1.Value + c5.Value)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing six properties hands the selector each observed change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAny_OnSixProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                static (c1, c2, c3, c4, c5, c6) => c1.Value + c6.Value)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing seven properties hands the selector each observed change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAny_OnSevenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                static (c1, c2, c3, c4, c5, c6, c7) => c1.Value + c7.Value)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing eight properties hands the selector each observed change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAny_OnEightProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                static (c1, c2, c3, c4, c5, c6, c7, c8) => c1.Value + c8.Value)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing nine properties hands the selector each observed change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAny_OnNineProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                static (c1, c2, c3, c4, c5, c6, c7, c8, c9) => c1.Value + c9.Value)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing ten properties hands the selector each observed change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAny_OnTenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                static (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) => c1.Value + c10.Value)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing eleven properties hands the selector each observed change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAny_OnElevenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                static (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11) => c1.Value + c11.Value)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing twelve properties hands the selector each observed change.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAny_OnTwelveProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                static (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12) => c1.Value + c12.Value)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenChangedWideArityTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenChangedWideArityTests.cs
@@ -1,0 +1,835 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using ReactiveUI.Binding.Tests.TestModels;
+using ReactiveUI.Binding.Tests.WhenAny;
+
+namespace ReactiveUI.Binding.Tests.Mixins;
+
+/// <summary>Reaches every arity of the runtime WhenChanged overloads, which observe after a value changes.</summary>
+/// <remarks>
+/// Each overload is called on the declaring class rather than as an extension method. Written as an
+/// extension call the generated dispatch wins overload resolution, and the runtime overload these
+/// assertions are about would never run.
+/// </remarks>
+public class WhenChangedWideArityTests
+{
+    /// <summary>The value every observed property starts out holding.</summary>
+    private const string InitialValue = "a";
+
+    /// <summary>The first and last observed values read together, which is what each test projects.</summary>
+    private const string BothEnds = InitialValue + InitialValue;
+
+    /// <summary>Observing one property reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnOneProperty_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(InitialValue);
+    }
+
+    /// <summary>Observing two properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnTwoProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property2));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing three properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnThreeProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property3));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing four properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnFourProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property4));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing five properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnFiveProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property5));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing six properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnSixProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property6));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing seven properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnSevenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property7));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing eight properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnEightProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property8));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing nine properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnNineProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property9));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing ten properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnTenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property10));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing eleven properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnElevenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property11));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing twelve properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnTwelveProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property12));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing thirteen properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnThirteenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property13));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing fourteen properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnFourteenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property14));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing fifteen properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnFifteenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                x => x.Value15)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property15));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing sixteen properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_OnSixteenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                x => x.Value15,
+                x => x.Value16)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property16));
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting two observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingTwoProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                static (v1, v2) => v1 + v2)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting three observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingThreeProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                static (v1, v2, v3) => v1 + v3)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting four observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingFourProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                static (v1, v2, v3, v4) => v1 + v4)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting five observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingFiveProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                static (v1, v2, v3, v4, v5) => v1 + v5)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting six observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingSixProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                static (v1, v2, v3, v4, v5, v6) => v1 + v6)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting seven observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingSevenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                static (v1, v2, v3, v4, v5, v6, v7) => v1 + v7)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting eight observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingEightProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                static (v1, v2, v3, v4, v5, v6, v7, v8) => v1 + v8)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting nine observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingNineProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9) => v1 + v9)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting ten observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingTenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) => v1 + v10)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting eleven observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingElevenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) => v1 + v11)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting twelve observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingTwelveProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) => v1 + v12)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting thirteen observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingThirteenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) => v1 + v13)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting fourteen observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingFourteenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) => v1 + v14)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting fifteen observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingFifteenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                x => x.Value15,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) => v1 + v15)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting sixteen observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_ProjectingSixteenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                x => x.Value15,
+                x => x.Value16,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) => v1 + v16)
+            .Subscribe(seen.Add);
+
+        await Assert.That(seen[0]).IsEqualTo(BothEnds);
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenChangingWideArityTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenChangingWideArityTests.cs
@@ -1,0 +1,897 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using ReactiveUI.Binding.Tests.TestModels;
+using ReactiveUI.Binding.Tests.WhenAny;
+
+namespace ReactiveUI.Binding.Tests.Mixins;
+
+/// <summary>Reaches every arity of the runtime WhenChanging overloads, which observe before a value changes.</summary>
+/// <remarks>
+/// Each overload is called on the declaring class rather than as an extension method. Written as an
+/// extension call the generated dispatch wins overload resolution, and the runtime overload these
+/// assertions are about would never run.
+/// </remarks>
+public class WhenChangingWideArityTests
+{
+    /// <summary>The value every observed property starts out holding.</summary>
+    private const string InitialValue = "a";
+
+    /// <summary>The first and last observed values read together, which is what each test projects.</summary>
+    private const string BothEnds = InitialValue + InitialValue;
+
+    /// <summary>Observing one property reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnOneProperty_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(InitialValue);
+    }
+
+    /// <summary>Observing two properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnTwoProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property2));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing three properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnThreeProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property3));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing four properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnFourProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property4));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing five properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnFiveProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property5));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing six properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnSixProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property6));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing seven properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnSevenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property7));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing eight properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnEightProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property8));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing nine properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnNineProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property9));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing ten properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnTenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property10));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing eleven properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnElevenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property11));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing twelve properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnTwelveProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property12));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing thirteen properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnThirteenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property13));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing fourteen properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnFourteenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property14));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing fifteen properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnFifteenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                x => x.Value15)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property15));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Observing sixteen properties reports the first and last observed value.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_OnSixteenProperties_ReportsTheObservedValues()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                x => x.Value15,
+                x => x.Value16)
+            .Subscribe(v => seen.Add(v.Property1 + v.Property16));
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting two observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingTwoProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                static (v1, v2) => v1 + v2)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting three observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingThreeProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                static (v1, v2, v3) => v1 + v3)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting four observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingFourProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                static (v1, v2, v3, v4) => v1 + v4)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting five observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingFiveProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                static (v1, v2, v3, v4, v5) => v1 + v5)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting six observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingSixProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                static (v1, v2, v3, v4, v5, v6) => v1 + v6)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting seven observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingSevenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                static (v1, v2, v3, v4, v5, v6, v7) => v1 + v7)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting eight observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingEightProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                static (v1, v2, v3, v4, v5, v6, v7, v8) => v1 + v8)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting nine observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingNineProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9) => v1 + v9)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting ten observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingTenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) => v1 + v10)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting eleven observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingElevenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) => v1 + v11)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting twelve observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingTwelveProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) => v1 + v12)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting thirteen observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingThirteenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) => v1 + v13)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting fourteen observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingFourteenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) => v1 + v14)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting fifteen observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingFifteenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                x => x.Value15,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) => v1 + v15)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+
+    /// <summary>Projecting sixteen observed properties reports what the selector returns.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanging_ProjectingSixteenProperties_ReportsTheSelectorResult()
+    {
+        WhenAnyTests.EnsureInitialized();
+
+        var fixture = new WideArityFixture();
+        var seen = new List<string>();
+
+        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+                fixture,
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                x => x.Value13,
+                x => x.Value14,
+                x => x.Value15,
+                x => x.Value16,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) => v1 + v16)
+            .Subscribe(seen.Add);
+
+        fixture.Value1 = InitialValue;
+
+        await Assert.That(seen[^1]).IsEqualTo(BothEnds);
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/DispatchStubControl.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/DispatchStubControl.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Binding.Tests.TestModels;
+
+/// <summary>A control a command binding names, carrying nothing beyond a property to bind against.</summary>
+public class DispatchStubControl
+{
+    /// <summary>Gets or sets the control's text.</summary>
+    public string Text { get; set; } = "a";
+}

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/DispatchStubView.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/DispatchStubView.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+
+namespace ReactiveUI.Binding.Tests.TestModels;
+
+/// <summary>A view naming the properties the binding dispatch stubs bind against.</summary>
+public class DispatchStubView : IViewFor, INotifyPropertyChanged
+{
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <inheritdoc/>
+    public object? ViewModel { get; set; }
+
+    /// <summary>Gets the control a command binding names.</summary>
+    public DispatchStubControl Control { get; } = new();
+
+    /// <summary>Gets or sets the bound text.</summary>
+    public string Caption
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Caption)));
+        }
+    } = "a";
+}

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/DispatchStubViewModel.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/DispatchStubViewModel.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using System.Windows.Input;
+
+namespace ReactiveUI.Binding.Tests.TestModels;
+
+/// <summary>A view model naming one property of each kind the binding dispatch stubs take.</summary>
+/// <remarks>
+/// The command and interaction are never invoked: a stub throws before it reads either, so the
+/// properties exist to satisfy the overloads' type constraints rather than to behave.
+/// </remarks>
+public class DispatchStubViewModel : INotifyPropertyChanged
+{
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>Gets or sets the bound text.</summary>
+    public string Caption
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Caption)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets the value a command binding passes as its parameter.</summary>
+    public string Parameter
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Parameter)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets the command a command binding names.</summary>
+    public ICommand? Run { get; set; }
+
+    /// <summary>Gets or sets the interaction an interaction binding names.</summary>
+    public IInteraction<string, bool> Confirm { get; set; } = null!;
+}

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/DynamicChainChild.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/DynamicChainChild.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+
+namespace ReactiveUI.Binding.Tests.TestModels;
+
+/// <summary>An object reached through an intermediate link of an observed chain.</summary>
+/// <remarks>Public because the chain is walked by reflection, which reads public members.</remarks>
+public class DynamicChainChild : INotifyPropertyChanged
+{
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>Gets or sets the observed value.</summary>
+    public string Name
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Name)));
+        }
+    } = "a";
+}

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/DynamicChainFixture.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/DynamicChainFixture.cs
@@ -1,0 +1,158 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+
+namespace ReactiveUI.Binding.Tests.TestModels;
+
+/// <summary>An object with enough notifying properties to observe every dynamic-chain arity.</summary>
+/// <remarks>Public because the chain is walked by reflection, which reads public members.</remarks>
+public class DynamicChainFixture : INotifyPropertyChanged
+{
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>Gets or sets observed property 1.</summary>
+    public string P1
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(P1)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 2.</summary>
+    public string P2
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(P2)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 3.</summary>
+    public string P3
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(P3)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 4.</summary>
+    public string P4
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(P4)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 5.</summary>
+    public string P5
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(P5)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 6.</summary>
+    public string P6
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(P6)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 7.</summary>
+    public string P7
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(P7)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 8.</summary>
+    public string P8
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(P8)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 9.</summary>
+    public string P9
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(P9)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 10.</summary>
+    public string P10
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(P10)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 11.</summary>
+    public string P11
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(P11)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 12.</summary>
+    public string P12
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(P12)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets the intermediate link an observed chain passes through.</summary>
+    public DynamicChainChild? Child
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Child)));
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/WideArityFixture.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/WideArityFixture.cs
@@ -1,0 +1,208 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.ComponentModel;
+
+namespace ReactiveUI.Binding.Tests.TestModels;
+
+/// <summary>An object with enough notifying properties to reach every wide-arity observation overload.</summary>
+public class WideArityFixture : INotifyPropertyChanged, INotifyPropertyChanging
+{
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <inheritdoc/>
+    public event PropertyChangingEventHandler? PropertyChanging;
+
+    /// <summary>Gets or sets observed property 1.</summary>
+    public string Value1
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value1)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value1)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 2.</summary>
+    public string Value2
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value2)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value2)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 3.</summary>
+    public string Value3
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value3)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value3)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 4.</summary>
+    public string Value4
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value4)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value4)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 5.</summary>
+    public string Value5
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value5)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value5)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 6.</summary>
+    public string Value6
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value6)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value6)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 7.</summary>
+    public string Value7
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value7)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value7)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 8.</summary>
+    public string Value8
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value8)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value8)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 9.</summary>
+    public string Value9
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value9)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value9)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 10.</summary>
+    public string Value10
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value10)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value10)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 11.</summary>
+    public string Value11
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value11)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value11)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 12.</summary>
+    public string Value12
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value12)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value12)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 13.</summary>
+    public string Value13
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value13)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value13)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 14.</summary>
+    public string Value14
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value14)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value14)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 15.</summary>
+    public string Value15
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value15)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value15)));
+        }
+    } = "a";
+
+    /// <summary>Gets or sets observed property 16.</summary>
+    public string Value16
+    {
+        get => field;
+        set
+        {
+            PropertyChanging?.Invoke(this, new(nameof(Value16)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Value16)));
+        }
+    } = "a";
+}

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/WideArityObservableFixture.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/WideArityObservableFixture.cs
@@ -1,0 +1,175 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+
+namespace ReactiveUI.Binding.Tests.TestModels;
+
+/// <summary>An object with enough observable properties to reach every wide-arity WhenAnyObservable overload.</summary>
+public class WideArityObservableFixture : INotifyPropertyChanged
+{
+    /// <summary>How many streams the fixture carries, which is the widest arity these overloads reach.</summary>
+    private const int StreamCount = 12;
+
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>Gets or sets observed stream 1.</summary>
+    public IObservable<string>? Stream1
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Stream1)));
+        }
+    }
+
+    /// <summary>Gets or sets observed stream 2.</summary>
+    public IObservable<string>? Stream2
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Stream2)));
+        }
+    }
+
+    /// <summary>Gets or sets observed stream 3.</summary>
+    public IObservable<string>? Stream3
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Stream3)));
+        }
+    }
+
+    /// <summary>Gets or sets observed stream 4.</summary>
+    public IObservable<string>? Stream4
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Stream4)));
+        }
+    }
+
+    /// <summary>Gets or sets observed stream 5.</summary>
+    public IObservable<string>? Stream5
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Stream5)));
+        }
+    }
+
+    /// <summary>Gets or sets observed stream 6.</summary>
+    public IObservable<string>? Stream6
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Stream6)));
+        }
+    }
+
+    /// <summary>Gets or sets observed stream 7.</summary>
+    public IObservable<string>? Stream7
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Stream7)));
+        }
+    }
+
+    /// <summary>Gets or sets observed stream 8.</summary>
+    public IObservable<string>? Stream8
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Stream8)));
+        }
+    }
+
+    /// <summary>Gets or sets observed stream 9.</summary>
+    public IObservable<string>? Stream9
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Stream9)));
+        }
+    }
+
+    /// <summary>Gets or sets observed stream 10.</summary>
+    public IObservable<string>? Stream10
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Stream10)));
+        }
+    }
+
+    /// <summary>Gets or sets observed stream 11.</summary>
+    public IObservable<string>? Stream11
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Stream11)));
+        }
+    }
+
+    /// <summary>Gets or sets observed stream 12.</summary>
+    public IObservable<string>? Stream12
+    {
+        get => field;
+        set
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Stream12)));
+        }
+    }
+
+    /// <summary>Fills every stream with a manually driven observable and hands them back in order.</summary>
+    /// <returns>The observables the streams were filled with.</returns>
+    internal ManualObservable<string>[] FillStreams()
+    {
+        var streams = new ManualObservable<string>[StreamCount];
+        for (var i = 0; i < streams.Length; i++)
+        {
+            streams[i] = new();
+        }
+
+        Stream1 = streams[0];
+        Stream2 = streams[1];
+        Stream3 = streams[2];
+        Stream4 = streams[3];
+        Stream5 = streams[4];
+        Stream6 = streams[5];
+        Stream7 = streams[6];
+        Stream8 = streams[7];
+        Stream9 = streams[8];
+        Stream10 = streams[9];
+        Stream11 = streams[10];
+        Stream12 = streams[11];
+
+        return streams;
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature, plus a test fix.

## What is the new behavior?

**`WhenAnyDynamic` observes a property chain the caller built at run time, across arities 1 to 12.**

- Takes the chain as a `System.Linq.Expressions.Expression` rather than a lambda the compiler could read, so
  the chain can come from a property name, a configuration entry, or a caller. Two overloads per arity, with
  and without the distinct gate. Functionally equivalent to ReactiveUI's overloads of the same name.
- Every overload carries `[RequiresUnreferencedCode]`. There is nothing for a generator to resolve in an
  expression built at run time, so the chain is walked by reflection - this is the one part of the observation
  surface that is not trimming- or AOT-safe, and a `PublishAot` build reports each call site.
- Every arity observes each of its chains through one shared helper and differs only in how many it combines.

**The runtime observation and binding overloads are covered.**

- `ReactiveUIBindingExtensions` no longer carries a class-level `[ExcludeFromCodeCoverage]`.
- Every arity of `WhenChanged`, `WhenChanging`, `WhenAnyValue`, `WhenAny` and `WhenAnyObservable` is exercised,
  along with each binding stub's refusal to bind without a generated overload.
- The overloads are reached on the declaring class rather than as extension methods. Written as an extension
  call the generated dispatch wins overload resolution and the runtime overload never runs, so the shape is
  load-bearing and is noted in each test file.

## What is the current behavior?

`WhenAnyDynamic` has no overload, so a chain only known at run time cannot be observed.

A class-level `[ExcludeFromCodeCoverage]` on one partial of `ReactiveUIBindingExtensions` applies to the merged
type, so it covers all fifteen partials rather than the four holding the refusing dispatch stubs it was written
for. 154 methods are excluded from the coverage report.

## What might this PR break?

None. `WhenAnyDynamic` is new API, and the coverage attribute has no effect on emitted behaviour.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

`WhenAnyDynamic` is level with ReactiveUI's engine rather than faster, which is what a reflection walk on both
sides predicts. Single chain, 1,000 changes, .NET 10.0:

| Single chain, .NET 10.0     |   Mean | Allocated |
|-----------------------------|-------:|----------:|
| Generated (`WhenChanged`)   | 175 us |   63.4 KB |
| `WhenAnyDynamic`            | 278 us |  102.7 KB |
| ReactiveUI `WhenAnyDynamic` | 299 us |  102.6 KB |

Most of the gap to the generated path is the `IObservedChange` handed to the selector - 40 bytes per
notification, which the signature has to produce.

`RxUiDynamicChainBaseline` sits outside the `ReactiveUI.Binding` namespace and types its selectors against
ReactiveUI's `IObservedChange`, so a call that resolved to this library's overload of the same name would fail
to compile rather than quietly benchmark the wrong engine.

Most of the diff is generated test bodies, one per arity. The hand-written files are
`ReactiveUIBindingExtensions.WhenAnyDynamic.WideArity.cs`, `BindingDispatchStubTests.cs`, the two benchmark
classes, and the `README.md` sections.
