### PR TITLE
fix: correct the expression rewriter's trimming annotation and the analyzer package assets

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -145,8 +145,8 @@
     <PackageReference Include="StyleSharp.Analyzers" PrivateAssets="all"/>
     <PackageReference Include="PerformanceSharp.Analyzers" PrivateAssets="all"/>
     <PackageReference Include="SecuritySharp.Analyzers" PrivateAssets="all"/>
-    <PackageReference Include="Roslynator.Analyzers"/>
-    <PackageReference Include="SonarAnalyzer.CSharp"/>
-    <PackageReference Include="Blazor.Common.Analyzers"/>
+    <PackageReference Include="Roslynator.Analyzers" PrivateAssets="all"/>
+    <PackageReference Include="SonarAnalyzer.CSharp" PrivateAssets="all"/>
+    <PackageReference Include="Blazor.Common.Analyzers" PrivateAssets="all"/>
   </ItemGroup>
 </Project>

--- a/src/ReactiveUI.Binding.Shared/Expression/ExpressionRewriter.cs
+++ b/src/ReactiveUI.Binding.Shared/Expression/ExpressionRewriter.cs
@@ -31,6 +31,8 @@ namespace ReactiveUI.Binding.Expressions;
 /// <item><description><see cref="ExpressionType.Convert"/> is stripped.</description></item>
 /// </list>
 /// </remarks>
+[RequiresUnreferencedCode(
+    "Expression rewriting uses reflection over runtime types which may be removed by trimming.")]
 internal sealed class ExpressionRewriter : ExpressionVisitor
 {
     /// <inheritdoc/>
@@ -141,8 +143,6 @@ internal sealed class ExpressionRewriter : ExpressionVisitor
     }
 
     /// <inheritdoc/>
-    [RequiresUnreferencedCode(
-        "Expression rewriting uses reflection over runtime types which may be removed by trimming.")]
     protected override Expression VisitBinary(BinaryExpression node)
     {
         if (node.Right is not ConstantExpression)
@@ -159,8 +159,6 @@ internal sealed class ExpressionRewriter : ExpressionVisitor
     }
 
     /// <inheritdoc/>
-    [RequiresUnreferencedCode(
-        "Expression rewriting uses reflection over runtime types which may be removed by trimming.")]
     protected override Expression VisitUnary(UnaryExpression node)
     {
         // Visit() only routes Convert and ArrayLength here, so no fallthrough is needed.
@@ -178,8 +176,6 @@ internal sealed class ExpressionRewriter : ExpressionVisitor
     }
 
     /// <inheritdoc/>
-    [RequiresUnreferencedCode(
-        "Expression rewriting uses reflection over runtime types which may be removed by trimming.")]
     protected override Expression VisitMethodCall(MethodCallExpression node)
     {
         if (!node.Method.IsSpecialName || !AllConstant(node.Arguments))

--- a/src/ReactiveUI.Binding.Shared/Expression/Reflection.cs
+++ b/src/ReactiveUI.Binding.Shared/Expression/Reflection.cs
@@ -15,17 +15,24 @@ namespace ReactiveUI.Binding.Expressions;
 /// <summary>Helper class for handling reflection and expression-tree related operations.</summary>
 public static class Reflection
 {
-    /// <summary>Singleton instance of the <see cref="ExpressionRewriter"/> used for rewriting expression trees.</summary>
+    /// <summary>Reported when an expression yields no chain to walk.</summary>
     private const string EmptyExpressionChainMessage = "Expression chain must contain at least one element.";
 
     /// <summary>The shared rewriter instance used to simplify expressions before inspection.</summary>
-    private static readonly ExpressionRewriter ExpressionRewriterInstance = new();
+    /// <remarks>
+    /// Built on first use rather than in a static initializer. The rewriter reads runtime types by
+    /// reflection and says so, and a static constructor has nowhere to carry that annotation.
+    /// </remarks>
+    private static ExpressionRewriter? _expressionRewriter;
 
     /// <summary>Uses the expression re-writer to simplify the expression down to its simplest expression.</summary>
     /// <param name="expression">The expression to rewrite.</param>
     /// <returns>The rewritten expression.</returns>
+    [RequiresUnreferencedCode(
+        "Expression rewriting uses reflection over runtime types which may be removed by trimming.")]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Expression Rewrite(Expression? expression) => ExpressionRewriterInstance.Visit(expression);
+    public static Expression Rewrite(Expression? expression) =>
+        (_expressionRewriter ??= new()).Visit(expression);
 
     /// <summary>Converts an expression that points to a property chain into a dotted path string.</summary>
     /// <param name="expression">The expression to generate the property names from.</param>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Two bug fixes.

## What is the new behavior?

**A trimmed consumer no longer sees IL2046 from the expression rewriter.**

- `RequiresUnreferencedCode` sits on `ExpressionRewriter` itself rather than on its `VisitBinary`,
  `VisitUnary` and `VisitMethodCall` overrides. An override cannot carry an annotation its base member lacks,
  and `ExpressionVisitor` carries none, so each of the three was reported.
- The shared rewriter is built on first use instead of in a static initializer. A static constructor has
  nowhere to carry the annotation the type now needs, so `Reflection.Rewrite` states it; all three callers
  already reach it from a path annotated the same way.

**Development-only analyzers are no longer package dependencies.**

- Three analyzer references gained `PrivateAssets="all"`, matching the five beside them that already had it.

## What is the current behavior?

Publishing a trimmed application that reaches the expression engine reports IL2046 three times, once per
annotated override.

Every packed project lists three repository-only analyzer packages as dependencies, so consumers inherit
build-time tooling in their dependency graph. The report named the generator package, but
`src/Directory.Build.props` applies to all of them, so the runtime and platform packages leak them too.

Closes #84
Closes #82

## What might this PR break?

`Reflection.Rewrite` is public and now carries `RequiresUnreferencedCode`. A consumer calling it directly
from a trimming-annotated context will see IL2026 where it previously saw nothing - the warning is accurate,
since the method has always used reflection. Callers inside this repository are unaffected: all three already
sit on annotated paths.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Both fixes were verified against the symptom rather than the source.

The trimming fix was reproduced first: a console app referencing the runtime library, reaching the expression
engine, published with `PublishTrimmed`. It reported IL2046 three times before the change and none after. The
two IL2026 warnings that remain are the app's own call to `WhenAnyDynamic`, which is deliberately
`RequiresUnreferencedCode`.

The packaging fix was checked by packing `ReactiveUI.Binding` and reading the dependency groups out of the
generated nuspec, which now list only `ReactiveUI.Primitives` and `Splat`.

Neither issue was caught by the AOT validation harness, because nothing in it reaches the expression engine.
Closing that gap needs a target that deliberately does, which cannot assert zero warnings the way the current
harness does - `WhenAnyDynamic` is annotated by design. Worth deciding separately.
