### PR TITLE
feat: claim binding call sites through interceptors

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -67,7 +67,6 @@
             ],
             "groupName": "test tooling",
             "matchPackageNames": [
-                "/^NSubstitute(\\.|$)/",
                 "/^BenchmarkDotNet(\\.|$)/"
             ]
         }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,6 +515,7 @@ Not all platforms support before-change notifications (WPF DP, WinUI DP, WinForm
 | RXUIBIND008 | Warning | Property does not implement IInteraction |
 | RXUIBIND009 | Warning | Generated binding dispatch is out of reach from this file |
 | RXUIBIND010 | Warning | Observed path passes through a type that raises no notification |
+| RXUIBIND011 | Warning | Binding call resolved to ReactiveUI's own mixin |
 
 ## Code Style & Quality Requirements
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,9 @@ src/
 │       ├── PooledStringBuilder.cs               # char[]-backed builder for generated fragments
 │       └── RuntimeFlavourRewriter.cs            # Retargets output onto the .Reactive package
 │
+├── ReactiveUI.Binding.SourceGenerators.Roslyn413/ # The same generator source against Roslyn 4.13
+├── ReactiveUI.Binding.Analyzer.Roslyn413/         # The same analyzer source against Roslyn 4.13
+│
 ├── ReactiveUI.Binding.Analyzer/                 # Roslyn analyzer (netstandard2.0)
 │   └── Analyzers/
 │       ├── BindingInvocationAnalyzer.cs          # RXUIBIND001, 003, 004, 005, 006, 007, 008
@@ -744,9 +747,9 @@ build keeps working right up until Wine starts. Each copy chains to the reposito
 - **Runtime library targets:** net8.0;net9.0;net10.0;net462;net472;net481
 - **No shallow clones:** Repository requires full clone for Nerdbank.GitVersioning
 - **Where the analyzers ship:** `ReactiveUI.Binding` and `ReactiveUI.Binding.Reactive` each pack the generator
-  and analyzer DLLs into `analyzers/dotnet/cs`, so referencing a runtime package is all a consumer needs.
-  `ReactiveUI.Binding.SourceGenerators` is a compatibility package that ships only the MSBuild props: a second
-  copy of the same assemblies under a different package root loads as a second generator and emits every
-  dispatch file twice, which fails the consumer's build
+  and analyzer DLLs into `analyzers/dotnet/roslyn4.8/cs` and `analyzers/dotnet/roslyn4.13/cs`, so referencing a
+  runtime package is all a consumer needs. `ReactiveUI.Binding.SourceGenerators` is a compatibility package that
+  ships only the MSBuild props and targets: a second copy of the same assemblies under a different package root
+  loads as a second generator and emits every dispatch file twice, which fails the consumer's build
 
 **Philosophy:** Generate zero-reflection, AOT-compatible property observation and binding code at compile-time. Support all ReactiveUI platform notification mechanisms. Fall back to runtime expression analysis only when compile-time analysis is not possible.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ generation. Zero reflection, fully AOT/trimming safe, 3-7x faster than the legac
 
 - [What does it do?](#what-does-it-do)
 - [How does it work?](#how-does-it-work)
+- [How a call site reaches its generated code](#how-a-call-site-reaches-its-generated-code)
 - [How do I install?](#how-do-i-install)
 - [Supported APIs](#supported-apis)
 - [Usage Examples](#usage-examples)
@@ -61,8 +62,9 @@ generation. Zero reflection, fully AOT/trimming safe, 3-7x faster than the legac
 ## What does it do?
 
 ReactiveUI.Binding.SourceGenerators is an incremental source generator that analyses your `WhenChanged`, `WhenChanging`,
-`WhenAnyValue`, `WhenAny`, `WhenAnyObservable`, `BindOneWay`, `BindTwoWay`, `OneWayBind`, and `Bind` call sites at
-compile time and emits optimised, strongly-typed observation and binding code. It eliminates:
+`WhenAnyValue`, `WhenAny`, `WhenAnyObservable`, `BindOneWay`, `BindTwoWay`, `OneWayBind`, `Bind`, `BindTo`,
+`BindCommand`, and `BindInteraction` call sites at compile time and emits optimised, strongly-typed observation and
+binding code. It eliminates:
 
 - **Runtime expression-tree compilation** -- no `Expression<Func<T>>` evaluation at runtime
 - **Reflection** -- all property access is generated as direct member access
@@ -80,31 +82,60 @@ WPF DependencyObject, WinUI DependencyObject, Apple KVO, WinForms Component, And
 observation factories via a `[ModuleInitializer]`.
 
 **Pipeline B (Invocation Detection)** scans method invocations and extracts lambda property paths at compile time. Each
-call site is identified by `[CallerFilePath]` + `[CallerLineNumber]`, and the generator emits a per-call-site optimised
-method that is dispatched to at runtime via a generated lookup table.
+call site gets its own optimised method with direct property access:
 
 ```csharp
 // You write:
 var obs = vm.WhenChanged(x => x.Name);
 
-// The generator emits a dispatch stub that captures caller info:
-public static IObservable<TReturn> WhenChanged<TObj, TReturn>(
-    this TObj obj, Expression<Func<TObj, TReturn>> property,
-    [CallerFilePath] string callerFilePath = "",
-    [CallerLineNumber] int callerLineNumber = 0) where TObj : class
-{
-    if (__GeneratedBindingDispatcher.TryGetWhenChanged(callerFilePath, callerLineNumber, obj, out var result))
-        return (IObservable<TReturn>)result!;
-    throw new InvalidOperationException("No generated binding found.");
-}
-
-// And a per-call-site method with direct property access:
+// The generator emits a per-call-site method with direct property access:
 private static IObservable<string> __WhenChanged_0(MyViewModel obj)
 {
     return new PropertyObservable<string>(
         obj, "Name", static o => ((MyViewModel)o).Name, true);
 }
 ```
+
+## How a call site reaches its generated code
+
+Two mechanisms. Your compiler picks one.
+
+**Roslyn 4.13 or newer: the call is intercepted.** The generator points the compiler at your exact call and says "run
+this instead". No name lookup is involved, so it works from any file and any language version - including
+`<LangVersion>7.3</LangVersion>` and .NET Framework 4.6.2:
+
+```csharp
+[InterceptsLocation(1, "j8MnGMWiKja+66BWQ5M81agPAABQcm9ncmFtLmNz")]  // vm.WhenChanged(x => x.Name) on line 12
+internal static IObservable<string> __Intercept_WhenChanged_7FFF(
+    this MyViewModel objectToMonitor,
+    Expression<Func<MyViewModel, string>> property1, /* caller-info parameters */)
+    => __WhenChanged_7FFF(objectToMonitor);
+```
+
+**Roslyn 4.8 to 4.12: a concrete overload competes for the call.** It beats the generic runtime stub because a
+non-generic method wins overload resolution - but only when extension-method lookup finds it. RXUIBIND009 warns when it
+will not.
+
+Either way the same generated method runs, so bindings behave identically.
+
+### What the package ships
+
+The generator and its analyzer are packed once per compiler generation:
+
+```
+analyzers/dotnet/roslyn4.8/cs/    <- Roslyn 4.8 - 4.12
+analyzers/dotnet/roslyn4.13/cs/   <- Roslyn 4.13+
+```
+
+The .NET SDK picks the highest folder your compiler supports. A legacy non-SDK project is handed both, so the package's
+targets delete the one you are not being served by - the generator never runs twice.
+
+Two knobs:
+
+| Setting                                                | Effect                                                       |
+|--------------------------------------------------------|--------------------------------------------------------------|
+| `<ReactiveUIBindingUseInterceptors>false</...>`         | Use the overloads even on a compiler that could intercept     |
+| Roslyn older than 4.8                                   | Build fails with **RXUIBIND100** rather than silently generating nothing |
 
 ## How do I install?
 
@@ -152,6 +183,7 @@ Platform-specific packages provide DependencyProperty observation and other plat
 | `BindTwoWay`        | Two-way binding between source and target                                           |
 | `OneWayBind`        | ReactiveUI compatibility shim for one-way binding                                   |
 | `Bind`              | ReactiveUI compatibility shim for two-way binding                                   |
+| `BindTo`            | Apply an observable stream to a target property                                     |
 | `BindCommand`       | Bind a command property to a UI element                                             |
 | `BindInteraction`   | Bind an interaction to a handler                                                    |
 
@@ -480,9 +512,15 @@ The separate analyzer package reports the following diagnostics:
 | RXUIBIND006 | Warning  | Expression contains an unsupported path segment (indexer, field, or method call). Only simple property access chains can be observed by the source generator.            |
 | RXUIBIND007 | Warning  | BindCommand control has no bindable event. Specify the `toEvent` parameter explicitly.                                                                                   |
 | RXUIBIND008 | Warning  | The property selected in a BindInteraction expression does not implement `IInteraction<TInput, TOutput>`.                                                                |
-| RXUIBIND009 | Warning  | The generated binding dispatch is out of reach from this file, so the call falls back to the runtime stub.                                                               |
+| RXUIBIND009 | Warning  | The generated binding dispatch is out of reach from this file, so the call falls back to the runtime stub. Not reported where the call site is claimed by an interceptor. |
 | RXUIBIND010 | Warning  | The observed path passes through a type that raises no notification, so it is read once and the observation stops following the path there.                              |
 | RXUIBIND011 | Warning  | The call resolved to ReactiveUI's own mixin, so nothing is generated for it and it takes the runtime expression engine. Import `ReactiveUI.Binding` in the file.          |
+
+The package's own targets report one build error of their own:
+
+| ID          | Description                                                                                                     |
+|-------------|-----------------------------------------------------------------------------------------------------------------|
+| RXUIBIND100 | The compiler building the project is older than the oldest analyzer slot, so no generator would be loaded at all. |
 
 ## Where this differs from ReactiveUI
 

--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ The separate analyzer package reports the following diagnostics:
 | RXUIBIND008 | Warning  | The property selected in a BindInteraction expression does not implement `IInteraction<TInput, TOutput>`.                                                                |
 | RXUIBIND009 | Warning  | The generated binding dispatch is out of reach from this file, so the call falls back to the runtime stub.                                                               |
 | RXUIBIND010 | Warning  | The observed path passes through a type that raises no notification, so it is read once and the observation stops following the path there.                              |
+| RXUIBIND011 | Warning  | The call resolved to ReactiveUI's own mixin, so nothing is generated for it and it takes the runtime expression engine. Import `ReactiveUI.Binding` in the file.          |
 
 ## Where this differs from ReactiveUI
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,7 +18,6 @@
 
   <ItemGroup>
     <!-- Testing Framework -->
-    <PackageVersion Include="NSubstitute" Version="6.2.0"/>
     <PackageVersion Include="TUnit" Version="1.66.16"/>
     <PackageVersion Include="Verify.TUnit" Version="32.0.0"/>
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0"/>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,19 +6,19 @@
 
   <!-- MAUI version varies by target framework -->
   <PropertyGroup>
-    <MauiVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.100</MauiVersion>
-    <MauiVersion Condition="$(TargetFramework.StartsWith('net11'))">11.0.0-preview.7.26406.9</MauiVersion>
+    <MauiVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.101</MauiVersion>
+    <MauiVersion Condition="$(TargetFramework.StartsWith('net11'))">11.0.0-rc.1.26451.6</MauiVersion>
   </PropertyGroup>
 
   <PropertyGroup>
     <!-- StyleSharp.Analyzers, PerformanceSharp.Analyzers and SecuritySharp.Analyzers ship from the
          same release pipeline and always share a version. -->
-    <RoslynCommonAnalyzersVersion>3.46.1</RoslynCommonAnalyzersVersion>
+    <RoslynCommonAnalyzersVersion>3.46.2</RoslynCommonAnalyzersVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- Testing Framework -->
-    <PackageVersion Include="TUnit" Version="1.66.16"/>
+    <PackageVersion Include="TUnit" Version="1.66.27"/>
     <PackageVersion Include="Verify.TUnit" Version="32.0.0"/>
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0"/>
 
@@ -36,15 +36,17 @@
       run against; it must stay at or above what their own tooling requires
       (Basic.Reference.Assemblies needs >= 4.11, BenchmarkDotNet needs >= 4.14).
       Running the generator on a newer Roslyn than it was built against is the
-      normal, supported direction.
+      normal, supported direction, and it is also what lets the suite name a
+      language version by its constant rather than as whatever preview happens
+      to be current.
 
       Microsoft.CodeAnalysis.Analyzers is a build-time-only analyzer package
       (the RS#### authoring rules) with no impact on the end-user-facing Roslyn
       version, so it tracks the latest stable release independently.
     -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.9.0"/>
 
     <!-- Test Infrastructure -->
     <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.11"/>
@@ -64,8 +66,8 @@
     <PackageVersion Include="PerformanceSharp.Analyzers" Version="$(RoslynCommonAnalyzersVersion)"/>
     <PackageVersion Include="SecuritySharp.Analyzers" Version="$(RoslynCommonAnalyzersVersion)"/>
     <PackageVersion Include="Roslynator.Analyzers" Version="5.0.0"/>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400"/>
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.33.0.1635"/>
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401"/>
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.34.0.3385"/>
     <PackageVersion Include="Blazor.Common.Analyzers" Version="2.1.0"/>
 
     <!-- MAUI -->

--- a/src/ReactiveUI.Binding.Analyzer.Roslyn413/ReactiveUI.Binding.Analyzer.Roslyn413.csproj
+++ b/src/ReactiveUI.Binding.Analyzer.Roslyn413/ReactiveUI.Binding.Analyzer.Roslyn413.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>ReactiveUI.Binding.Analyzer</AssemblyName>
+    <RootNamespace>ReactiveUI.Binding.Analyzer</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- RS1038: Workspaces reference is required for code fix providers in this assembly -->
+    <NoWarn>$(NoWarn);RS1038</NoWarn>
+  </PropertyGroup>
+
+  <!-- The analyzer travels in the same slot as the generator, so it is compiled against the same compiler
+       and answers the same question about interception at compile time: a diagnostic about the reach of a
+       dispatch overload is only meaningful where dispatch overloads are what gets emitted. -->
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ROSLYN_4_13</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" VersionOverride="4.13.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" VersionOverride="4.13.0"/>
+  </ItemGroup>
+
+  <!-- The same analyzer source, compiled a second time against the newer compiler. -->
+  <ItemGroup>
+    <Compile Include="..\ReactiveUI.Binding.Analyzer\**\*.cs"
+             Exclude="..\ReactiveUI.Binding.Analyzer\bin\**\*.cs;..\ReactiveUI.Binding.Analyzer\obj\**\*.cs"
+             LinkBase="Analyzer"/>
+    <Compile Include="..\ReactiveUI.Binding.SourceGenerators\DiagnosticWarnings.cs" Link="DiagnosticWarnings.cs"/>
+    <Compile Include="..\ReactiveUI.Binding.SourceGenerators\Constants.cs" Link="Constants.cs"/>
+    <Compile Include="..\ReactiveUI.Binding.SourceGenerators\Models\InterceptorLocation.cs" Link="Models\InterceptorLocation.cs"/>
+    <Compile Include="..\ReactiveUI.Binding.SourceGenerators\Helpers\InterceptableLocationReader.cs" Link="Helpers\InterceptableLocationReader.cs"/>
+    <Compile Include="..\ReactiveUI.Binding.Shared\Polyfills\**.cs" Link="Polyfills"/>
+    <Compile Include="..\ReactiveUI.Binding.Shared\Helpers\ArgumentExceptionHelper.cs" Link="Helpers\ArgumentExceptionHelper.cs"/>
+  </ItemGroup>
+
+  <!-- Release tracking reads these through AdditionalFiles. The package auto-includes them from the project
+       directory, which does not reach a linked copy, so they are named explicitly. -->
+  <ItemGroup>
+    <AdditionalFiles Include="..\ReactiveUI.Binding.Analyzer\AnalyzerReleases.Shipped.md" Link="AnalyzerReleases.Shipped.md"/>
+    <AdditionalFiles Include="..\ReactiveUI.Binding.Analyzer\AnalyzerReleases.Unshipped.md" Link="AnalyzerReleases.Unshipped.md"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ReactiveUI.Binding.Analyzer.Tests"/>
+    <InternalsVisibleTo Include="ReactiveUI.Binding.Analyzer.Tests.Roslyn413"/>
+  </ItemGroup>
+</Project>

--- a/src/ReactiveUI.Binding.Analyzer/AnalyzerReleases.Unshipped.md
+++ b/src/ReactiveUI.Binding.Analyzer/AnalyzerReleases.Unshipped.md
@@ -12,3 +12,4 @@
  RXUIBIND008 | Usage    | Warning  | Property is not an IInteraction                                                         
  RXUIBIND009 | Usage    | Warning  | Generated binding dispatch is out of reach for this file
  RXUIBIND010 | Usage    | Warning  | Observed path passes through a type that raises no notification
+ RXUIBIND011 | Usage    | Warning  | Binding call resolved to ReactiveUI's own mixin

--- a/src/ReactiveUI.Binding.Analyzer/Analyzers/BindingInvocationAnalyzer.cs
+++ b/src/ReactiveUI.Binding.Analyzer/Analyzers/BindingInvocationAnalyzer.cs
@@ -24,9 +24,10 @@ public class BindingInvocationAnalyzer : DiagnosticAnalyzer
     /// <summary>The parameter type a property path arrives as, which marks it out from the other arguments.</summary>
     private const string ExpressionParameterTypePrefix = "System.Linq.Expressions.Expression<";
 
-    /// <inheritdoc/>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        ImmutableArray.Create(
+    /// <summary>The diagnostics this analyzer reports.</summary>
+    private static readonly ImmutableArray<DiagnosticDescriptor> ReportedDiagnostics =
+        new[]
+        {
             DiagnosticWarnings.NonInlineLambda,
             DiagnosticWarnings.PrivateMember,
             DiagnosticWarnings.NoBeforeChangeSupport,
@@ -34,7 +35,11 @@ public class BindingInvocationAnalyzer : DiagnosticAnalyzer
             DiagnosticWarnings.UnsupportedPathSegment,
             DiagnosticWarnings.NoBindableEvent,
             DiagnosticWarnings.InvalidInteractionType,
-            DiagnosticWarnings.SilentPathLink);
+            DiagnosticWarnings.SilentPathLink,
+        }.ToImmutableArray();
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ReportedDiagnostics;
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)

--- a/src/ReactiveUI.Binding.Analyzer/Analyzers/DispatchReachAnalyzer.cs
+++ b/src/ReactiveUI.Binding.Analyzer/Analyzers/DispatchReachAnalyzer.cs
@@ -80,7 +80,7 @@ public class DispatchReachAnalyzer : DiagnosticAnalyzer
         // An interceptor replaces the call the compiler already bound, so nothing about it goes through
         // extension-method lookup and no namespace has to be in reach. Where this build emits interceptors
         // instead of overloads, the file's namespace stops deciding anything.
-        if (InterceptableLocationReader.IsSupported && InterceptableLocationReader.IsOptedIn(parseOptions))
+        if (InterceptableLocationReader.IsInterceptionEnabled(parseOptions))
         {
             return;
         }

--- a/src/ReactiveUI.Binding.Analyzer/Analyzers/DispatchReachAnalyzer.cs
+++ b/src/ReactiveUI.Binding.Analyzer/Analyzers/DispatchReachAnalyzer.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using ReactiveUI.Binding.Helpers;
 using ReactiveUI.Binding.SourceGenerators;
+using ReactiveUI.Binding.SourceGenerators.Helpers;
 
 namespace ReactiveUI.Binding.Analyzer.Analyzers;
 
@@ -29,9 +30,12 @@ public class DispatchReachAnalyzer : DiagnosticAnalyzer
     /// <summary>The analyzer config key a build exposes the root namespace under.</summary>
     private const string RootNamespaceKey = "build_property.RootNamespace";
 
+    /// <summary>The diagnostics this analyzer reports.</summary>
+    private static readonly ImmutableArray<DiagnosticDescriptor> ReportedDiagnostics =
+        new[] { DiagnosticWarnings.DispatchOutOfReach }.ToImmutableArray();
+
     /// <inheritdoc/>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        ImmutableArray.Create(DiagnosticWarnings.DispatchOutOfReach);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ReportedDiagnostics;
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
@@ -68,7 +72,15 @@ public class DispatchReachAnalyzer : DiagnosticAnalyzer
 
         // Read the language version from the tree rather than the compilation: it is a parse option, so a
         // compilation can hold trees that differ, and the reach of a generated overload follows the file.
-        if (invocation.Syntax.SyntaxTree.Options is not CSharpParseOptions { LanguageVersion: < LanguageVersion.CSharp10 })
+        if (invocation.Syntax.SyntaxTree.Options is not CSharpParseOptions { LanguageVersion: < LanguageVersion.CSharp10 } parseOptions)
+        {
+            return;
+        }
+
+        // An interceptor replaces the call the compiler already bound, so nothing about it goes through
+        // extension-method lookup and no namespace has to be in reach. Where this build emits interceptors
+        // instead of overloads, the file's namespace stops deciding anything.
+        if (InterceptableLocationReader.IsSupported && InterceptableLocationReader.IsOptedIn(parseOptions))
         {
             return;
         }

--- a/src/ReactiveUI.Binding.Analyzer/Analyzers/MixinShadowAnalyzer.cs
+++ b/src/ReactiveUI.Binding.Analyzer/Analyzers/MixinShadowAnalyzer.cs
@@ -38,8 +38,8 @@ public class MixinShadowAnalyzer : DiagnosticAnalyzer
         $"{Constants.ReactiveRuntimeNamespace}.{Constants.StubExtensionClassName}";
 
     /// <summary>The API names this package generates bindings for.</summary>
-    private static readonly ImmutableHashSet<string> GeneratedApiNames = ImmutableHashSet.Create(
-        StringComparer.Ordinal,
+    private static readonly ImmutableHashSet<string> GeneratedApiNames = new[]
+    {
         Constants.WhenChangedMethodName,
         Constants.WhenChangingMethodName,
         Constants.WhenAnyMethodName,
@@ -51,11 +51,15 @@ public class MixinShadowAnalyzer : DiagnosticAnalyzer
         Constants.BindMethodName,
         Constants.BindToMethodName,
         Constants.BindCommandMethodName,
-        Constants.BindInteractionMethodName);
+        Constants.BindInteractionMethodName,
+    }.ToImmutableHashSet(StringComparer.Ordinal);
+
+    /// <summary>The diagnostics this analyzer reports.</summary>
+    private static readonly ImmutableArray<DiagnosticDescriptor> ReportedDiagnostics =
+        new[] { DiagnosticWarnings.MixinShadowsGeneratedBinding }.ToImmutableArray();
 
     /// <inheritdoc/>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        ImmutableArray.Create(DiagnosticWarnings.MixinShadowsGeneratedBinding);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ReportedDiagnostics;
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)

--- a/src/ReactiveUI.Binding.Analyzer/Analyzers/MixinShadowAnalyzer.cs
+++ b/src/ReactiveUI.Binding.Analyzer/Analyzers/MixinShadowAnalyzer.cs
@@ -1,0 +1,139 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using ReactiveUI.Binding.Helpers;
+using ReactiveUI.Binding.SourceGenerators;
+
+namespace ReactiveUI.Binding.Analyzer.Analyzers;
+
+/// <summary>
+/// Reports a binding call that reached ReactiveUI's own mixin instead of a generated overload, so losing
+/// compile-time binding is a build warning rather than something found in a profiler.
+/// </summary>
+/// <remarks>
+/// Which method the call reaches is decided by extension-method lookup. A file that imports ReactiveUI and
+/// not this package binds to ReactiveUI's mixin, and every extractor recognises a call by its declaring type,
+/// so that call is simply not one of ours: no dispatch is generated and none of the other diagnostics have
+/// anything to say about it. Two ordinary things put a file in that state - importing ReactiveUI for
+/// <c>ReactiveCommand</c> alongside this package, and an editor's import cleanup removing the binding import
+/// once calls resolve to the generated overloads that made it look unused.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class MixinShadowAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>The namespace ReactiveUI declares its own observation and binding mixins in.</summary>
+    private const string ReactiveUiNamespace = "ReactiveUI";
+
+    /// <summary>The stub class the lean runtime package declares, used to detect that it is referenced.</summary>
+    private const string StubMetadataName =
+        $"{Constants.SharedGeneratedNamespace}.{Constants.StubExtensionClassName}";
+
+    /// <summary>The same stub class in the System.Reactive flavour of the runtime package.</summary>
+    private const string ReactiveStubMetadataName =
+        $"{Constants.ReactiveRuntimeNamespace}.{Constants.StubExtensionClassName}";
+
+    /// <summary>The API names this package generates bindings for.</summary>
+    private static readonly ImmutableHashSet<string> GeneratedApiNames = ImmutableHashSet.Create(
+        StringComparer.Ordinal,
+        Constants.WhenChangedMethodName,
+        Constants.WhenChangingMethodName,
+        Constants.WhenAnyMethodName,
+        Constants.WhenAnyValueMethodName,
+        Constants.WhenAnyObservableMethodName,
+        Constants.BindOneWayMethodName,
+        Constants.BindTwoWayMethodName,
+        Constants.OneWayBindMethodName,
+        Constants.BindMethodName,
+        Constants.BindToMethodName,
+        Constants.BindCommandMethodName,
+        Constants.BindInteractionMethodName);
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(DiagnosticWarnings.MixinShadowsGeneratedBinding);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(context);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        // Only a compilation that references this package can have lost a binding to ReactiveUI's mixin, and
+        // that is a property of the whole compilation, so settle it once rather than per call site.
+        context.RegisterCompilationStartAction(static startContext =>
+        {
+            if (!ReferencesBindingPackage(startContext.Compilation))
+            {
+                return;
+            }
+
+            startContext.RegisterOperationAction(
+                static operationContext => AnalyzeInvocation(in operationContext),
+                OperationKind.Invocation);
+        });
+    }
+
+    /// <summary>Reports a call that ReactiveUI's mixin answered in place of a generated overload.</summary>
+    /// <param name="context">The operation analysis context.</param>
+    internal static void AnalyzeInvocation(in OperationAnalysisContext context)
+    {
+        var method = ((IInvocationOperation)context.Operation).TargetMethod;
+
+        if (!GeneratedApiNames.Contains(method.Name) || AnalyzerHelpers.IsBindingExtensionMethod(method))
+        {
+            return;
+        }
+
+        // An extension declared in an extension block belongs to a synthesized type nested in the class the
+        // consumer wrote, so the namespace is only correct once the walk reaches the outermost type.
+        var declaringType = OutermostContainingType(method.ContainingType);
+        if (!IsReactiveUiNamespace(declaringType.ContainingNamespace))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticWarnings.MixinShadowsGeneratedBinding,
+            context.Operation.Syntax.GetLocation(),
+            method.Name,
+            declaringType.Name));
+    }
+
+    /// <summary>Walks out of any nested or synthesized type to the type the consumer wrote.</summary>
+    /// <param name="type">The type the invoked method belongs to.</param>
+    /// <returns>The outermost containing type.</returns>
+    private static INamedTypeSymbol OutermostContainingType(INamedTypeSymbol type)
+    {
+        while (type.ContainingType is not null)
+        {
+            type = type.ContainingType;
+        }
+
+        return type;
+    }
+
+    /// <summary>Determines whether a namespace is ReactiveUI's own, rather than one nested under it.</summary>
+    /// <param name="namespaceSymbol">The namespace the declaring type sits in.</param>
+    /// <returns><see langword="true"/> for exactly <c>ReactiveUI</c>.</returns>
+    /// <remarks>
+    /// Nested namespaces are excluded deliberately: this package declares its surface under
+    /// <c>ReactiveUI.Binding</c>, which is the case this diagnostic exists to tell apart.
+    /// </remarks>
+    private static bool IsReactiveUiNamespace(INamespaceSymbol namespaceSymbol) =>
+        !namespaceSymbol.IsGlobalNamespace
+        && string.Equals(namespaceSymbol.Name, ReactiveUiNamespace, StringComparison.Ordinal)
+        && namespaceSymbol.ContainingNamespace.IsGlobalNamespace;
+
+    /// <summary>Determines whether the compilation references this package at all.</summary>
+    /// <param name="compilation">The compilation being analyzed.</param>
+    /// <returns><see langword="true"/> when either runtime flavour's stub class is in reach.</returns>
+    private static bool ReferencesBindingPackage(Compilation compilation) =>
+        compilation.GetTypeByMetadataName(StubMetadataName) is not null
+        || compilation.GetTypeByMetadataName(ReactiveStubMetadataName) is not null;
+}

--- a/src/ReactiveUI.Binding.Analyzer/Analyzers/TypeAnalyzer.cs
+++ b/src/ReactiveUI.Binding.Analyzer/Analyzers/TypeAnalyzer.cs
@@ -15,9 +15,12 @@ namespace ReactiveUI.Binding.Analyzer.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class TypeAnalyzer : DiagnosticAnalyzer
 {
+    /// <summary>The diagnostics this analyzer reports.</summary>
+    private static readonly ImmutableArray<DiagnosticDescriptor> ReportedDiagnostics =
+        new[] { DiagnosticWarnings.NoObservableProperties }.ToImmutableArray();
+
     /// <inheritdoc/>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        ImmutableArray.Create(DiagnosticWarnings.NoObservableProperties);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ReportedDiagnostics;
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
@@ -39,6 +42,14 @@ public class TypeAnalyzer : DiagnosticAnalyzer
 
         var methodSymbol = invocationOp.TargetMethod;
         if (!AnalyzerHelpers.IsBindingExtensionMethod(methodSymbol))
+        {
+            return;
+        }
+
+        // The check reads the first type argument, which every other API names the observed object with.
+        // BindTo names the value type of a stream the caller already built, and nothing about that type is
+        // ever observed, so asking whether it notifies has no answer worth reporting.
+        if (methodSymbol.Name == Constants.BindToMethodName)
         {
             return;
         }

--- a/src/ReactiveUI.Binding.Analyzer/ReactiveUI.Binding.Analyzer.csproj
+++ b/src/ReactiveUI.Binding.Analyzer/ReactiveUI.Binding.Analyzer.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ReactiveUI.Binding.Analyzer.Tests"/>
+    <InternalsVisibleTo Include="ReactiveUI.Binding.Analyzer.Tests.Roslyn413"/>
   </ItemGroup>
 
   <!-- Roslyn 4.8.0 baseline (VS 2022 17.8, .NET 8.0.1xx SDK). Ships alongside the generator in the
@@ -22,10 +23,14 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" VersionOverride="4.8.0"/>
   </ItemGroup>
 
-  <!-- Link shared diagnostic descriptors and constants from generator project -->
+  <!-- Link shared diagnostic descriptors and constants from generator project. The interception reader comes
+       with them because a diagnostic about the reach of a dispatch overload only applies where dispatch
+       overloads are what this slot's generator emits, and both answer that from the same source. -->
   <ItemGroup>
     <Compile Include="..\ReactiveUI.Binding.SourceGenerators\DiagnosticWarnings.cs" Link="DiagnosticWarnings.cs"/>
     <Compile Include="..\ReactiveUI.Binding.SourceGenerators\Constants.cs" Link="Constants.cs"/>
+    <Compile Include="..\ReactiveUI.Binding.SourceGenerators\Models\InterceptorLocation.cs" Link="Models\InterceptorLocation.cs"/>
+    <Compile Include="..\ReactiveUI.Binding.SourceGenerators\Helpers\InterceptableLocationReader.cs" Link="Helpers\InterceptableLocationReader.cs"/>
   </ItemGroup>
 
   <!-- Link polyfills and helpers from runtime library for netstandard2.0 compatibility -->

--- a/src/ReactiveUI.Binding.Reactive/ReactiveUI.Binding.Reactive.csproj
+++ b/src/ReactiveUI.Binding.Reactive/ReactiveUI.Binding.Reactive.csproj
@@ -53,15 +53,25 @@
        generator is not run over this project's own source. -->
   <ItemGroup>
     <ProjectReference Include="..\ReactiveUI.Binding.SourceGenerators\ReactiveUI.Binding.SourceGenerators.csproj" PrivateAssets="all" ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="..\ReactiveUI.Binding.SourceGenerators.Roslyn413\ReactiveUI.Binding.SourceGenerators.Roslyn413.csproj" PrivateAssets="all" ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="..\ReactiveUI.Binding.Analyzer.Roslyn413\ReactiveUI.Binding.Analyzer.Roslyn413.csproj" PrivateAssets="all" ReferenceOutputAssembly="false"/>
   </ItemGroup>
 
   <!-- Packed as plain files rather than through TargetsForTfmSpecificContentInPackage: that hook runs once
        per target framework, and the analyzer folder is framework-agnostic, so it would offer the same path
-       six times over. -->
+       six times over.
+
+       One slot per compiler generation, because what the generator can do differs between them: the 4.13
+       build claims each call site with an interceptor, the 4.8 build offers an overload that has to win
+       extension-method lookup. The accompanying .targets is what keeps a consumer whose build does not
+       narrow the slots itself from loading both. -->
   <ItemGroup>
-    <None Include="..\ReactiveUI.Binding.SourceGenerators\bin\$(Configuration)\netstandard2.0\ReactiveUI.Binding.SourceGenerators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
-    <None Include="..\ReactiveUI.Binding.Analyzer\bin\$(Configuration)\netstandard2.0\ReactiveUI.Binding.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+    <None Include="..\ReactiveUI.Binding.SourceGenerators\bin\$(Configuration)\netstandard2.0\ReactiveUI.Binding.SourceGenerators.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.8/cs" Visible="false"/>
+    <None Include="..\ReactiveUI.Binding.Analyzer\bin\$(Configuration)\netstandard2.0\ReactiveUI.Binding.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.8/cs" Visible="false"/>
+    <None Include="..\ReactiveUI.Binding.SourceGenerators.Roslyn413\bin\$(Configuration)\netstandard2.0\ReactiveUI.Binding.SourceGenerators.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.13/cs" Visible="false"/>
+    <None Include="..\ReactiveUI.Binding.Analyzer.Roslyn413\bin\$(Configuration)\netstandard2.0\ReactiveUI.Binding.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.13/cs" Visible="false"/>
     <None Include="..\ReactiveUI.Binding.SourceGenerators\build\ReactiveUI.Binding.SourceGenerators.props" Pack="true" PackagePath="build\$(MSBuildProjectName).props;buildTransitive\$(MSBuildProjectName).props" Visible="false"/>
+    <None Include="..\ReactiveUI.Binding.SourceGenerators\build\ReactiveUI.Binding.SourceGenerators.targets" Pack="true" PackagePath="build\$(MSBuildProjectName).targets;buildTransitive\$(MSBuildProjectName).targets" Visible="false"/>
   </ItemGroup>
 
   <!-- DateOnly and TimeOnly only exist on .NET 6+. Their converters are guarded with

--- a/src/ReactiveUI.Binding.SourceGenerators.Roslyn413/ReactiveUI.Binding.SourceGenerators.Roslyn413.csproj
+++ b/src/ReactiveUI.Binding.SourceGenerators.Roslyn413/ReactiveUI.Binding.SourceGenerators.Roslyn413.csproj
@@ -46,5 +46,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ReactiveUI.Binding.SourceGenerators.Tests"/>
+    <InternalsVisibleTo Include="ReactiveUI.Binding.SourceGenerators.Tests.Roslyn413"/>
   </ItemGroup>
 </Project>

--- a/src/ReactiveUI.Binding.SourceGenerators.Roslyn413/ReactiveUI.Binding.SourceGenerators.Roslyn413.csproj
+++ b/src/ReactiveUI.Binding.SourceGenerators.Roslyn413/ReactiveUI.Binding.SourceGenerators.Roslyn413.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>ReactiveUI.Binding.SourceGenerators</AssemblyName>
+    <RootNamespace>ReactiveUI.Binding.SourceGenerators</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoWarn>$(NoWarn);AD0001</NoWarn>
+    <DebugType>full</DebugType>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+  </PropertyGroup>
+
+  <!-- Roslyn 4.13.0 is the first release where SemanticModel.GetInterceptableLocation is a supported API
+       rather than an experimental one, so this build reaches it without acknowledging RSEXPERIMENTAL002.
+       It is what lets the generator redirect a call site rather than compete with it through
+       extension-method lookup. A consumer on an older compiler selects the 4.8 slot, whose generator emits
+       the dispatch overloads instead. Only APIs present in Roslyn 4.13 may be used here. -->
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ROSLYN_4_13</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" VersionOverride="4.13.0"/>
+  </ItemGroup>
+
+  <!-- The same generator source, compiled a second time against the newer compiler. Nothing is duplicated:
+       the two leaves differ only in which Roslyn they bind to and what ROSLYN_4_13 turns on. -->
+  <ItemGroup>
+    <Compile Include="..\ReactiveUI.Binding.SourceGenerators\**\*.cs"
+             Exclude="..\ReactiveUI.Binding.SourceGenerators\bin\**\*.cs;..\ReactiveUI.Binding.SourceGenerators\obj\**\*.cs"
+             LinkBase="SourceGenerators"/>
+    <Compile Include="..\ReactiveUI.Binding.Shared\Polyfills\**.cs" Link="Polyfills"/>
+    <Compile Include="..\ReactiveUI.Binding.Shared\Helpers\ArgumentExceptionHelper.cs" Link="Helpers\ArgumentExceptionHelper.cs"/>
+    <Compile Include="..\ReactiveUI.Binding.Shared\Bindings\BindingAffinity.cs" Link="Bindings\BindingAffinity.cs"/>
+  </ItemGroup>
+
+  <!-- Release tracking reads these through AdditionalFiles. The package auto-includes them from the project
+       directory, which does not reach a linked copy, so they are named explicitly. -->
+  <ItemGroup>
+    <AdditionalFiles Include="..\ReactiveUI.Binding.SourceGenerators\AnalyzerReleases.Shipped.md" Link="AnalyzerReleases.Shipped.md"/>
+    <AdditionalFiles Include="..\ReactiveUI.Binding.SourceGenerators\AnalyzerReleases.Unshipped.md" Link="AnalyzerReleases.Unshipped.md"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ReactiveUI.Binding.SourceGenerators.Tests"/>
+  </ItemGroup>
+</Project>

--- a/src/ReactiveUI.Binding.SourceGenerators.slnx
+++ b/src/ReactiveUI.Binding.SourceGenerators.slnx
@@ -33,6 +33,8 @@
         <Project Path="benchmarks/ReactiveUI.Binding.Benchmarks/ReactiveUI.Binding.Benchmarks.csproj"/>
         <Project Path="benchmarks/ReactiveUI.Binding.Generator.Benchmarks/ReactiveUI.Binding.Generator.Benchmarks.csproj"/>
         <Project
+            Path="benchmarks/ReactiveUI.Binding.Generator.Benchmarks.Roslyn413/ReactiveUI.Binding.Generator.Benchmarks.Roslyn413.csproj"/>
+        <Project
             Path="benchmarks/ReactiveUI.Binding.Benchmarks.ReactiveUI/ReactiveUI.Binding.Benchmarks.ReactiveUI.csproj"/>
     </Folder>
     <Folder Name="/tests/">

--- a/src/ReactiveUI.Binding.SourceGenerators.slnx
+++ b/src/ReactiveUI.Binding.SourceGenerators.slnx
@@ -19,6 +19,7 @@
     </Folder>
     <Project Path="ReactiveUI.Binding/ReactiveUI.Binding.csproj"/>
     <Project Path="ReactiveUI.Binding.SourceGenerators/ReactiveUI.Binding.SourceGenerators.csproj"/>
+    <Project Path="ReactiveUI.Binding.SourceGenerators.Roslyn413/ReactiveUI.Binding.SourceGenerators.Roslyn413.csproj"/>
     <Project Path="ReactiveUI.Binding.Analyzer/ReactiveUI.Binding.Analyzer.csproj"/>
     <Project Path="ReactiveUI.Binding.Wpf/ReactiveUI.Binding.Wpf.csproj"/>
     <Project Path="ReactiveUI.Binding.WinForms/ReactiveUI.Binding.WinForms.csproj"/>

--- a/src/ReactiveUI.Binding.SourceGenerators.slnx
+++ b/src/ReactiveUI.Binding.SourceGenerators.slnx
@@ -21,6 +21,7 @@
     <Project Path="ReactiveUI.Binding.SourceGenerators/ReactiveUI.Binding.SourceGenerators.csproj"/>
     <Project Path="ReactiveUI.Binding.SourceGenerators.Roslyn413/ReactiveUI.Binding.SourceGenerators.Roslyn413.csproj"/>
     <Project Path="ReactiveUI.Binding.Analyzer/ReactiveUI.Binding.Analyzer.csproj"/>
+    <Project Path="ReactiveUI.Binding.Analyzer.Roslyn413/ReactiveUI.Binding.Analyzer.Roslyn413.csproj"/>
     <Project Path="ReactiveUI.Binding.Wpf/ReactiveUI.Binding.Wpf.csproj"/>
     <Project Path="ReactiveUI.Binding.WinForms/ReactiveUI.Binding.WinForms.csproj"/>
     <Project Path="ReactiveUI.Binding.Reactive/ReactiveUI.Binding.Reactive.csproj"/>
@@ -38,7 +39,11 @@
         <Project Path="tests/ReactiveUI.Binding.Tests/ReactiveUI.Binding.Tests.csproj"/>
         <Project
             Path="tests/ReactiveUI.Binding.SourceGenerators.Tests/ReactiveUI.Binding.SourceGenerators.Tests.csproj"/>
+        <Project
+            Path="tests/ReactiveUI.Binding.SourceGenerators.Tests.Roslyn413/ReactiveUI.Binding.SourceGenerators.Tests.Roslyn413.csproj"/>
         <Project Path="tests/ReactiveUI.Binding.Analyzer.Tests/ReactiveUI.Binding.Analyzer.Tests.csproj"/>
+        <Project
+            Path="tests/ReactiveUI.Binding.Analyzer.Tests.Roslyn413/ReactiveUI.Binding.Analyzer.Tests.Roslyn413.csproj"/>
         <Project
             Path="tests/ReactiveUI.Binding.GeneratedCode.TestModels/ReactiveUI.Binding.GeneratedCode.TestModels.csproj"/>
         <Project Path="tests/ReactiveUI.Binding.GeneratedCode.Tests/ReactiveUI.Binding.GeneratedCode.Tests.csproj"/>

--- a/src/ReactiveUI.Binding.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/src/ReactiveUI.Binding.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -12,3 +12,4 @@
  RXUIBIND008 | Usage    | Warning  | Property is not an IInteraction                                                         
  RXUIBIND009 | Usage    | Warning  | Generated binding dispatch is out of reach for this file
  RXUIBIND010 | Usage    | Warning  | Observed path passes through a type that raises no notification
+ RXUIBIND011 | Usage    | Warning  | Binding call resolved to ReactiveUI's own mixin

--- a/src/ReactiveUI.Binding.SourceGenerators/BindingGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/BindingGenerator.cs
@@ -309,8 +309,7 @@ public class BindingGenerator : IIncrementalGenerator
 
                 // An interceptor claims its call site outright, so where one can be emitted none of the
                 // placement below applies: there is no namespace for lookup to reach and no import to scope.
-                var supportsInterceptors = InterceptableLocationReader.IsSupported
-                    && InterceptableLocationReader.IsOptedIn(parseOptions);
+                var supportsInterceptors = InterceptableLocationReader.IsInterceptionEnabled(parseOptions);
 
                 var dispatchNamespace = supportsGlobalUsings
                     ? SelectGeneratedNamespace(configOptions, compilation)

--- a/src/ReactiveUI.Binding.SourceGenerators/BindingGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/BindingGenerator.cs
@@ -233,6 +233,14 @@ public class BindingGenerator : IIncrementalGenerator
                     .Append(Constants.GeneratedExtensionClassName)
                     .Append("\n    {\n    }\n}\n");
 
+                if (features.SupportsInterceptors)
+                {
+                    // No framework declares the interception attribute, so the compilation that carries the
+                    // interceptors has to. Once for all of them: each dispatch file is another part of the
+                    // same class, but the attribute is a type of its own and would collide with itself.
+                    _ = sb.Append('\n').Append(CodeGeneration.InterceptorEmitter.BuildAttributeDeclaration());
+                }
+
                 CodeGeneration.CodeGeneratorHelpers.AddGeneratedSource(
                     ctx,
                     "GeneratedBindingsAttributes.g.cs",
@@ -298,20 +306,30 @@ public class BindingGenerator : IIncrementalGenerator
                 var sharedNamespace = usesReactiveRuntime
                     ? Constants.ReactiveRuntimeNamespace
                     : Constants.SharedGeneratedNamespace;
-                var generatedNamespace = supportsGlobalUsings
+
+                // An interceptor claims its call site outright, so where one can be emitted none of the
+                // placement below applies: there is no namespace for lookup to reach and no import to scope.
+                var supportsInterceptors = InterceptableLocationReader.IsSupported
+                    && InterceptableLocationReader.IsOptedIn(parseOptions);
+
+                var dispatchNamespace = supportsGlobalUsings
                     ? SelectGeneratedNamespace(configOptions, compilation)
                     : SelectSharedTierNamespace(configOptions, compilation, sharedNamespace);
+                var generatedNamespace = supportsInterceptors
+                    ? Constants.InterceptorNamespace
+                    : dispatchNamespace;
 
                 return new LanguageFeatures(
                     supportsCallerArgExpr,
                     languageVersion >= LanguageVersion.CSharp8,
                     emitGeneratedCodeMarkers,
                     generatedNamespace,
-                    supportsGlobalUsings,
+                    supportsGlobalUsings && !supportsInterceptors,
                     callerArgExprAvailable,
                     usesReactiveRuntime,
                     runtimeNamespaceMembers,
-                    primitivesNamespaceMembers);
+                    primitivesNamespaceMembers,
+                    supportsInterceptors);
             });
 
     /// <summary>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindCommandCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindCommandCodeGenerator.cs
@@ -28,6 +28,9 @@ internal static class BindCommandCodeGenerator
     /// <summary>Closes the view parameter of a generated binding worker.</summary>
     private const string ViewParameterSuffix = " view,";
 
+    /// <summary>The caller-supplied parameter stream a worker takes on top of the two bound objects.</summary>
+    private const string ObservableParameterArgument = ", withParameter";
+
     /// <summary>Generates concrete typed overloads and binding methods for BindCommand invocations.</summary>
     /// <param name="invocations">All detected BindCommand invocations.</param>
     /// <param name="allClasses">All detected class binding info.</param>
@@ -382,12 +385,28 @@ internal static class BindCommandCodeGenerator
         bool supportsNullable,
         string dispatchSummaryLine)
     {
-        var commandType = CodeGeneratorHelpers.NullableSelectorLeafType(group.Invocations[0].CommandPropertyPath, supportsNullable);
-
         _ = sb.AppendLine("        /// <summary>").Append("        /// Concrete typed overload for BindCommand on ").Append(group.ViewTypeFullName)
             .AppendLine(".").AppendLine(dispatchSummaryLine).AppendLine("        /// </summary>")
-            .AppendLine("        public static global::System.IDisposable BindCommand(").Append("            this ").Append(group.ViewTypeFullName)
-            .AppendLine(ViewParameterSuffix).Append("            ").Append(group.ViewModelTypeFullName).AppendLine(" viewModel,")
+            .AppendLine("        public static global::System.IDisposable BindCommand(");
+
+        AppendBindCommandParameters(sb, group, supportsNullable, true);
+    }
+
+    /// <summary>Appends the view, view model, selector and event parameters every generated BindCommand member declares.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="group">The BindCommand type group whose types the parameters are written from.</param>
+    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
+    /// <param name="isExtensionMethod">Whether the view parameter is the extension receiver.</param>
+    private static void AppendBindCommandParameters(
+        StringBuilder sb,
+        BindCommandTypeGroup group,
+        bool supportsNullable,
+        bool isExtensionMethod)
+    {
+        var commandType = CodeGeneratorHelpers.NullableSelectorLeafType(group.Invocations[0].CommandPropertyPath, supportsNullable);
+
+        _ = sb.Append(isExtensionMethod ? "            this " : CodeGeneratorHelpers.ParameterIndent).Append(group.ViewTypeFullName)
+            .AppendLine(ViewParameterSuffix).Append(CodeGeneratorHelpers.ParameterIndent).Append(group.ViewModelTypeFullName).AppendLine(" viewModel,")
             .Append(GeneratedSyntax.SelectorParameterOpen).Append(group.ViewModelTypeFullName).Append(", ")
             .Append(commandType).AppendLine(">> propertyName,").Append(GeneratedSyntax.SelectorParameterOpen)
             .Append(group.ViewTypeFullName).Append(", ").Append(group.ControlTypeFullName).AppendLine(">> controlName,");
@@ -407,6 +426,31 @@ internal static class BindCommandCodeGenerator
         }
 
         _ = sb.Append("            string").Append(supportsNullable ? "?" : string.Empty).AppendLine(" toEvent = null,");
+    }
+
+    /// <summary>Emits one interceptor per generated binding, claiming every call site that reaches it.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="group">The group of call sites being claimed.</param>
+    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
+    private static void GenerateInterceptors(StringBuilder sb, BindCommandTypeGroup group, bool supportsNullable)
+    {
+        var extraArgs = group.HasObservableParameter ? ObservableParameterArgument : string.Empty;
+
+        foreach (var entry in InterceptorEmitter.GroupCallSites(group.Invocations, static x => x.Interceptor, MethodSuffix))
+        {
+            foreach (var callSite in entry.Value)
+            {
+                InterceptorEmitter.AppendAttribute(sb, callSite.Interceptor, InterceptorEmitter.MemberIndent);
+            }
+
+            _ = sb.Append("        internal static global::System.IDisposable __Intercept_BindCommand_").Append(entry.Key).AppendLine("(");
+
+            AppendBindCommandParameters(sb, group, supportsNullable, false);
+            InterceptorEmitter.CloseParameterList(sb);
+
+            _ = sb.Append("            => ").Append(WorkerMethodPrefix).Append(entry.Key).Append('(').Append(WorkerArguments)
+                .Append(extraArgs).AppendLine(");").AppendLine();
+        }
     }
 
     /// <summary>Emits the overload and the workers for one group of call sites.</summary>
@@ -429,12 +473,20 @@ internal static class BindCommandCodeGenerator
             }
             : group;
 
-        GenerateConcreteOverload(
-            sb,
-            collapsed,
-            features.SupportsCallerArgExpr,
-            features.SupportsNullable,
-            features.StubHasExpressionParameters);
+        if (features.SupportsInterceptors)
+        {
+            GenerateInterceptors(sb, collapsed, features.SupportsNullable);
+        }
+        else
+        {
+            GenerateConcreteOverload(
+                sb,
+                collapsed,
+                features.SupportsCallerArgExpr,
+                features.SupportsNullable,
+                features.StubHasExpressionParameters);
+        }
+
         _ = sb.AppendLine();
 
         for (var i = 0; i < collapsed.Invocations.Length; i++)
@@ -455,7 +507,7 @@ internal static class BindCommandCodeGenerator
     /// <param name="group">The BindCommand type group.</param>
     private static void EmitExpressionDispatchBranches(StringBuilder sb, BindCommandTypeGroup group)
     {
-        var extraArgs = group.HasObservableParameter ? ", withParameter" : string.Empty;
+        var extraArgs = group.HasObservableParameter ? ObservableParameterArgument : string.Empty;
 
         for (var i = 0; i < group.Invocations.Length; i++)
         {
@@ -486,7 +538,7 @@ internal static class BindCommandCodeGenerator
     /// <param name="group">The BindCommand type group.</param>
     private static void EmitFilePathDispatchBranches(StringBuilder sb, BindCommandTypeGroup group)
     {
-        var extraArgs = group.HasObservableParameter ? ", withParameter" : string.Empty;
+        var extraArgs = group.HasObservableParameter ? ObservableParameterArgument : string.Empty;
 
         for (var i = 0; i < group.Invocations.Length; i++)
         {

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindCommandCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindCommandCodeGenerator.cs
@@ -131,21 +131,10 @@ internal static class BindCommandCodeGenerator
         BindCommandTypeGroup group,
         bool supportsNullable)
     {
-        AppendOverloadSignature(sb, group, supportsNullable, "        /// Uses CallerArgumentExpression for dispatch.");
-
-        _ = sb.AppendLine("            [global::System.Runtime.CompilerServices.CallerArgumentExpression(\"propertyName\")] string propertyNameExpression = \"\",")
-            .AppendLine("            [global::System.Runtime.CompilerServices.CallerArgumentExpression(\"controlName\")] string controlNameExpression = \"\",");
-
-        if (group.HasExpressionParameter)
-        {
-            _ = sb.AppendLine("""
-                                      [global::System.Runtime.CompilerServices.CallerArgumentExpression("withParameter")] string withParameterExpression = "",
-                          """);
-        }
+        AppendOverloadSummary(sb, group, "        /// Uses CallerArgumentExpression for dispatch.");
+        AppendParameterList(sb, group, true, supportsNullable, true);
 
         _ = sb.AppendLine("""
-                                  [global::System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = "",
-                                  [global::System.Runtime.CompilerServices.CallerLineNumber] int callerLineNumber = 0)
                               {
                                   propertyNameExpression = propertyNameExpression.StartsWith("static ", global::System.StringComparison.Ordinal)
                                       ? propertyNameExpression.Substring(7)
@@ -171,24 +160,10 @@ internal static class BindCommandCodeGenerator
         bool supportsNullable,
         bool stubHasExpressionParameters)
     {
-        AppendOverloadSignature(sb, group, supportsNullable, "        /// Uses CallerFilePath + CallerLineNumber for dispatch.");
+        AppendOverloadSummary(sb, group, "        /// Uses CallerFilePath + CallerLineNumber for dispatch.");
+        AppendParameterList(sb, group, false, supportsNullable, stubHasExpressionParameters);
 
-        if (stubHasExpressionParameters)
-        {
-            CodeGeneratorHelpers.AppendExpressionParameter(sb, "propertyName", "propertyNameExpression", false);
-            CodeGeneratorHelpers.AppendExpressionParameter(sb, "controlName", "controlNameExpression", false);
-
-            if (group.HasExpressionParameter)
-            {
-                CodeGeneratorHelpers.AppendExpressionParameter(sb, "withParameter", "withParameterExpression", false);
-            }
-        }
-
-        _ = sb.AppendLine("""
-                                  [global::System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = "",
-                                  [global::System.Runtime.CompilerServices.CallerLineNumber] int callerLineNumber = 0)
-                              {
-                      """);
+        _ = sb.AppendLine(GeneratedSyntax.MemberBodyOpen);
 
         EmitFilePathDispatchBranches(sb, group);
         EmitDispatchFallthrough(sb);
@@ -370,7 +345,6 @@ internal static class BindCommandCodeGenerator
     /// <summary>Appends the signature both dispatch overloads declare, up to the parameters that identify a call site.</summary>
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The BindCommand type group.</param>
-    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
     /// <param name="dispatchSummaryLine">The documentation line naming what the overload matches a call site on.</param>
     /// <remarks>
     /// The command selector is nullable - a command property may be null - matching the runtime stub's
@@ -379,33 +353,36 @@ internal static class BindCommandCodeGenerator
     /// generated overload rather than falling through to the runtime fallback. The expression-form parameter
     /// selector is nullable for a reference-type parameter, for the same reason: the lambda may return null.
     /// </remarks>
-    private static void AppendOverloadSignature(
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AppendOverloadSummary(
         StringBuilder sb,
         BindCommandTypeGroup group,
-        bool supportsNullable,
-        string dispatchSummaryLine)
-    {
-        _ = sb.AppendLine("        /// <summary>").Append("        /// Concrete typed overload for BindCommand on ").Append(group.ViewTypeFullName)
+        string dispatchSummaryLine) =>
+        sb.AppendLine("        /// <summary>").Append("        /// Concrete typed overload for BindCommand on ").Append(group.ViewTypeFullName)
             .AppendLine(".").AppendLine(dispatchSummaryLine).AppendLine("        /// </summary>")
             .AppendLine("        public static global::System.IDisposable BindCommand(");
 
-        AppendBindCommandParameters(sb, group, supportsNullable, true);
-    }
-
-    /// <summary>Appends the view, view model, selector and event parameters every generated BindCommand member declares.</summary>
+    /// <summary>Writes the parameters a BindCommand member declares, closing the list.</summary>
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The BindCommand type group whose types the parameters are written from.</param>
+    /// <param name="dispatchesOnExpressionText">Whether the captured expression text is what identifies a call site.</param>
     /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
-    /// <param name="isExtensionMethod">Whether the view parameter is the extension receiver.</param>
-    private static void AppendBindCommandParameters(
+    /// <param name="stubHasExpressionParameters">Whether the runtime stub declares the expression parameters.</param>
+    /// <remarks>
+    /// One list serves the overload and the interceptor, because both have to be the stub's signature: the
+    /// overload only wins resolution against a candidate it is otherwise indistinguishable from, and an
+    /// interceptor is refused outright unless its signature is the intercepted method's.
+    /// </remarks>
+    private static void AppendParameterList(
         StringBuilder sb,
         BindCommandTypeGroup group,
+        bool dispatchesOnExpressionText,
         bool supportsNullable,
-        bool isExtensionMethod)
+        bool stubHasExpressionParameters)
     {
         var commandType = CodeGeneratorHelpers.NullableSelectorLeafType(group.Invocations[0].CommandPropertyPath, supportsNullable);
 
-        _ = sb.Append(isExtensionMethod ? "            this " : CodeGeneratorHelpers.ParameterIndent).Append(group.ViewTypeFullName)
+        _ = sb.Append("            this ").Append(group.ViewTypeFullName)
             .AppendLine(ViewParameterSuffix).Append(CodeGeneratorHelpers.ParameterIndent).Append(group.ViewModelTypeFullName).AppendLine(" viewModel,")
             .Append(GeneratedSyntax.SelectorParameterOpen).Append(group.ViewModelTypeFullName).Append(", ")
             .Append(commandType).AppendLine(">> propertyName,").Append(GeneratedSyntax.SelectorParameterOpen)
@@ -426,15 +403,31 @@ internal static class BindCommandCodeGenerator
         }
 
         _ = sb.Append("            string").Append(supportsNullable ? "?" : string.Empty).AppendLine(" toEvent = null,");
+
+        if (dispatchesOnExpressionText || stubHasExpressionParameters)
+        {
+            CodeGeneratorHelpers.AppendExpressionParameter(sb, "propertyName", CommandExpressionParameter, dispatchesOnExpressionText);
+            CodeGeneratorHelpers.AppendExpressionParameter(sb, "controlName", ControlExpressionParameter, dispatchesOnExpressionText);
+
+            if (group.HasExpressionParameter)
+            {
+                CodeGeneratorHelpers.AppendExpressionParameter(sb, "withParameter", "withParameterExpression", dispatchesOnExpressionText);
+            }
+        }
+
+        _ = sb.AppendLine(CodeGeneratorHelpers.CallerInfoParameterList);
     }
 
     /// <summary>Emits one interceptor per generated binding, claiming every call site that reaches it.</summary>
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The group of call sites being claimed.</param>
-    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
-    private static void GenerateInterceptors(StringBuilder sb, BindCommandTypeGroup group, bool supportsNullable)
+    /// <param name="features">The consumer compilation's language-feature snapshot.</param>
+    private static void GenerateInterceptors(StringBuilder sb, BindCommandTypeGroup group, in LanguageFeatures features)
     {
         var extraArgs = group.HasObservableParameter ? ObservableParameterArgument : string.Empty;
+        var dispatchesOnExpressionText = features.SupportsCallerArgExpr;
+        var supportsNullable = features.SupportsNullable;
+        var stubHasExpressionParameters = features.StubHasExpressionParameters;
 
         foreach (var entry in InterceptorEmitter.GroupCallSites(group.Invocations, static x => x.Interceptor, MethodSuffix))
         {
@@ -445,8 +438,7 @@ internal static class BindCommandCodeGenerator
 
             _ = sb.Append("        internal static global::System.IDisposable __Intercept_BindCommand_").Append(entry.Key).AppendLine("(");
 
-            AppendBindCommandParameters(sb, group, supportsNullable, false);
-            InterceptorEmitter.CloseParameterList(sb);
+            AppendParameterList(sb, group, dispatchesOnExpressionText, supportsNullable, stubHasExpressionParameters);
 
             _ = sb.Append("            => ").Append(WorkerMethodPrefix).Append(entry.Key).Append('(').Append(WorkerArguments)
                 .Append(extraArgs).AppendLine(");").AppendLine();
@@ -475,7 +467,7 @@ internal static class BindCommandCodeGenerator
 
         if (features.SupportsInterceptors)
         {
-            GenerateInterceptors(sb, collapsed, features.SupportsNullable);
+            GenerateInterceptors(sb, collapsed, in features);
         }
         else
         {

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindInteractionCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindInteractionCodeGenerator.cs
@@ -235,17 +235,54 @@ internal static class BindInteractionCodeGenerator
         BindInteractionTypeGroup group,
         string dispatchSummaryLine)
     {
+        _ = sb.AppendLine("        /// <summary>").Append("        /// Concrete typed overload for BindInteraction on ")
+            .Append(group.ViewTypeFullName).AppendLine(".").AppendLine(dispatchSummaryLine)
+            .AppendLine("        /// </summary>").AppendLine("        public static global::System.IDisposable BindInteraction(");
+
+        AppendInteractionParameters(sb, group, true);
+    }
+
+    /// <summary>Appends the view, view model, selector and handler parameters every generated BindInteraction member declares.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="group">The BindInteraction type group whose types the parameters are written from.</param>
+    /// <param name="isExtensionMethod">Whether the view parameter is the extension receiver.</param>
+    private static void AppendInteractionParameters(
+        StringBuilder sb,
+        BindInteractionTypeGroup group,
+        bool isExtensionMethod)
+    {
         var handlerType = group.IsTaskHandler
             ? $"global::System.Func<global::ReactiveUI.Binding.IInteractionContext<{group.InputTypeFullName}, {group.OutputTypeFullName}>, global::System.Threading.Tasks.Task>"
             : $"global::System.Func<global::ReactiveUI.Binding.IInteractionContext<{group.InputTypeFullName}, {group.OutputTypeFullName}>, global::System.IObservable<{group.DontCareTypeFullName}>>";
 
-        _ = sb.AppendLine("        /// <summary>").Append("        /// Concrete typed overload for BindInteraction on ")
-            .Append(group.ViewTypeFullName).AppendLine(".").AppendLine(dispatchSummaryLine)
-            .AppendLine("        /// </summary>").AppendLine("        public static global::System.IDisposable BindInteraction(")
-            .Append("            this ").Append(group.ViewTypeFullName).AppendLine(" view,").Append("            ").Append(group.ViewModelTypeFullName)
-            .AppendLine(ViewModelParameterSuffix).Append("            ").Append(Expression).Append('<').Append(Func).Append('<').Append(group.ViewModelTypeFullName)
-            .Append(", ").Append(IInteraction).Append('<').Append(group.InputTypeFullName).Append(", ").Append(group.OutputTypeFullName)
-            .AppendLine(">>> propertyName,").Append("            ").Append(handlerType).AppendLine(" handler,");
+        _ = sb.Append(isExtensionMethod ? "            this " : CodeGeneratorHelpers.ParameterIndent).Append(group.ViewTypeFullName)
+            .AppendLine(ViewParameterSuffix).Append(CodeGeneratorHelpers.ParameterIndent).Append(group.ViewModelTypeFullName)
+            .AppendLine(ViewModelParameterSuffix).Append(CodeGeneratorHelpers.ParameterIndent).Append(Expression).Append('<').Append(Func).Append('<')
+            .Append(group.ViewModelTypeFullName).Append(", ").Append(IInteraction).Append('<').Append(group.InputTypeFullName).Append(", ")
+            .Append(group.OutputTypeFullName).AppendLine(">>> propertyName,").Append(CodeGeneratorHelpers.ParameterIndent).Append(handlerType)
+            .AppendLine(" handler,");
+    }
+
+    /// <summary>Emits one interceptor per generated binding, claiming every call site that reaches it.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="group">The group of call sites being claimed.</param>
+    private static void GenerateInterceptors(StringBuilder sb, BindInteractionTypeGroup group)
+    {
+        foreach (var entry in InterceptorEmitter.GroupCallSites(group.Invocations, static x => x.Interceptor, MethodSuffix))
+        {
+            foreach (var callSite in entry.Value)
+            {
+                InterceptorEmitter.AppendAttribute(sb, callSite.Interceptor, InterceptorEmitter.MemberIndent);
+            }
+
+            _ = sb.Append("        internal static global::System.IDisposable __Intercept_BindInteraction_").Append(entry.Key).AppendLine("(");
+
+            AppendInteractionParameters(sb, group, false);
+            InterceptorEmitter.CloseParameterList(sb);
+
+            _ = sb.Append("            => ").Append(WorkerMethodPrefix).Append(entry.Key).Append('(').Append(WorkerArguments)
+                .AppendLine(");").AppendLine();
+        }
     }
 
     /// <summary>Emits the overload and the workers for one group of call sites.</summary>
@@ -268,7 +305,15 @@ internal static class BindInteractionCodeGenerator
             }
             : group;
 
-        GenerateConcreteOverload(sb, collapsed, features.SupportsCallerArgExpr, features.StubHasExpressionParameters);
+        if (features.SupportsInterceptors)
+        {
+            GenerateInterceptors(sb, collapsed);
+        }
+        else
+        {
+            GenerateConcreteOverload(sb, collapsed, features.SupportsCallerArgExpr, features.StubHasExpressionParameters);
+        }
+
         _ = sb.AppendLine();
 
         for (var i = 0; i < collapsed.Invocations.Length; i++)

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindInteractionCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindInteractionCodeGenerator.cs
@@ -127,11 +127,10 @@ internal static class BindInteractionCodeGenerator
         StringBuilder sb,
         BindInteractionTypeGroup group)
     {
-        AppendOverloadSignature(sb, group, "        /// Uses CallerArgumentExpression for dispatch.");
+        AppendOverloadSummary(sb, group, "        /// Uses CallerArgumentExpression for dispatch.");
+        AppendParameterList(sb, group, true, true);
 
-        _ = sb.AppendLine("            [global::System.Runtime.CompilerServices.CallerArgumentExpression(\"propertyName\")] string propertyNameExpression = \"\",")
-            .AppendLine("            [global::System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = \"\",")
-            .AppendLine("            [global::System.Runtime.CompilerServices.CallerLineNumber] int callerLineNumber = 0)").AppendLine("        {")
+        _ = sb.AppendLine(GeneratedSyntax.MemberBodyOpen)
             .Append("            propertyNameExpression = propertyNameExpression.StartsWith(\"static \", global::System.StringComparison.Ordinal)")
             .AppendLine(" ? propertyNameExpression.Substring(7) : propertyNameExpression;")
             .AppendLine();
@@ -158,18 +157,10 @@ internal static class BindInteractionCodeGenerator
         BindInteractionTypeGroup group,
         bool stubHasExpressionParameters)
     {
-        AppendOverloadSignature(sb, group, "        /// Uses CallerFilePath + CallerLineNumber for dispatch.");
+        AppendOverloadSummary(sb, group, "        /// Uses CallerFilePath + CallerLineNumber for dispatch.");
+        AppendParameterList(sb, group, false, stubHasExpressionParameters);
 
-        if (stubHasExpressionParameters)
-        {
-            CodeGeneratorHelpers.AppendExpressionParameter(sb, "propertyName", "propertyNameExpression", false);
-        }
-
-        _ = sb.AppendLine("""
-            [global::System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = "",
-            [global::System.Runtime.CompilerServices.CallerLineNumber] int callerLineNumber = 0)
-        {
-""");
+        _ = sb.AppendLine(GeneratedSyntax.MemberBodyOpen);
 
         for (var i = 0; i < group.Invocations.Length; i++)
         {
@@ -230,44 +221,59 @@ internal static class BindInteractionCodeGenerator
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The BindInteraction type group.</param>
     /// <param name="dispatchSummaryLine">The documentation line naming what the overload matches a call site on.</param>
-    private static void AppendOverloadSignature(
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AppendOverloadSummary(
         StringBuilder sb,
         BindInteractionTypeGroup group,
-        string dispatchSummaryLine)
-    {
-        _ = sb.AppendLine("        /// <summary>").Append("        /// Concrete typed overload for BindInteraction on ")
+        string dispatchSummaryLine) =>
+        sb.AppendLine("        /// <summary>").Append("        /// Concrete typed overload for BindInteraction on ")
             .Append(group.ViewTypeFullName).AppendLine(".").AppendLine(dispatchSummaryLine)
             .AppendLine("        /// </summary>").AppendLine("        public static global::System.IDisposable BindInteraction(");
 
-        AppendInteractionParameters(sb, group, true);
-    }
-
-    /// <summary>Appends the view, view model, selector and handler parameters every generated BindInteraction member declares.</summary>
+    /// <summary>Writes the parameters a BindInteraction member declares, closing the list.</summary>
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The BindInteraction type group whose types the parameters are written from.</param>
-    /// <param name="isExtensionMethod">Whether the view parameter is the extension receiver.</param>
-    private static void AppendInteractionParameters(
+    /// <param name="dispatchesOnExpressionText">Whether the captured expression text is what identifies a call site.</param>
+    /// <param name="stubHasExpressionParameters">Whether the runtime stub declares the expression parameter.</param>
+    /// <remarks>
+    /// One list serves the overload and the interceptor, because both have to be the stub's signature: the
+    /// overload only wins resolution against a candidate it is otherwise indistinguishable from, and an
+    /// interceptor is refused outright unless its signature is the intercepted method's.
+    /// </remarks>
+    private static void AppendParameterList(
         StringBuilder sb,
         BindInteractionTypeGroup group,
-        bool isExtensionMethod)
+        bool dispatchesOnExpressionText,
+        bool stubHasExpressionParameters)
     {
         var handlerType = group.IsTaskHandler
             ? $"global::System.Func<global::ReactiveUI.Binding.IInteractionContext<{group.InputTypeFullName}, {group.OutputTypeFullName}>, global::System.Threading.Tasks.Task>"
             : $"global::System.Func<global::ReactiveUI.Binding.IInteractionContext<{group.InputTypeFullName}, {group.OutputTypeFullName}>, global::System.IObservable<{group.DontCareTypeFullName}>>";
 
-        _ = sb.Append(isExtensionMethod ? "            this " : CodeGeneratorHelpers.ParameterIndent).Append(group.ViewTypeFullName)
+        _ = sb.Append("            this ").Append(group.ViewTypeFullName)
             .AppendLine(ViewParameterSuffix).Append(CodeGeneratorHelpers.ParameterIndent).Append(group.ViewModelTypeFullName)
             .AppendLine(ViewModelParameterSuffix).Append(CodeGeneratorHelpers.ParameterIndent).Append(Expression).Append('<').Append(Func).Append('<')
             .Append(group.ViewModelTypeFullName).Append(", ").Append(IInteraction).Append('<').Append(group.InputTypeFullName).Append(", ")
             .Append(group.OutputTypeFullName).AppendLine(">>> propertyName,").Append(CodeGeneratorHelpers.ParameterIndent).Append(handlerType)
             .AppendLine(" handler,");
+
+        if (dispatchesOnExpressionText || stubHasExpressionParameters)
+        {
+            CodeGeneratorHelpers.AppendExpressionParameter(sb, "propertyName", "propertyNameExpression", dispatchesOnExpressionText);
+        }
+
+        _ = sb.AppendLine(CodeGeneratorHelpers.CallerInfoParameterList);
     }
 
     /// <summary>Emits one interceptor per generated binding, claiming every call site that reaches it.</summary>
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The group of call sites being claimed.</param>
-    private static void GenerateInterceptors(StringBuilder sb, BindInteractionTypeGroup group)
+    /// <param name="features">The consumer compilation's language-feature snapshot.</param>
+    private static void GenerateInterceptors(StringBuilder sb, BindInteractionTypeGroup group, in LanguageFeatures features)
     {
+        var dispatchesOnExpressionText = features.SupportsCallerArgExpr;
+        var stubHasExpressionParameters = features.StubHasExpressionParameters;
+
         foreach (var entry in InterceptorEmitter.GroupCallSites(group.Invocations, static x => x.Interceptor, MethodSuffix))
         {
             foreach (var callSite in entry.Value)
@@ -277,8 +283,7 @@ internal static class BindInteractionCodeGenerator
 
             _ = sb.Append("        internal static global::System.IDisposable __Intercept_BindInteraction_").Append(entry.Key).AppendLine("(");
 
-            AppendInteractionParameters(sb, group, false);
-            InterceptorEmitter.CloseParameterList(sb);
+            AppendParameterList(sb, group, dispatchesOnExpressionText, stubHasExpressionParameters);
 
             _ = sb.Append("            => ").Append(WorkerMethodPrefix).Append(entry.Key).Append('(').Append(WorkerArguments)
                 .AppendLine(");").AppendLine();
@@ -307,7 +312,7 @@ internal static class BindInteractionCodeGenerator
 
         if (features.SupportsInterceptors)
         {
-            GenerateInterceptors(sb, collapsed);
+            GenerateInterceptors(sb, collapsed, in features);
         }
         else
         {

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindToCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindToCodeGenerator.cs
@@ -63,7 +63,7 @@ internal static class BindToCodeGenerator
 
             if (features.SupportsInterceptors)
             {
-                GenerateInterceptors(sb, group, features.SupportsNullable);
+                GenerateInterceptors(sb, group, in features);
             }
             else
             {
@@ -177,12 +177,9 @@ internal static class BindToCodeGenerator
             .AppendLine("        /// Uses CallerArgumentExpression for dispatch.").AppendLine("        /// </summary>").Append("        public static ")
             .Append(GeneratedTypeNames.IDisposable).AppendLine(" BindTo(");
 
-        AppendBindToParameters(sb, group, supportsNullable, true);
-        AppendExtraParameters(sb, group);
+        AppendParameterList(sb, group, true, supportsNullable, true);
 
-        _ = sb.Append(GeneratedSyntax.ParameterAttributeOpen).Append(CallerArgumentExpression).AppendLine("(\"property\")] string propertyExpression = \"\",")
-            .Append(GeneratedSyntax.ParameterAttributeOpen).Append(CallerFilePath).AppendLine("] string callerFilePath = \"\",").Append(GeneratedSyntax.ParameterAttributeOpen).Append(CallerLineNumber)
-            .AppendLine("] int callerLineNumber = 0)").AppendLine(GeneratedSyntax.MemberBodyOpen)
+        _ = sb.AppendLine(GeneratedSyntax.MemberBodyOpen)
             .AppendLine("            propertyExpression = propertyExpression.StartsWith(\"static \", global::System.StringComparison.Ordinal) ? propertyExpression.Substring(7) : propertyExpression;")
             .AppendLine();
 
@@ -220,16 +217,9 @@ internal static class BindToCodeGenerator
             .AppendLine("        /// Uses CallerFilePath + CallerLineNumber for dispatch.").AppendLine("        /// </summary>")
             .Append("        public static ").Append(GeneratedTypeNames.IDisposable).AppendLine(" BindTo(");
 
-        AppendBindToParameters(sb, group, supportsNullable, true);
-        AppendExtraParameters(sb, group);
+        AppendParameterList(sb, group, false, supportsNullable, stubHasExpressionParameters);
 
-        if (stubHasExpressionParameters)
-        {
-            CodeGeneratorHelpers.AppendExpressionParameter(sb, "property", "propertyExpression", false);
-        }
-
-        _ = sb.Append(GeneratedSyntax.ParameterAttributeOpen).Append(CallerFilePath).AppendLine("] string callerFilePath = \"\",").Append(GeneratedSyntax.ParameterAttributeOpen)
-            .Append(CallerLineNumber).AppendLine("] int callerLineNumber = 0)").AppendLine(GeneratedSyntax.MemberBodyOpen);
+        _ = sb.AppendLine(GeneratedSyntax.MemberBodyOpen);
 
         var extraArguments = FormatExtraArgs(group);
 
@@ -356,10 +346,13 @@ internal static class BindToCodeGenerator
     /// <summary>Emits one interceptor per generated binding, claiming every call site that reaches it.</summary>
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The group of call sites being claimed.</param>
-    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
-    private static void GenerateInterceptors(StringBuilder sb, BindToTypeGroup group, bool supportsNullable)
+    /// <param name="features">The consumer compilation's language-feature snapshot.</param>
+    private static void GenerateInterceptors(StringBuilder sb, BindToTypeGroup group, in LanguageFeatures features)
     {
         var extraArguments = FormatExtraArgs(group);
+        var dispatchesOnExpressionText = features.SupportsCallerArgExpr;
+        var supportsNullable = features.SupportsNullable;
+        var stubHasExpressionParameters = features.StubHasExpressionParameters;
 
         foreach (var entry in InterceptorEmitter.GroupCallSites(group.Invocations, static x => x.Interceptor, BindToMethodSuffix))
         {
@@ -371,31 +364,45 @@ internal static class BindToCodeGenerator
             _ = sb.Append("        internal static ").Append(GeneratedTypeNames.IDisposable).Append(" __Intercept_BindTo_")
                 .Append(entry.Key).AppendLine("(");
 
-            AppendBindToParameters(sb, group, supportsNullable, false);
-            AppendExtraParameters(sb, group);
-            InterceptorEmitter.CloseParameterList(sb);
+            AppendParameterList(sb, group, dispatchesOnExpressionText, supportsNullable, stubHasExpressionParameters);
 
             AppendWorkerInvocation(sb, ForwardingBodyPrefix, entry.Key, extraArguments);
             _ = sb.AppendLine();
         }
     }
 
-    /// <summary>Appends the observable, target and property parameters every generated <c>BindTo</c> member declares.</summary>
+    /// <summary>Writes the parameters a <c>BindTo</c> member declares, closing the list.</summary>
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The group whose types the parameters are written from.</param>
+    /// <param name="dispatchesOnExpressionText">Whether the captured expression text is what identifies a call site.</param>
     /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
-    /// <param name="isExtensionMethod">Whether the observable parameter is the extension receiver.</param>
-    private static void AppendBindToParameters(
+    /// <param name="stubHasExpressionParameters">Whether the runtime stub declares the expression parameter.</param>
+    /// <remarks>
+    /// One list serves the overload and the interceptor, because both have to be the stub's signature: the
+    /// overload only wins resolution against a candidate it is otherwise indistinguishable from, and an
+    /// interceptor is refused outright unless its signature is the intercepted method's.
+    /// </remarks>
+    private static void AppendParameterList(
         StringBuilder sb,
         BindToTypeGroup group,
+        bool dispatchesOnExpressionText,
         bool supportsNullable,
-        bool isExtensionMethod)
+        bool stubHasExpressionParameters)
     {
         var targetPropType = CodeGeneratorHelpers.NullableSelectorLeafType(group.Invocations[0].TargetPropertyPath, supportsNullable);
 
-        _ = sb.Append(isExtensionMethod ? "            this " : "            ").Append(ObservableOf(group.SourceValueTypeFullName))
+        _ = sb.Append("            this ").Append(ObservableOf(group.SourceValueTypeFullName))
             .AppendLine(" source,").Append("            ").Append(group.TargetTypeFullName).AppendLine(" target,")
             .Append("            ").Append(PropertyExpression(group.TargetTypeFullName, targetPropType)).AppendLine(" property,");
+
+        AppendExtraParameters(sb, group);
+
+        if (dispatchesOnExpressionText || stubHasExpressionParameters)
+        {
+            CodeGeneratorHelpers.AppendExpressionParameter(sb, "property", "propertyExpression", dispatchesOnExpressionText);
+        }
+
+        _ = sb.AppendLine(CodeGeneratorHelpers.CallerInfoParameterList);
     }
 
     /// <summary>Appends the call forwarding the bound stream and target on to the generated worker.</summary>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindToCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindToCodeGenerator.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using System.Text;
 using ReactiveUI.Binding.SourceGenerators.Models;
 
@@ -22,6 +23,12 @@ internal static class BindToCodeGenerator
 
     /// <summary>The indentation the converted-assignment subscription body sits at, one block deeper.</summary>
     private const string ConvertedSubscriptionBodyIndent = "                    ";
+
+    /// <summary>The indentation and keyword a dispatch branch returns its binding behind.</summary>
+    private const string ReturnStatementPrefix = "                return ";
+
+    /// <summary>The indentation and arrow an interceptor forwards to its binding behind.</summary>
+    private const string ForwardingBodyPrefix = "            => ";
 
     /// <summary>Generates concrete typed overloads and binding methods for <c>BindTo</c> invocations.</summary>
     /// <param name="invocations">All detected <c>BindTo</c> invocations.</param>
@@ -54,7 +61,15 @@ internal static class BindToCodeGenerator
                 }
                 : groups[g];
 
-            GenerateConcreteOverload(sb, group, supportsCallerArgExpr, features.SupportsNullable, features.StubHasExpressionParameters);
+            if (features.SupportsInterceptors)
+            {
+                GenerateInterceptors(sb, group, features.SupportsNullable);
+            }
+            else
+            {
+                GenerateConcreteOverload(sb, group, supportsCallerArgExpr, features.SupportsNullable, features.StubHasExpressionParameters);
+            }
+
             _ = sb.AppendLine();
 
             for (var i = 0; i < group.Invocations.Length; i++)
@@ -157,14 +172,12 @@ internal static class BindToCodeGenerator
     /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
     internal static void GenerateCallerArgExprOverload(StringBuilder sb, BindToTypeGroup group, bool supportsNullable)
     {
-        var targetPropType = CodeGeneratorHelpers.NullableSelectorLeafType(group.Invocations[0].TargetPropertyPath, supportsNullable);
         _ = sb.AppendLine("        /// <summary>").Append("        /// Concrete typed overload for BindTo of ").Append(IObservable).Append("&lt;")
             .Append(group.SourceValueTypeFullName).Append("&gt; to ").Append(group.TargetTypeFullName).AppendLine(".")
             .AppendLine("        /// Uses CallerArgumentExpression for dispatch.").AppendLine("        /// </summary>").Append("        public static ")
-            .Append(GeneratedTypeNames.IDisposable).AppendLine(" BindTo(").Append("            this ").Append(ObservableOf(group.SourceValueTypeFullName))
-            .AppendLine(" source,").Append("            ").Append(group.TargetTypeFullName).AppendLine(" target,").Append("            ")
-            .Append(PropertyExpression(group.TargetTypeFullName, targetPropType)).AppendLine(" property,");
+            .Append(GeneratedTypeNames.IDisposable).AppendLine(" BindTo(");
 
+        AppendBindToParameters(sb, group, supportsNullable, true);
         AppendExtraParameters(sb, group);
 
         _ = sb.Append(GeneratedSyntax.ParameterAttributeOpen).Append(CallerArgumentExpression).AppendLine("(\"property\")] string propertyExpression = \"\",")
@@ -173,20 +186,18 @@ internal static class BindToCodeGenerator
             .AppendLine("            propertyExpression = propertyExpression.StartsWith(\"static \", global::System.StringComparison.Ordinal) ? propertyExpression.Substring(7) : propertyExpression;")
             .AppendLine();
 
+        var extraArguments = FormatExtraArgs(group);
+
         for (var i = 0; i < group.Invocations.Length; i++)
         {
             var inv = group.Invocations[i];
-            var methodSuffix = CodeGeneratorHelpers.ComputeStableMethodSuffix(
-                inv.TargetTypeFullName,
-                inv.CallerFilePath,
-                inv.CallerLineNumber,
-                inv.TargetExpressionText);
             var condition = CodeGeneratorHelpers.ConditionKeyword(i);
             var escapedTargetExpr = CodeGeneratorHelpers.EscapeString(inv.TargetExpressionText);
 
             _ = sb.Append("            ").Append(condition).Append(" (propertyExpression == \"").Append(escapedTargetExpr).AppendLine("\")")
-                .AppendLine(GeneratedSyntax.StatementBlockOpen).Append("                return __BindTo_").Append(methodSuffix).Append("(source, target")
-                .Append(FormatExtraArgs(group)).AppendLine(");").AppendLine("            }");
+                .AppendLine(GeneratedSyntax.StatementBlockOpen);
+            AppendWorkerInvocation(sb, ReturnStatementPrefix, BindToMethodSuffix(inv), extraArguments);
+            _ = sb.AppendLine("            }");
         }
 
         _ = sb.Append("            throw new ").Append(GeneratedTypeNames.InvalidOperationException).AppendLine("(").Append("                \"")
@@ -204,14 +215,12 @@ internal static class BindToCodeGenerator
         bool supportsNullable,
         bool stubHasExpressionParameters)
     {
-        var targetPropType = CodeGeneratorHelpers.NullableSelectorLeafType(group.Invocations[0].TargetPropertyPath, supportsNullable);
         _ = sb.AppendLine("        /// <summary>").Append("        /// Concrete typed overload for BindTo of ").Append(IObservable).Append("&lt;")
             .Append(group.SourceValueTypeFullName).Append("&gt; to ").Append(group.TargetTypeFullName).AppendLine(".")
             .AppendLine("        /// Uses CallerFilePath + CallerLineNumber for dispatch.").AppendLine("        /// </summary>")
-            .Append("        public static ").Append(GeneratedTypeNames.IDisposable).AppendLine(" BindTo(").Append("            this ")
-            .Append(ObservableOf(group.SourceValueTypeFullName)).AppendLine(" source,").Append("            ").Append(group.TargetTypeFullName)
-            .AppendLine(" target,").Append("            ").Append(PropertyExpression(group.TargetTypeFullName, targetPropType)).AppendLine(" property,");
+            .Append("        public static ").Append(GeneratedTypeNames.IDisposable).AppendLine(" BindTo(");
 
+        AppendBindToParameters(sb, group, supportsNullable, true);
         AppendExtraParameters(sb, group);
 
         if (stubHasExpressionParameters)
@@ -222,21 +231,19 @@ internal static class BindToCodeGenerator
         _ = sb.Append(GeneratedSyntax.ParameterAttributeOpen).Append(CallerFilePath).AppendLine("] string callerFilePath = \"\",").Append(GeneratedSyntax.ParameterAttributeOpen)
             .Append(CallerLineNumber).AppendLine("] int callerLineNumber = 0)").AppendLine(GeneratedSyntax.MemberBodyOpen);
 
+        var extraArguments = FormatExtraArgs(group);
+
         for (var i = 0; i < group.Invocations.Length; i++)
         {
             var inv = group.Invocations[i];
-            var methodSuffix = CodeGeneratorHelpers.ComputeStableMethodSuffix(
-                inv.TargetTypeFullName,
-                inv.CallerFilePath,
-                inv.CallerLineNumber,
-                inv.TargetExpressionText);
             var pathSuffix = CodeGeneratorHelpers.ComputePathSuffix(inv.CallerFilePath);
             var condition = CodeGeneratorHelpers.ConditionKeyword(i);
 
             _ = sb.Append("            ").Append(condition).Append(" (callerLineNumber == ").Append(inv.CallerLineNumber).AppendLine()
                 .Append("                && callerFilePath.EndsWith(\"").Append(CodeGeneratorHelpers.EscapeString(pathSuffix)).Append("\", ")
-                .Append(OrdinalIgnoreCase).AppendLine("))").AppendLine(GeneratedSyntax.StatementBlockOpen).Append("                return __BindTo_").Append(methodSuffix)
-                .Append("(source, target").Append(FormatExtraArgs(group)).AppendLine(");").AppendLine("            }");
+                .Append(OrdinalIgnoreCase).AppendLine("))").AppendLine(GeneratedSyntax.StatementBlockOpen);
+            AppendWorkerInvocation(sb, ReturnStatementPrefix, BindToMethodSuffix(inv), extraArguments);
+            _ = sb.AppendLine("            }");
         }
 
         _ = sb.Append("            throw new ").Append(GeneratedTypeNames.InvalidOperationException).AppendLine("(").Append("                \"")
@@ -345,6 +352,71 @@ internal static class BindToCodeGenerator
 
         return sb.ToStringAndReturn();
     }
+
+    /// <summary>Emits one interceptor per generated binding, claiming every call site that reaches it.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="group">The group of call sites being claimed.</param>
+    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
+    private static void GenerateInterceptors(StringBuilder sb, BindToTypeGroup group, bool supportsNullable)
+    {
+        var extraArguments = FormatExtraArgs(group);
+
+        foreach (var entry in InterceptorEmitter.GroupCallSites(group.Invocations, static x => x.Interceptor, BindToMethodSuffix))
+        {
+            foreach (var callSite in entry.Value)
+            {
+                InterceptorEmitter.AppendAttribute(sb, callSite.Interceptor, InterceptorEmitter.MemberIndent);
+            }
+
+            _ = sb.Append("        internal static ").Append(GeneratedTypeNames.IDisposable).Append(" __Intercept_BindTo_")
+                .Append(entry.Key).AppendLine("(");
+
+            AppendBindToParameters(sb, group, supportsNullable, false);
+            AppendExtraParameters(sb, group);
+            InterceptorEmitter.CloseParameterList(sb);
+
+            AppendWorkerInvocation(sb, ForwardingBodyPrefix, entry.Key, extraArguments);
+            _ = sb.AppendLine();
+        }
+    }
+
+    /// <summary>Appends the observable, target and property parameters every generated <c>BindTo</c> member declares.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="group">The group whose types the parameters are written from.</param>
+    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
+    /// <param name="isExtensionMethod">Whether the observable parameter is the extension receiver.</param>
+    private static void AppendBindToParameters(
+        StringBuilder sb,
+        BindToTypeGroup group,
+        bool supportsNullable,
+        bool isExtensionMethod)
+    {
+        var targetPropType = CodeGeneratorHelpers.NullableSelectorLeafType(group.Invocations[0].TargetPropertyPath, supportsNullable);
+
+        _ = sb.Append(isExtensionMethod ? "            this " : "            ").Append(ObservableOf(group.SourceValueTypeFullName))
+            .AppendLine(" source,").Append("            ").Append(group.TargetTypeFullName).AppendLine(" target,")
+            .Append("            ").Append(PropertyExpression(group.TargetTypeFullName, targetPropType)).AppendLine(" property,");
+    }
+
+    /// <summary>Appends the call forwarding the bound stream and target on to the generated worker.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="prefix">The indentation and statement keyword the call sits behind.</param>
+    /// <param name="methodSuffix">The stable suffix naming the worker.</param>
+    /// <param name="extraArguments">The conversion-hint and converter-override arguments, if any.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AppendWorkerInvocation(StringBuilder sb, string prefix, string methodSuffix, string extraArguments) =>
+        sb.Append(prefix).Append("__BindTo_").Append(methodSuffix).Append("(source, target").Append(extraArguments).AppendLine(");");
+
+    /// <summary>Names the generated binding a call site reaches.</summary>
+    /// <param name="inv">The call site.</param>
+    /// <returns>The stable method-name suffix.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string BindToMethodSuffix(BindToInvocationInfo inv) =>
+        CodeGeneratorHelpers.ComputeStableMethodSuffix(
+            inv.TargetTypeFullName,
+            inv.CallerFilePath,
+            inv.CallerLineNumber,
+            inv.TargetExpressionText);
 
     /// <summary>Formats the conversion-hint and converter-override arguments handed to the runtime converter.</summary>
     /// <param name="inv">The invocation info.</param>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindingEmitterHelpers.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindingEmitterHelpers.cs
@@ -511,10 +511,6 @@ internal static class BindingEmitterHelpers
         bool supportsNullable,
         bool stubHasExpressionParameters)
     {
-        var first = group.Invocations[0];
-        var sourceLeaf = CodeGeneratorHelpers.NullableSelectorLeafType(first.SourcePropertyPath, supportsNullable);
-        var targetLeaf = CodeGeneratorHelpers.NullableSelectorLeafType(first.TargetPropertyPath, supportsNullable);
-
         CodeGeneratorHelpers.AppendDispatchSummary(
             sb,
             api.Name,
@@ -522,8 +518,49 @@ internal static class BindingEmitterHelpers
             group.TargetTypeFullName,
             dispatchesOnExpressionText);
 
-        _ = sb.Append("        public static ").Append(api.FormatReturnType(group)).Append(' ').Append(api.Name).AppendLine("(")
-            .Append("            this ").Append(api.ReceiverIsTarget ? group.TargetTypeFullName : group.SourceTypeFullName)
+        _ = sb.Append("        public static ").Append(api.FormatReturnType(group)).Append(' ').Append(api.Name).AppendLine("(");
+
+        AppendParameterList(sb, group, api, dispatchesOnExpressionText, supportsNullable, stubHasExpressionParameters);
+
+        _ = sb.AppendLine(GeneratedSyntax.MemberBodyOpen);
+
+        if (dispatchesOnExpressionText)
+        {
+            AppendExpressionDispatchBody(sb, group, api);
+        }
+        else
+        {
+            AppendCallerInfoDispatchBody(sb, group, api);
+        }
+
+        CodeGeneratorHelpers.AppendBindingDispatchFallthrough(sb);
+    }
+
+    /// <summary>Writes the parameters a binding member declares, closing the list.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="group">The binding type group.</param>
+    /// <param name="api">What distinguishes this API's output from the other three.</param>
+    /// <param name="dispatchesOnExpressionText">Whether the captured expression text is what identifies a call site.</param>
+    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
+    /// <param name="stubHasExpressionParameters">Whether the runtime stub declares the expression parameters.</param>
+    /// <remarks>
+    /// One list serves the overload and the interceptor, because both have to be the stub's signature: the
+    /// overload only wins resolution against a candidate it is otherwise indistinguishable from, and an
+    /// interceptor is refused outright unless its signature is the intercepted method's.
+    /// </remarks>
+    internal static void AppendParameterList(
+        StringBuilder sb,
+        BindingTypeGroup group,
+        BindingDispatchApi api,
+        bool dispatchesOnExpressionText,
+        bool supportsNullable,
+        bool stubHasExpressionParameters)
+    {
+        var first = group.Invocations[0];
+        var sourceLeaf = CodeGeneratorHelpers.NullableSelectorLeafType(first.SourcePropertyPath, supportsNullable);
+        var targetLeaf = CodeGeneratorHelpers.NullableSelectorLeafType(first.TargetPropertyPath, supportsNullable);
+
+        _ = sb.Append("            this ").Append(api.ReceiverIsTarget ? group.TargetTypeFullName : group.SourceTypeFullName)
             .Append(' ').Append(api.ReceiverParameterName).AppendLine(",")
             .Append(CodeGeneratorHelpers.ParameterIndent)
             .Append(api.ReceiverIsTarget ? group.SourceTypeFullName : group.TargetTypeFullName)
@@ -535,16 +572,13 @@ internal static class BindingEmitterHelpers
 
         api.AppendExtraParameters(sb, group);
 
-        if (dispatchesOnExpressionText)
+        if (dispatchesOnExpressionText || stubHasExpressionParameters)
         {
-            AppendExpressionDispatchBody(sb, group, api);
-        }
-        else
-        {
-            AppendCallerInfoDispatchBody(sb, group, api, stubHasExpressionParameters);
+            CodeGeneratorHelpers.AppendExpressionParameter(sb, api.SourceSelectorName, api.SourceExpressionParameter, dispatchesOnExpressionText);
+            CodeGeneratorHelpers.AppendExpressionParameter(sb, api.TargetSelectorName, api.TargetExpressionParameter, dispatchesOnExpressionText);
         }
 
-        CodeGeneratorHelpers.AppendBindingDispatchFallthrough(sb);
+        _ = sb.AppendLine(CodeGeneratorHelpers.CallerInfoParameterList);
     }
 
     /// <summary>Emits whichever of the two ways this group's call sites are reached.</summary>
@@ -564,7 +598,7 @@ internal static class BindingEmitterHelpers
     {
         if (features.SupportsInterceptors)
         {
-            GenerateInterceptors(sb, group, api, features.SupportsNullable);
+            GenerateInterceptors(sb, group, api, in features);
             return;
         }
 
@@ -581,43 +615,34 @@ internal static class BindingEmitterHelpers
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The binding type group.</param>
     /// <param name="api">What distinguishes this API's output from the other three.</param>
-    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
+    /// <param name="features">The consumer compilation's language-feature snapshot.</param>
     /// <remarks>
-    /// The signature is the overload's without the dispatch parameters: an interceptor is reached by name
-    /// rather than matched, so it takes only what the call site passes and forwards straight to the worker.
+    /// The signature is the overload's, because the compiler refuses an interceptor whose signature is not the
+    /// intercepted method's. What the interceptor does with it differs: the call site is already known, so the
+    /// dispatch parameters go unread and the body forwards straight to the worker.
     /// </remarks>
     internal static void GenerateInterceptors(
         StringBuilder sb,
         BindingTypeGroup group,
         BindingDispatchApi api,
-        bool supportsNullable)
+        in LanguageFeatures features)
     {
-        var first = group.Invocations[0];
-        var sourceLeaf = CodeGeneratorHelpers.NullableSelectorLeafType(first.SourcePropertyPath, supportsNullable);
-        var targetLeaf = CodeGeneratorHelpers.NullableSelectorLeafType(first.TargetPropertyPath, supportsNullable);
         var extraArguments = api.FormatExtraArguments(group);
+        var dispatchesOnExpressionText = features.SupportsCallerArgExpr;
+        var supportsNullable = features.SupportsNullable;
+        var stubHasExpressionParameters = features.StubHasExpressionParameters;
 
         foreach (var entry in GroupCallSitesByWorker(group))
         {
             foreach (var callSite in entry.Value)
             {
-                InterceptorEmitter.AppendAttribute(sb, callSite.Interceptor, "        ");
+                InterceptorEmitter.AppendAttribute(sb, callSite.Interceptor, InterceptorEmitter.MemberIndent);
             }
 
             _ = sb.Append("        internal static ").Append(api.FormatReturnType(group)).Append(" __Intercept_")
-                .Append(api.Name).Append('_').Append(entry.Key).AppendLine("(")
-                .Append("            ").Append(api.ReceiverIsTarget ? group.TargetTypeFullName : group.SourceTypeFullName)
-                .Append(' ').Append(api.ReceiverParameterName).AppendLine(",")
-                .Append(CodeGeneratorHelpers.ParameterIndent)
-                .Append(api.ReceiverIsTarget ? group.SourceTypeFullName : group.TargetTypeFullName)
-                .Append(' ').Append(api.OtherParameterName).AppendLine(",")
-                .Append(GeneratedSyntax.SelectorParameterOpen).Append(group.SourceTypeFullName).Append(", ").Append(sourceLeaf)
-                .Append(">> ").Append(api.SourceSelectorName).AppendLine(",")
-                .Append(GeneratedSyntax.SelectorParameterOpen).Append(group.TargetTypeFullName).Append(", ").Append(targetLeaf)
-                .Append(">> ").Append(api.TargetSelectorName).AppendLine(",");
+                .Append(api.Name).Append('_').Append(entry.Key).AppendLine("(");
 
-            api.AppendExtraParameters(sb, group);
-            InterceptorEmitter.CloseParameterList(sb);
+            AppendParameterList(sb, group, api, dispatchesOnExpressionText, supportsNullable, stubHasExpressionParameters);
 
             _ = sb.Append("            => ").Append(api.WorkerMethodPrefix).Append(entry.Key).Append('(')
                 .Append(api.WorkerArguments).Append(extraArguments).AppendLine(");").AppendLine();
@@ -758,8 +783,6 @@ internal static class BindingEmitterHelpers
     /// <param name="api">What distinguishes this API's overload from the other three.</param>
     private static void AppendExpressionDispatchBody(StringBuilder sb, BindingTypeGroup group, BindingDispatchApi api)
     {
-        CodeGeneratorHelpers.AppendExpressionDispatchParameters(sb, api.SourceSelectorName, api.TargetSelectorName);
-
         if (api.NormalizesStaticPrefix)
         {
             CodeGeneratorHelpers.AppendStaticPrefixNormalization(sb, api.SourceExpressionParameter);
@@ -791,21 +814,11 @@ internal static class BindingEmitterHelpers
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The binding type group.</param>
     /// <param name="api">What distinguishes this API's overload from the other three.</param>
-    /// <param name="stubHasExpressionParameters">Whether the runtime stub declares the expression parameters this overload has to match.</param>
     private static void AppendCallerInfoDispatchBody(
         StringBuilder sb,
         BindingTypeGroup group,
-        BindingDispatchApi api,
-        bool stubHasExpressionParameters)
+        BindingDispatchApi api)
     {
-        if (stubHasExpressionParameters)
-        {
-            CodeGeneratorHelpers.AppendExpressionParameter(sb, api.SourceSelectorName, api.SourceExpressionParameter, false);
-            CodeGeneratorHelpers.AppendExpressionParameter(sb, api.TargetSelectorName, api.TargetExpressionParameter, false);
-        }
-
-        CodeGeneratorHelpers.AppendCallerInfoDispatchParameters(sb);
-
         var extraArguments = api.FormatExtraArguments(group);
 
         for (var i = 0; i < group.Invocations.Length; i++)

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindingEmitterHelpers.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindingEmitterHelpers.cs
@@ -547,6 +547,83 @@ internal static class BindingEmitterHelpers
         CodeGeneratorHelpers.AppendBindingDispatchFallthrough(sb);
     }
 
+    /// <summary>Emits whichever of the two ways this group's call sites are reached.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="group">The binding type group.</param>
+    /// <param name="api">What distinguishes this API's output from the other three.</param>
+    /// <param name="features">The consumer compilation's language-feature snapshot.</param>
+    /// <remarks>
+    /// The four APIs choose between the same two shapes on the same condition, so the choice is made here
+    /// rather than repeated at each of their four call sites.
+    /// </remarks>
+    internal static void EmitOverloadOrInterceptors(
+        StringBuilder sb,
+        BindingTypeGroup group,
+        BindingDispatchApi api,
+        in LanguageFeatures features)
+    {
+        if (features.SupportsInterceptors)
+        {
+            GenerateInterceptors(sb, group, api, features.SupportsNullable);
+            return;
+        }
+
+        GenerateDispatchOverload(
+            sb,
+            group,
+            api,
+            features.SupportsCallerArgExpr,
+            features.SupportsNullable,
+            features.StubHasExpressionParameters);
+    }
+
+    /// <summary>Emits one interceptor per generated worker, claiming every call site that reaches it.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="group">The binding type group.</param>
+    /// <param name="api">What distinguishes this API's output from the other three.</param>
+    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
+    /// <remarks>
+    /// The signature is the overload's without the dispatch parameters: an interceptor is reached by name
+    /// rather than matched, so it takes only what the call site passes and forwards straight to the worker.
+    /// </remarks>
+    internal static void GenerateInterceptors(
+        StringBuilder sb,
+        BindingTypeGroup group,
+        BindingDispatchApi api,
+        bool supportsNullable)
+    {
+        var first = group.Invocations[0];
+        var sourceLeaf = CodeGeneratorHelpers.NullableSelectorLeafType(first.SourcePropertyPath, supportsNullable);
+        var targetLeaf = CodeGeneratorHelpers.NullableSelectorLeafType(first.TargetPropertyPath, supportsNullable);
+        var extraArguments = api.FormatExtraArguments(group);
+
+        foreach (var entry in GroupCallSitesByWorker(group))
+        {
+            foreach (var callSite in entry.Value)
+            {
+                InterceptorEmitter.AppendAttribute(sb, callSite.Interceptor, "        ");
+            }
+
+            _ = sb.Append("        internal static ").Append(api.FormatReturnType(group)).Append(" __Intercept_")
+                .Append(api.Name).Append('_').Append(entry.Key).AppendLine("(")
+                .Append("            ").Append(api.ReceiverIsTarget ? group.TargetTypeFullName : group.SourceTypeFullName)
+                .Append(' ').Append(api.ReceiverParameterName).AppendLine(",")
+                .Append(CodeGeneratorHelpers.ParameterIndent)
+                .Append(api.ReceiverIsTarget ? group.SourceTypeFullName : group.TargetTypeFullName)
+                .Append(' ').Append(api.OtherParameterName).AppendLine(",")
+                .Append(GeneratedSyntax.SelectorParameterOpen).Append(group.SourceTypeFullName).Append(", ").Append(sourceLeaf)
+                .Append(">> ").Append(api.SourceSelectorName).AppendLine(",")
+                .Append(GeneratedSyntax.SelectorParameterOpen).Append(group.TargetTypeFullName).Append(", ").Append(targetLeaf)
+                .Append(">> ").Append(api.TargetSelectorName).AppendLine(",");
+
+            api.AppendExtraParameters(sb, group);
+            InterceptorEmitter.CloseParameterList(sb);
+
+            _ = sb.Append("            => ").Append(api.WorkerMethodPrefix).Append(entry.Key).Append('(')
+                .Append(api.WorkerArguments).Append(extraArguments).AppendLine(");").AppendLine();
+        }
+    }
+
     /// <summary>Emits the head of a generated worker: its signature, the path it binds, and the hook guard.</summary>
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="api">What distinguishes this API's worker from the other three.</param>
@@ -632,6 +709,37 @@ internal static class BindingEmitterHelpers
         }
 
         return new(sourceVar, targetVar);
+    }
+
+    /// <summary>Gathers the call sites of a group under the worker each of them reaches.</summary>
+    /// <param name="group">The binding type group whose call sites are being gathered.</param>
+    /// <returns>Each generated worker, against every call site that resolves to it.</returns>
+    /// <remarks>
+    /// A call site the compiler declined to describe is left out: nothing can claim it, and it keeps whatever
+    /// the call already resolved to.
+    /// </remarks>
+    private static Dictionary<string, List<BindingInvocationInfo>> GroupCallSitesByWorker(BindingTypeGroup group)
+    {
+        var claimed = new Dictionary<string, List<BindingInvocationInfo>>(StringComparer.Ordinal);
+        for (var i = 0; i < group.Invocations.Length; i++)
+        {
+            var inv = group.Invocations[i];
+            if (!inv.Interceptor.IsAvailable)
+            {
+                continue;
+            }
+
+            var suffix = BindingMethodSuffix(inv);
+            if (!claimed.TryGetValue(suffix, out var callSites))
+            {
+                callSites = [];
+                claimed[suffix] = callSites;
+            }
+
+            callSites.Add(inv);
+        }
+
+        return claimed;
     }
 
     /// <summary>Finds the type a view declares its view model property as.</summary>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindingEmitterHelpers.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindingEmitterHelpers.cs
@@ -718,29 +718,9 @@ internal static class BindingEmitterHelpers
     /// A call site the compiler declined to describe is left out: nothing can claim it, and it keeps whatever
     /// the call already resolved to.
     /// </remarks>
-    private static Dictionary<string, List<BindingInvocationInfo>> GroupCallSitesByWorker(BindingTypeGroup group)
-    {
-        var claimed = new Dictionary<string, List<BindingInvocationInfo>>(StringComparer.Ordinal);
-        for (var i = 0; i < group.Invocations.Length; i++)
-        {
-            var inv = group.Invocations[i];
-            if (!inv.Interceptor.IsAvailable)
-            {
-                continue;
-            }
-
-            var suffix = BindingMethodSuffix(inv);
-            if (!claimed.TryGetValue(suffix, out var callSites))
-            {
-                callSites = [];
-                claimed[suffix] = callSites;
-            }
-
-            callSites.Add(inv);
-        }
-
-        return claimed;
-    }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Dictionary<string, List<BindingInvocationInfo>> GroupCallSitesByWorker(BindingTypeGroup group) =>
+        InterceptorEmitter.GroupCallSites(group.Invocations, static x => x.Interceptor, BindingMethodSuffix);
 
     /// <summary>Finds the type a view declares its view model property as.</summary>
     /// <param name="targetClassInfo">The view type's binding info.</param>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/CodeGeneratorHelpers.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/CodeGeneratorHelpers.cs
@@ -29,6 +29,17 @@ internal static class CodeGeneratorHelpers
     /// <summary>Completes the name of the parameter that captures a selector's expression text.</summary>
     internal const string ExpressionParameterSuffix = "Expression";
 
+    /// <summary>The caller-info parameters every runtime stub ends with, closing the parameter list.</summary>
+    /// <remarks>
+    /// Emitted by the interceptors as well as the dispatch overloads. The stub declares them, so both have to:
+    /// an overload that omits them is merely applicable rather than better, and an interceptor that omits them
+    /// is refused as a signature that is not the intercepted method's.
+    /// </remarks>
+    internal const string CallerInfoParameterList = """
+                    [global::System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = "",
+                    [global::System.Runtime.CompilerServices.CallerLineNumber] int callerLineNumber = 0)
+        """;
+
     /// <summary>Buffer capacity to reserve per property-path segment when building an access chain.</summary>
     private const int PerPathSegmentCapacity = 16;
 
@@ -597,32 +608,6 @@ internal static class CodeGeneratorHelpers
                 ? "        /// Uses CallerArgumentExpression for dispatch."
                 : "        /// Uses CallerFilePath + CallerLineNumber for dispatch.")
             .AppendLine("        /// </summary>");
-
-    /// <summary>Appends the expression-text parameters a dispatch overload keys on, and opens its body.</summary>
-    /// <param name="sb">The string builder to append to.</param>
-    /// <param name="firstSelectorName">The name of the first selector parameter.</param>
-    /// <param name="secondSelectorName">The name of the second selector parameter.</param>
-    internal static void AppendExpressionDispatchParameters(
-        StringBuilder sb,
-        string firstSelectorName,
-        string secondSelectorName)
-    {
-        AppendExpressionParameter(sb, firstSelectorName, firstSelectorName + ExpressionParameterSuffix, true);
-        AppendExpressionParameter(sb, secondSelectorName, secondSelectorName + ExpressionParameterSuffix, true);
-        AppendCallerInfoDispatchParameters(sb);
-    }
-
-    /// <summary>Appends the file and line parameters every dispatch overload carries, and opens its body.</summary>
-    /// <param name="sb">The string builder to append to.</param>
-    /// <remarks>
-    /// They are declared whether or not dispatch uses them, because the concrete overload only beats the
-    /// generic stub once their parameter lists match.
-    /// </remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void AppendCallerInfoDispatchParameters(StringBuilder sb) =>
-        sb.AppendLine("            [global::System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = \"\",")
-            .AppendLine("            [global::System.Runtime.CompilerServices.CallerLineNumber] int callerLineNumber = 0)")
-            .AppendLine(GeneratedSyntax.MemberBodyOpen);
 
     /// <summary>Appends the strip that takes the <c>static</c> prefix off a captured expression.</summary>
     /// <param name="sb">The string builder to append to.</param>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/InterceptorEmitter.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/InterceptorEmitter.cs
@@ -70,4 +70,104 @@ internal static class InterceptorEmitter
 
         return PooledBuilder.ToStringAndReturn(builder);
     }
+
+    /// <summary>Emits one interceptor per generated body, claiming every call site that reaches it.</summary>
+    /// <param name="builder">The string builder to append to.</param>
+    /// <param name="group">The type group whose call sites are being claimed.</param>
+    /// <param name="methodPrefix">The method name prefix the generated bodies carry.</param>
+    /// <param name="suffixOf">Names the body a call site reaches.</param>
+    /// <param name="appendParameters">Writes the parameters after the receiver, closing the list.</param>
+    /// <remarks>
+    /// The grouping and the attribute are the whole of what every API shares here, so they live in one place
+    /// and each API supplies only the signature it is being called with. Call sites that reach one body are
+    /// claimed by one method carrying an attribute each, which is what the attribute allowing repeats is for.
+    /// </remarks>
+    internal static void GenerateInterceptors(
+        StringBuilder builder,
+        ObservationCodeGenerator.TypeGroup group,
+        string methodPrefix,
+        Func<InvocationInfo, string> suffixOf,
+        Action<StringBuilder, InvocationInfo> appendParameters)
+    {
+        foreach (var entry in GroupCallSitesByBody(group, suffixOf))
+        {
+            var first = entry.Value[0];
+
+            foreach (var callSite in entry.Value)
+            {
+                AppendAttribute(builder, callSite.Interceptor, "        ");
+            }
+
+            _ = builder.Append("        internal static global::System.IObservable<").Append(first.ReturnTypeFullName)
+                .Append("> __Intercept_").Append(methodPrefix).Append('_').Append(entry.Key).AppendLine("(")
+                .Append("            ").Append(first.SourceTypeFullName).AppendLine(" objectToMonitor,");
+
+            appendParameters(builder, first);
+
+            _ = builder.Append("            => __").Append(methodPrefix).Append('_').Append(entry.Key)
+                .Append("(objectToMonitor").Append(first.HasSelector ? ", selector" : string.Empty).AppendLine(");");
+        }
+    }
+
+    /// <summary>Emits the observed-property parameters, and the projection when the overload takes one.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="first">The invocation whose types the parameters are written from.</param>
+    /// <param name="propCount">How many observed properties the overload takes.</param>
+    /// <param name="selectorType">The projection's type, or <see langword="null"/> when it takes none.</param>
+    internal static void AppendPropertyParameters(
+        StringBuilder sb,
+        InvocationInfo first,
+        int propCount,
+        string? selectorType)
+    {
+        var hasSelector = selectorType is not null;
+        for (var i = 0; i < propCount; i++)
+        {
+            var type = first.PropertyPaths[i][first.PropertyPaths[i].Length - 1].PropertyTypeFullName;
+            _ = sb.Append("            global::System.Linq.Expressions.Expression<global::System.Func<")
+                .Append(first.SourceTypeFullName).Append(", ").Append(type).Append(">> property").Append(i + 1);
+            _ = hasSelector || i < propCount - 1 ? sb.AppendLine(",") : sb.AppendLine(")");
+        }
+
+        if (!hasSelector)
+        {
+            return;
+        }
+
+        _ = sb.Append("            ").Append(selectorType).AppendLine(" selector)");
+    }
+
+    /// <summary>Gathers the call sites of a group under the body each of them reaches.</summary>
+    /// <param name="group">The type group whose call sites are being gathered.</param>
+    /// <param name="suffixOf">Names the body a call site reaches.</param>
+    /// <returns>Each generated body, against every call site that resolves to it.</returns>
+    /// <remarks>
+    /// A call site the compiler declined to describe is left out: nothing can claim it, and it keeps whatever
+    /// the call already resolved to.
+    /// </remarks>
+    private static Dictionary<string, List<InvocationInfo>> GroupCallSitesByBody(
+        ObservationCodeGenerator.TypeGroup group,
+        Func<InvocationInfo, string> suffixOf)
+    {
+        var claimed = new Dictionary<string, List<InvocationInfo>>(StringComparer.Ordinal);
+        for (var i = 0; i < group.Invocations.Length; i++)
+        {
+            var inv = group.Invocations[i];
+            if (!inv.Interceptor.IsAvailable)
+            {
+                continue;
+            }
+
+            var suffix = suffixOf(inv);
+            if (!claimed.TryGetValue(suffix, out var callSites))
+            {
+                callSites = [];
+                claimed[suffix] = callSites;
+            }
+
+            callSites.Add(inv);
+        }
+
+        return claimed;
+    }
 }

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/InterceptorEmitter.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/InterceptorEmitter.cs
@@ -137,6 +137,28 @@ internal static class InterceptorEmitter
         _ = sb.Append("            ").Append(selectorType).AppendLine(" selector)");
     }
 
+    /// <summary>Closes a parameter list whose last entry was written expecting another to follow.</summary>
+    /// <param name="builder">The builder whose trailing separator becomes the closing parenthesis.</param>
+    /// <remarks>
+    /// The parameter writers are shared with the dispatch overloads, which always have the caller-info
+    /// parameters coming after, so each entry ends in a separator. An interceptor takes none of those, so the
+    /// last separator written is the one that has to close the list instead.
+    /// </remarks>
+    internal static void CloseParameterList(StringBuilder builder)
+    {
+        for (var i = builder.Length - 1; i >= 0; i--)
+        {
+            if (builder[i] != ',')
+            {
+                continue;
+            }
+
+            builder.Length = i;
+            _ = builder.AppendLine(")");
+            return;
+        }
+    }
+
     /// <summary>Gathers the call sites of a group under the body each of them reaches.</summary>
     /// <param name="group">The type group whose call sites are being gathered.</param>
     /// <param name="suffixOf">Names the body a call site reaches.</param>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/InterceptorEmitter.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/InterceptorEmitter.cs
@@ -29,6 +29,12 @@ internal static class InterceptorEmitter
     /// <summary>Room for the declaration, which is a fixed block of text.</summary>
     private const int DeclarationCapacity = 640;
 
+    /// <summary>Writes the parameter list one API's members declare, closing it.</summary>
+    /// <param name="builder">The string builder to append to.</param>
+    /// <param name="first">The invocation whose types the parameters are written from.</param>
+    /// <param name="features">The consumer compilation's language-feature snapshot.</param>
+    internal delegate void ParameterListWriter(StringBuilder builder, InvocationInfo first, in LanguageFeatures features);
+
     /// <summary>Writes the attribute that binds a generated method to one call site.</summary>
     /// <param name="builder">The builder receiving the attribute line.</param>
     /// <param name="location">The call site the compiler described.</param>
@@ -80,18 +86,24 @@ internal static class InterceptorEmitter
     /// <param name="group">The type group whose call sites are being claimed.</param>
     /// <param name="methodPrefix">The method name prefix the generated bodies carry.</param>
     /// <param name="suffixOf">Names the body a call site reaches.</param>
+    /// <param name="features">The consumer compilation's language-feature snapshot, handed to the writer.</param>
     /// <param name="appendParameterList">Writes the whole parameter list, closing it.</param>
     /// <remarks>
     /// The grouping and the attribute are the whole of what every API shares here, so they live in one place
     /// and each API supplies only the signature it is being called with. Call sites that reach one body are
     /// claimed by one method carrying an attribute each, which is what the attribute allowing repeats is for.
+    /// <para>
+    /// The feature snapshot travels as an argument rather than being closed over, so the writer each API hands
+    /// in captures nothing and the compiler caches one delegate for the whole compilation.
+    /// </para>
     /// </remarks>
     internal static void GenerateInterceptors(
         StringBuilder builder,
         ObservationCodeGenerator.TypeGroup group,
         string methodPrefix,
         Func<InvocationInfo, string> suffixOf,
-        Action<StringBuilder, InvocationInfo> appendParameterList)
+        in LanguageFeatures features,
+        ParameterListWriter appendParameterList)
     {
         foreach (var entry in GroupCallSitesByBody(group, suffixOf))
         {
@@ -105,7 +117,7 @@ internal static class InterceptorEmitter
             _ = builder.Append("        internal static global::System.IObservable<").Append(first.ReturnTypeFullName)
                 .Append("> __Intercept_").Append(methodPrefix).Append('_').Append(entry.Key).AppendLine("(");
 
-            appendParameterList(builder, first);
+            appendParameterList(builder, first, in features);
 
             _ = builder.Append("            => __").Append(methodPrefix).Append('_').Append(entry.Key)
                 .Append("(objectToMonitor").Append(first.HasSelector ? ", selector" : string.Empty).AppendLine(");").AppendLine();

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/InterceptorEmitter.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/InterceptorEmitter.cs
@@ -80,7 +80,7 @@ internal static class InterceptorEmitter
     /// <param name="group">The type group whose call sites are being claimed.</param>
     /// <param name="methodPrefix">The method name prefix the generated bodies carry.</param>
     /// <param name="suffixOf">Names the body a call site reaches.</param>
-    /// <param name="appendParameters">Writes the parameters after the receiver, closing the list.</param>
+    /// <param name="appendParameterList">Writes the whole parameter list, closing it.</param>
     /// <remarks>
     /// The grouping and the attribute are the whole of what every API shares here, so they live in one place
     /// and each API supplies only the signature it is being called with. Call sites that reach one body are
@@ -91,7 +91,7 @@ internal static class InterceptorEmitter
         ObservationCodeGenerator.TypeGroup group,
         string methodPrefix,
         Func<InvocationInfo, string> suffixOf,
-        Action<StringBuilder, InvocationInfo> appendParameters)
+        Action<StringBuilder, InvocationInfo> appendParameterList)
     {
         foreach (var entry in GroupCallSitesByBody(group, suffixOf))
         {
@@ -103,63 +103,12 @@ internal static class InterceptorEmitter
             }
 
             _ = builder.Append("        internal static global::System.IObservable<").Append(first.ReturnTypeFullName)
-                .Append("> __Intercept_").Append(methodPrefix).Append('_').Append(entry.Key).AppendLine("(")
-                .Append("            ").Append(first.SourceTypeFullName).AppendLine(" objectToMonitor,");
+                .Append("> __Intercept_").Append(methodPrefix).Append('_').Append(entry.Key).AppendLine("(");
 
-            appendParameters(builder, first);
+            appendParameterList(builder, first);
 
             _ = builder.Append("            => __").Append(methodPrefix).Append('_').Append(entry.Key)
-                .Append("(objectToMonitor").Append(first.HasSelector ? ", selector" : string.Empty).AppendLine(");");
-        }
-    }
-
-    /// <summary>Emits the observed-property parameters, and the projection when the overload takes one.</summary>
-    /// <param name="sb">The string builder to append to.</param>
-    /// <param name="first">The invocation whose types the parameters are written from.</param>
-    /// <param name="propCount">How many observed properties the overload takes.</param>
-    /// <param name="selectorType">The projection's type, or <see langword="null"/> when it takes none.</param>
-    internal static void AppendPropertyParameters(
-        StringBuilder sb,
-        InvocationInfo first,
-        int propCount,
-        string? selectorType)
-    {
-        var hasSelector = selectorType is not null;
-        for (var i = 0; i < propCount; i++)
-        {
-            var type = first.PropertyPaths[i][first.PropertyPaths[i].Length - 1].PropertyTypeFullName;
-            _ = sb.Append("            global::System.Linq.Expressions.Expression<global::System.Func<")
-                .Append(first.SourceTypeFullName).Append(", ").Append(type).Append(">> property").Append(i + 1);
-            _ = hasSelector || i < propCount - 1 ? sb.AppendLine(",") : sb.AppendLine(")");
-        }
-
-        if (!hasSelector)
-        {
-            return;
-        }
-
-        _ = sb.Append("            ").Append(selectorType).AppendLine(" selector)");
-    }
-
-    /// <summary>Closes a parameter list whose last entry was written expecting another to follow.</summary>
-    /// <param name="builder">The builder whose trailing separator becomes the closing parenthesis.</param>
-    /// <remarks>
-    /// The parameter writers are shared with the dispatch overloads, which always have the caller-info
-    /// parameters coming after, so each entry ends in a separator. An interceptor takes none of those, so the
-    /// last separator written is the one that has to close the list instead.
-    /// </remarks>
-    internal static void CloseParameterList(StringBuilder builder)
-    {
-        for (var i = builder.Length - 1; i >= 0; i--)
-        {
-            if (builder[i] != ',')
-            {
-                continue;
-            }
-
-            builder.Length = i;
-            _ = builder.AppendLine(")");
-            return;
+                .Append("(objectToMonitor").Append(first.HasSelector ? ", selector" : string.Empty).AppendLine(");").AppendLine();
         }
     }
 

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/InterceptorEmitter.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/InterceptorEmitter.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Text;
+using ReactiveUI.Binding.SourceGenerators.Models;
+
+namespace ReactiveUI.Binding.SourceGenerators.CodeGeneration;
+
+/// <summary>
+/// Writes the one thing every intercepted call site needs, whichever API it belongs to: the attribute naming
+/// the call, and the declaration of that attribute.
+/// </summary>
+/// <remarks>
+/// An interceptor redirects a call the compiler has already bound, so nothing about it depends on which API is
+/// being generated - only on where the call is and what it should run instead. That is why every generator
+/// shares this rather than growing its own copy, and why the tier needs none of the namespace placement the
+/// dispatch overloads do: lookup never sees an interceptor.
+/// </remarks>
+internal static class InterceptorEmitter
+{
+    /// <summary>The attribute a generated method carries to claim a call site.</summary>
+    private const string AttributeName = "global::System.Runtime.CompilerServices.InterceptsLocation";
+
+    /// <summary>Room for the declaration, which is a fixed block of text.</summary>
+    private const int DeclarationCapacity = 640;
+
+    /// <summary>Writes the attribute that binds a generated method to one call site.</summary>
+    /// <param name="builder">The builder receiving the attribute line.</param>
+    /// <param name="location">The call site the compiler described.</param>
+    /// <param name="indent">The indentation the enclosing class is written at.</param>
+    internal static void AppendAttribute(StringBuilder builder, in InterceptorLocation location, string indent) =>
+        _ = builder.Append(indent)
+            .Append('[')
+            .Append(AttributeName)
+            .Append('(')
+            .Append(location.Version)
+            .Append(", \"")
+            .Append(location.Data)
+            .AppendLine("\")]");
+
+    /// <summary>Builds the declaration of the interception attribute.</summary>
+    /// <returns>The source of a file declaring the attribute.</returns>
+    /// <remarks>
+    /// The attribute is not part of any framework, so the compiler expects the consumer's own compilation to
+    /// declare it. It is emitted once for the whole compilation rather than per dispatch file, which would
+    /// declare the same type repeatedly, and it is written to the rules the oldest supported consumer parses:
+    /// no file-scoped namespace, no file-local type.
+    /// </remarks>
+    internal static string BuildAttributeDeclaration()
+    {
+        var builder = PooledBuilder.Rent(DeclarationCapacity);
+
+        _ = builder.AppendLine("namespace System.Runtime.CompilerServices")
+            .AppendLine("{")
+            .AppendLine("    /// <summary>Binds a generated method to the call site it replaces.</summary>")
+            .AppendLine("    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]")
+            .AppendLine("    internal sealed class InterceptsLocationAttribute : global::System.Attribute")
+            .AppendLine("    {")
+            .AppendLine("        /// <summary>Initializes a new instance of the <see cref=\"InterceptsLocationAttribute\"/> class.</summary>")
+            .AppendLine("        /// <param name=\"version\">The encoding of <paramref name=\"data\"/>.</param>")
+            .AppendLine("        /// <param name=\"data\">The call site being replaced.</param>")
+            .AppendLine("        public InterceptsLocationAttribute(int version, string data)")
+            .AppendLine("        {")
+            .AppendLine("            _ = version;")
+            .AppendLine("            _ = data;")
+            .AppendLine("        }")
+            .AppendLine("    }")
+            .AppendLine("}");
+
+        return PooledBuilder.ToStringAndReturn(builder);
+    }
+}

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/InterceptorEmitter.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/InterceptorEmitter.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using System.Text;
 using ReactiveUI.Binding.SourceGenerators.Models;
 
@@ -19,6 +20,9 @@ namespace ReactiveUI.Binding.SourceGenerators.CodeGeneration;
 /// </remarks>
 internal static class InterceptorEmitter
 {
+    /// <summary>The indentation a member of the generated class is written at.</summary>
+    internal const string MemberIndent = "        ";
+
     /// <summary>The attribute a generated method carries to claim a call site.</summary>
     private const string AttributeName = "global::System.Runtime.CompilerServices.InterceptsLocation";
 
@@ -95,7 +99,7 @@ internal static class InterceptorEmitter
 
             foreach (var callSite in entry.Value)
             {
-                AppendAttribute(builder, callSite.Interceptor, "        ");
+                AppendAttribute(builder, callSite.Interceptor, MemberIndent);
             }
 
             _ = builder.Append("        internal static global::System.IObservable<").Append(first.ReturnTypeFullName)
@@ -159,6 +163,44 @@ internal static class InterceptorEmitter
         }
     }
 
+    /// <summary>Gathers call sites under the generated method each of them reaches.</summary>
+    /// <typeparam name="T">The per-call-site model this API extracts.</typeparam>
+    /// <param name="invocations">The call sites of one group.</param>
+    /// <param name="locationOf">Reads where a call site is.</param>
+    /// <param name="suffixOf">Names the generated method a call site reaches.</param>
+    /// <returns>Each generated method, against every call site that resolves to it.</returns>
+    /// <remarks>
+    /// Every API claims its call sites the same way, so the gathering is written once over whatever model the
+    /// API happens to carry. A call site the compiler declined to describe is left out: nothing can claim it,
+    /// and it keeps whatever the call already resolved to.
+    /// </remarks>
+    internal static Dictionary<string, List<T>> GroupCallSites<T>(
+        IReadOnlyList<T> invocations,
+        Func<T, InterceptorLocation> locationOf,
+        Func<T, string> suffixOf)
+    {
+        var claimed = new Dictionary<string, List<T>>(StringComparer.Ordinal);
+        for (var i = 0; i < invocations.Count; i++)
+        {
+            var invocation = invocations[i];
+            if (!locationOf(invocation).IsAvailable)
+            {
+                continue;
+            }
+
+            var suffix = suffixOf(invocation);
+            if (!claimed.TryGetValue(suffix, out var callSites))
+            {
+                callSites = [];
+                claimed[suffix] = callSites;
+            }
+
+            callSites.Add(invocation);
+        }
+
+        return claimed;
+    }
+
     /// <summary>Gathers the call sites of a group under the body each of them reaches.</summary>
     /// <param name="group">The type group whose call sites are being gathered.</param>
     /// <param name="suffixOf">Names the body a call site reaches.</param>
@@ -167,29 +209,9 @@ internal static class InterceptorEmitter
     /// A call site the compiler declined to describe is left out: nothing can claim it, and it keeps whatever
     /// the call already resolved to.
     /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Dictionary<string, List<InvocationInfo>> GroupCallSitesByBody(
         ObservationCodeGenerator.TypeGroup group,
-        Func<InvocationInfo, string> suffixOf)
-    {
-        var claimed = new Dictionary<string, List<InvocationInfo>>(StringComparer.Ordinal);
-        for (var i = 0; i < group.Invocations.Length; i++)
-        {
-            var inv = group.Invocations[i];
-            if (!inv.Interceptor.IsAvailable)
-            {
-                continue;
-            }
-
-            var suffix = suffixOf(inv);
-            if (!claimed.TryGetValue(suffix, out var callSites))
-            {
-                callSites = [];
-                claimed[suffix] = callSites;
-            }
-
-            callSites.Add(inv);
-        }
-
-        return claimed;
-    }
+        Func<InvocationInfo, string> suffixOf) =>
+        GroupCallSites(group.Invocations, static x => x.Interceptor, suffixOf);
 }

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs
@@ -989,86 +989,16 @@ internal static class ObservationCodeGenerator
     /// each. A call site the compiler declined to describe is left alone: it keeps whatever the call already
     /// resolved to, which is the same outcome an unreachable dispatch overload produces.
     /// </remarks>
-    private static void GenerateInterceptors(StringBuilder sb, TypeGroup group, string methodPrefix)
-    {
-        foreach (var entry in GroupCallSitesByObservation(group))
-        {
-            var first = entry.Value[0];
-            var propCount = first.PropertyPaths.Length;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void GenerateInterceptors(StringBuilder sb, TypeGroup group, string methodPrefix) =>
+        InterceptorEmitter.GenerateInterceptors(sb, group, methodPrefix, MethodSuffix, AppendObservationParameters);
 
-            foreach (var callSite in entry.Value)
-            {
-                InterceptorEmitter.AppendAttribute(sb, callSite.Interceptor, "        ");
-            }
-
-            _ = sb.Append("        internal static global::System.IObservable<").Append(first.ReturnTypeFullName)
-                .Append("> __Intercept_").Append(methodPrefix).Append('_').Append(entry.Key).AppendLine("(")
-                .Append("            ").Append(first.SourceTypeFullName).AppendLine(" objectToMonitor,");
-
-            AppendPropertyParameters(sb, first, propCount, first.HasSelector);
-
-            _ = sb.Append("            => __").Append(methodPrefix).Append('_').Append(entry.Key)
-                .Append("(objectToMonitor").Append(first.HasSelector ? ", selector" : string.Empty).AppendLine(");");
-        }
-    }
-
-    /// <summary>Gathers the call sites of a group under the observation each of them reaches.</summary>
-    /// <param name="group">The type group whose call sites are being gathered.</param>
-    /// <returns>Each generated observation, against every call site that resolves to it.</returns>
-    /// <remarks>
-    /// A call site the compiler declined to describe is left out: nothing can claim it, and it keeps whatever
-    /// the call already resolved to.
-    /// </remarks>
-    private static Dictionary<string, List<InvocationInfo>> GroupCallSitesByObservation(TypeGroup group)
-    {
-        var claimed = new Dictionary<string, List<InvocationInfo>>(StringComparer.Ordinal);
-        for (var i = 0; i < group.Invocations.Length; i++)
-        {
-            var inv = group.Invocations[i];
-            if (!inv.Interceptor.IsAvailable)
-            {
-                continue;
-            }
-
-            var suffix = MethodSuffix(inv);
-            if (!claimed.TryGetValue(suffix, out var callSites))
-            {
-                callSites = [];
-                claimed[suffix] = callSites;
-            }
-
-            callSites.Add(inv);
-        }
-
-        return claimed;
-    }
-
-    /// <summary>Emits the observed-property parameters, and the projection when the overload takes one.</summary>
+    /// <summary>Writes the observed-property parameters an observation overload takes.</summary>
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="first">The invocation whose types the parameters are written from.</param>
-    /// <param name="propCount">How many observed properties the overload takes.</param>
-    /// <param name="hasSelector">Whether the overload takes a projection after them.</param>
-    private static void AppendPropertyParameters(
-        StringBuilder sb,
-        InvocationInfo first,
-        int propCount,
-        bool hasSelector)
-    {
-        for (var i = 0; i < propCount; i++)
-        {
-            var type = first.PropertyPaths[i][first.PropertyPaths[i].Length - 1].PropertyTypeFullName;
-            _ = sb.Append("            global::System.Linq.Expressions.Expression<global::System.Func<")
-                .Append(first.SourceTypeFullName).Append(", ").Append(type).Append(">> property").Append(i + 1);
-            _ = hasSelector || i < propCount - 1 ? sb.AppendLine(",") : sb.AppendLine(")");
-        }
-
-        if (!hasSelector)
-        {
-            return;
-        }
-
-        _ = sb.Append("            ").Append(GetSelectorType(first)).AppendLine(" selector)");
-    }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AppendObservationParameters(StringBuilder sb, InvocationInfo first) =>
+        InterceptorEmitter.AppendPropertyParameters(sb, first, first.PropertyPaths.Length, first.HasSelector ? GetSelectorType(first) : null);
 
     /// <summary>Emits the trailing projection lambda that gathers a selector-less <c>CombineLatest</c> into one emission.</summary>
     /// <param name="sb">The string builder to append to.</param>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs
@@ -943,7 +943,7 @@ internal static class ObservationCodeGenerator
         // Either claim each call site outright, or emit the overload that competes for them all.
         if (features.SupportsInterceptors)
         {
-            GenerateInterceptors(sb, group, methodPrefix);
+            GenerateInterceptors(sb, group, methodPrefix, features.SupportsCallerArgExpr, features.StubHasExpressionParameters);
         }
         else
         {
@@ -983,6 +983,8 @@ internal static class ObservationCodeGenerator
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The type group whose call sites are being claimed.</param>
     /// <param name="methodPrefix">The method name prefix.</param>
+    /// <param name="supportsCallerArgExpr">Whether the target language version supports CallerArgumentExpression.</param>
+    /// <param name="stubHasExpressionParameters">Whether the runtime stub declares the expression parameters.</param>
     /// <remarks>
     /// Call sites that share a source type and the same expressions produce one observation between them, and
     /// the attribute may be applied repeatedly, so they are claimed by a single method carrying one attribute
@@ -990,15 +992,24 @@ internal static class ObservationCodeGenerator
     /// resolved to, which is the same outcome an unreachable dispatch overload produces.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void GenerateInterceptors(StringBuilder sb, TypeGroup group, string methodPrefix) =>
-        InterceptorEmitter.GenerateInterceptors(sb, group, methodPrefix, MethodSuffix, AppendObservationParameters);
-
-    /// <summary>Writes the observed-property parameters an observation overload takes.</summary>
-    /// <param name="sb">The string builder to append to.</param>
-    /// <param name="first">The invocation whose types the parameters are written from.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void AppendObservationParameters(StringBuilder sb, InvocationInfo first) =>
-        InterceptorEmitter.AppendPropertyParameters(sb, first, first.PropertyPaths.Length, first.HasSelector ? GetSelectorType(first) : null);
+    private static void GenerateInterceptors(
+        StringBuilder sb,
+        TypeGroup group,
+        string methodPrefix,
+        bool supportsCallerArgExpr,
+        bool stubHasExpressionParameters) =>
+        InterceptorEmitter.GenerateInterceptors(
+            sb,
+            group,
+            methodPrefix,
+            MethodSuffix,
+            (builder, first) => AppendParameterList(
+                builder,
+                first,
+                supportsCallerArgExpr,
+                stubHasExpressionParameters,
+                first.PropertyPaths.Length,
+                first.HasSelector));
 
     /// <summary>Emits the trailing projection lambda that gathers a selector-less <c>CombineLatest</c> into one emission.</summary>
     /// <param name="sb">The string builder to append to.</param>
@@ -1054,7 +1065,34 @@ internal static class ObservationCodeGenerator
         _ = sb.AppendLine("        /// <summary>").Append("        /// Concrete typed overload for ").Append(methodPrefix).Append(" on ")
             .Append(first.SourceTypeFullName).AppendLine(".").AppendLine("        /// </summary>")
             .Append("        public static global::System.IObservable<").Append(first.ReturnTypeFullName).Append("> ").Append(methodPrefix)
-            .AppendLine("(").Append("            this ").Append(first.SourceTypeFullName).AppendLine(" objectToMonitor,");
+            .AppendLine("(");
+
+        AppendParameterList(sb, first, supportsCallerArgExpr, stubHasExpressionParameters, propCount, hasSelector);
+
+        _ = sb.AppendLine(GeneratedSyntax.MemberBodyOpen);
+    }
+
+    /// <summary>Writes the parameters an observation member declares, closing the list.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="first">The invocation whose types the parameters are written from.</param>
+    /// <param name="supportsCallerArgExpr">Whether the target language version supports CallerArgumentExpression.</param>
+    /// <param name="stubHasExpressionParameters">Whether the runtime stub declares the expression parameters.</param>
+    /// <param name="propCount">The number of property expressions.</param>
+    /// <param name="hasSelector">Whether a selector function is present.</param>
+    /// <remarks>
+    /// One list serves the overload and the interceptor, because both have to be the stub's signature: the
+    /// overload only wins resolution against a candidate it is otherwise indistinguishable from, and an
+    /// interceptor is refused outright unless its signature is the intercepted method's.
+    /// </remarks>
+    private static void AppendParameterList(
+        StringBuilder sb,
+        InvocationInfo first,
+        bool supportsCallerArgExpr,
+        bool stubHasExpressionParameters,
+        int propCount,
+        bool hasSelector)
+    {
+        _ = sb.Append("            this ").Append(first.SourceTypeFullName).AppendLine(" objectToMonitor,");
 
         for (var i = 0; i < propCount; i++)
         {
@@ -1080,11 +1118,7 @@ internal static class ObservationCodeGenerator
             }
         }
 
-        _ = sb.AppendLine("""
-                                  [global::System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = "",
-                                  [global::System.Runtime.CompilerServices.CallerLineNumber] int callerLineNumber = 0)
-                              {
-                      """);
+        _ = sb.AppendLine(CodeGeneratorHelpers.CallerInfoParameterList);
     }
 
     /// <summary>Emits the if/else-if dispatch table that routes each matched invocation to its generated method.</summary>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs
@@ -943,7 +943,7 @@ internal static class ObservationCodeGenerator
         // Either claim each call site outright, or emit the overload that competes for them all.
         if (features.SupportsInterceptors)
         {
-            GenerateInterceptors(sb, group, methodPrefix, features.SupportsCallerArgExpr, features.StubHasExpressionParameters);
+            GenerateInterceptors(sb, group, methodPrefix, in features);
         }
         else
         {
@@ -983,8 +983,7 @@ internal static class ObservationCodeGenerator
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The type group whose call sites are being claimed.</param>
     /// <param name="methodPrefix">The method name prefix.</param>
-    /// <param name="supportsCallerArgExpr">Whether the target language version supports CallerArgumentExpression.</param>
-    /// <param name="stubHasExpressionParameters">Whether the runtime stub declares the expression parameters.</param>
+    /// <param name="features">The consumer compilation's language-feature snapshot.</param>
     /// <remarks>
     /// Call sites that share a source type and the same expressions produce one observation between them, and
     /// the attribute may be applied repeatedly, so they are claimed by a single method carrying one attribute
@@ -996,18 +995,18 @@ internal static class ObservationCodeGenerator
         StringBuilder sb,
         TypeGroup group,
         string methodPrefix,
-        bool supportsCallerArgExpr,
-        bool stubHasExpressionParameters) =>
+        in LanguageFeatures features) =>
         InterceptorEmitter.GenerateInterceptors(
             sb,
             group,
             methodPrefix,
             MethodSuffix,
-            (builder, first) => AppendParameterList(
+            in features,
+            static (StringBuilder builder, InvocationInfo first, in LanguageFeatures snapshot) => AppendParameterList(
                 builder,
                 first,
-                supportsCallerArgExpr,
-                stubHasExpressionParameters,
+                snapshot.SupportsCallerArgExpr,
+                snapshot.StubHasExpressionParameters,
                 first.PropertyPaths.Length,
                 first.HasSelector));
 

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs
@@ -104,8 +104,7 @@ internal static class ObservationCodeGenerator
                 sb,
                 group,
                 allClasses,
-                snapshot.SupportsCallerArgExpr,
-                snapshot.StubHasExpressionParameters,
+                in snapshot,
                 methodPrefix));
 
     /// <summary>Generates an observation method for a single invocation.</summary>
@@ -932,19 +931,30 @@ internal static class ObservationCodeGenerator
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The type group to generate code for.</param>
     /// <param name="allClasses">All detected class binding info for type mechanism lookup.</param>
-    /// <param name="supportsCallerArgExpr">Whether the target language version supports CallerArgumentExpression.</param>
-    /// <param name="stubHasExpressionParameters">Whether the runtime stub declares the expression parameters this overload has to match.</param>
+    /// <param name="features">The consumer compilation's language-feature snapshot, which settles the dispatch.</param>
     /// <param name="methodPrefix">The method name prefix.</param>
     private static void GenerateGroup(
         StringBuilder sb,
         TypeGroup group,
         ImmutableArray<ClassBindingInfo> allClasses,
-        bool supportsCallerArgExpr,
-        bool stubHasExpressionParameters,
+        in LanguageFeatures features,
         string methodPrefix)
     {
-        // Generate the concrete typed extension method overload
-        GenerateConcreteOverload(sb, group, supportsCallerArgExpr, stubHasExpressionParameters, methodPrefix);
+        // Either claim each call site outright, or emit the overload that competes for them all.
+        if (features.SupportsInterceptors)
+        {
+            GenerateInterceptors(sb, group, methodPrefix);
+        }
+        else
+        {
+            GenerateConcreteOverload(
+                sb,
+                group,
+                features.SupportsCallerArgExpr,
+                features.StubHasExpressionParameters,
+                methodPrefix);
+        }
+
         _ = sb.AppendLine();
 
         // Generate the observation methods for each invocation in this group. Call sites that share the
@@ -967,6 +977,97 @@ internal static class ObservationCodeGenerator
 
             GenerateObservationMethod(sb, inv, classInfo, suffix, inv.IsBeforeChange, methodPrefix);
         }
+    }
+
+    /// <summary>Emits one interceptor per generated observation, claiming every call site that reaches it.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="group">The type group whose call sites are being claimed.</param>
+    /// <param name="methodPrefix">The method name prefix.</param>
+    /// <remarks>
+    /// Call sites that share a source type and the same expressions produce one observation between them, and
+    /// the attribute may be applied repeatedly, so they are claimed by a single method carrying one attribute
+    /// each. A call site the compiler declined to describe is left alone: it keeps whatever the call already
+    /// resolved to, which is the same outcome an unreachable dispatch overload produces.
+    /// </remarks>
+    private static void GenerateInterceptors(StringBuilder sb, TypeGroup group, string methodPrefix)
+    {
+        foreach (var entry in GroupCallSitesByObservation(group))
+        {
+            var first = entry.Value[0];
+            var propCount = first.PropertyPaths.Length;
+
+            foreach (var callSite in entry.Value)
+            {
+                InterceptorEmitter.AppendAttribute(sb, callSite.Interceptor, "        ");
+            }
+
+            _ = sb.Append("        internal static global::System.IObservable<").Append(first.ReturnTypeFullName)
+                .Append("> __Intercept_").Append(methodPrefix).Append('_').Append(entry.Key).AppendLine("(")
+                .Append("            ").Append(first.SourceTypeFullName).AppendLine(" objectToMonitor,");
+
+            AppendPropertyParameters(sb, first, propCount, first.HasSelector);
+
+            _ = sb.Append("            => __").Append(methodPrefix).Append('_').Append(entry.Key)
+                .Append("(objectToMonitor").Append(first.HasSelector ? ", selector" : string.Empty).AppendLine(");");
+        }
+    }
+
+    /// <summary>Gathers the call sites of a group under the observation each of them reaches.</summary>
+    /// <param name="group">The type group whose call sites are being gathered.</param>
+    /// <returns>Each generated observation, against every call site that resolves to it.</returns>
+    /// <remarks>
+    /// A call site the compiler declined to describe is left out: nothing can claim it, and it keeps whatever
+    /// the call already resolved to.
+    /// </remarks>
+    private static Dictionary<string, List<InvocationInfo>> GroupCallSitesByObservation(TypeGroup group)
+    {
+        var claimed = new Dictionary<string, List<InvocationInfo>>(StringComparer.Ordinal);
+        for (var i = 0; i < group.Invocations.Length; i++)
+        {
+            var inv = group.Invocations[i];
+            if (!inv.Interceptor.IsAvailable)
+            {
+                continue;
+            }
+
+            var suffix = MethodSuffix(inv);
+            if (!claimed.TryGetValue(suffix, out var callSites))
+            {
+                callSites = [];
+                claimed[suffix] = callSites;
+            }
+
+            callSites.Add(inv);
+        }
+
+        return claimed;
+    }
+
+    /// <summary>Emits the observed-property parameters, and the projection when the overload takes one.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="first">The invocation whose types the parameters are written from.</param>
+    /// <param name="propCount">How many observed properties the overload takes.</param>
+    /// <param name="hasSelector">Whether the overload takes a projection after them.</param>
+    private static void AppendPropertyParameters(
+        StringBuilder sb,
+        InvocationInfo first,
+        int propCount,
+        bool hasSelector)
+    {
+        for (var i = 0; i < propCount; i++)
+        {
+            var type = first.PropertyPaths[i][first.PropertyPaths[i].Length - 1].PropertyTypeFullName;
+            _ = sb.Append("            global::System.Linq.Expressions.Expression<global::System.Func<")
+                .Append(first.SourceTypeFullName).Append(", ").Append(type).Append(">> property").Append(i + 1);
+            _ = hasSelector || i < propCount - 1 ? sb.AppendLine(",") : sb.AppendLine(")");
+        }
+
+        if (!hasSelector)
+        {
+            return;
+        }
+
+        _ = sb.Append("            ").Append(GetSelectorType(first)).AppendLine(" selector)");
     }
 
     /// <summary>Emits the trailing projection lambda that gathers a selector-less <c>CombineLatest</c> into one emission.</summary>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/WhenAnyCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/WhenAnyCodeGenerator.cs
@@ -248,21 +248,18 @@ internal static class WhenAnyCodeGenerator
     {
         if (features.SupportsInterceptors)
         {
-            var supportsCallerArgExpr = features.SupportsCallerArgExpr;
-            var supportsNullable = features.SupportsNullable;
-            var stubHasExpressionParameters = features.StubHasExpressionParameters;
-
             InterceptorEmitter.GenerateInterceptors(
                 sb,
                 group,
                 Constants.WhenAnyMethodName,
                 ObservationMethodSuffix,
-                (builder, first) => AppendParameterList(
+                in features,
+                static (StringBuilder builder, InvocationInfo first, in LanguageFeatures snapshot) => AppendParameterList(
                     builder,
                     first,
-                    supportsCallerArgExpr,
-                    supportsNullable,
-                    stubHasExpressionParameters));
+                    snapshot.SupportsCallerArgExpr,
+                    snapshot.SupportsNullable,
+                    snapshot.StubHasExpressionParameters));
         }
         else
         {

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/WhenAnyCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/WhenAnyCodeGenerator.cs
@@ -56,36 +56,11 @@ internal static class WhenAnyCodeGenerator
 
         _ = sb.AppendLine("        /// <summary>").Append("        /// Concrete typed overload for WhenAny on ").Append(first.SourceTypeFullName)
             .AppendLine(".").AppendLine("        /// </summary>").Append("        public static global::System.IObservable<")
-            .Append(first.ReturnTypeFullName).AppendLine("> WhenAny(").Append("            this ").Append(first.SourceTypeFullName)
-            .AppendLine(" objectToMonitor,");
+            .Append(first.ReturnTypeFullName).AppendLine("> WhenAny(");
 
-        for (var i = 0; i < propCount; i++)
-        {
-            var type = CodeGeneratorHelpers.NullableSelectorLeafType(first.PropertyPaths[i], supportsNullable);
-            _ = sb.Append("            global::System.Linq.Expressions.Expression<global::System.Func<").Append(first.SourceTypeFullName).Append(", ")
-                .Append(type).Append(">> property").Append(i + 1).AppendLine(",");
-        }
+        AppendParameterList(sb, first, supportsCallerArgExpr, supportsNullable, stubHasExpressionParameters);
 
-        // WhenAny always has a selector that takes IObservedChange parameters
-        _ = sb.Append("            ").Append(GetWhenAnySelectorType(first)).AppendLine(" selector,");
-
-        if (stubHasExpressionParameters)
-        {
-            for (var i = 0; i < propCount; i++)
-            {
-                CodeGeneratorHelpers.AppendExpressionParameter(
-                    sb,
-                    $"property{i + 1}",
-                    $"property{i + 1}Expression",
-                    supportsCallerArgExpr);
-            }
-        }
-
-        _ = sb.AppendLine("""
-                                  [global::System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = "",
-                                  [global::System.Runtime.CompilerServices.CallerLineNumber] int callerLineNumber = 0)
-                              {
-                      """);
+        _ = sb.AppendLine(GeneratedSyntax.MemberBodyOpen);
 
         CodeGeneratorHelpers.AppendIndexedStaticPrefixNormalization(sb, supportsCallerArgExpr, "property", propCount);
         EmitDispatchTable(sb, group, supportsCallerArgExpr, propCount);
@@ -273,12 +248,21 @@ internal static class WhenAnyCodeGenerator
     {
         if (features.SupportsInterceptors)
         {
+            var supportsCallerArgExpr = features.SupportsCallerArgExpr;
+            var supportsNullable = features.SupportsNullable;
+            var stubHasExpressionParameters = features.StubHasExpressionParameters;
+
             InterceptorEmitter.GenerateInterceptors(
                 sb,
                 group,
                 Constants.WhenAnyMethodName,
                 ObservationMethodSuffix,
-                AppendWhenAnyParameters);
+                (builder, first) => AppendParameterList(
+                    builder,
+                    first,
+                    supportsCallerArgExpr,
+                    supportsNullable,
+                    stubHasExpressionParameters));
         }
         else
         {
@@ -303,17 +287,50 @@ internal static class WhenAnyCodeGenerator
         }
     }
 
-    /// <summary>Writes the parameters a WhenAny interceptor takes after the observed object.</summary>
+    /// <summary>Writes the parameters a WhenAny member declares, closing the list.</summary>
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="first">The invocation whose types the parameters are written from.</param>
-    /// <remarks>WhenAny always projects, so the projection closes the list rather than being optional.</remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void AppendWhenAnyParameters(StringBuilder sb, InvocationInfo first) =>
-        InterceptorEmitter.AppendPropertyParameters(
-            sb,
-            first,
-            first.PropertyPaths.Length,
-            GetWhenAnySelectorType(first));
+    /// <param name="supportsCallerArgExpr">Whether the target language version supports CallerArgumentExpression.</param>
+    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
+    /// <param name="stubHasExpressionParameters">Whether the runtime stub declares the expression parameters.</param>
+    /// <remarks>
+    /// One list serves the overload and the interceptor, because both have to be the stub's signature. WhenAny
+    /// always projects, so the projection is unconditional rather than optional.
+    /// </remarks>
+    private static void AppendParameterList(
+        StringBuilder sb,
+        InvocationInfo first,
+        bool supportsCallerArgExpr,
+        bool supportsNullable,
+        bool stubHasExpressionParameters)
+    {
+        var propCount = first.PropertyPaths.Length;
+
+        _ = sb.Append("            this ").Append(first.SourceTypeFullName).AppendLine(" objectToMonitor,");
+
+        for (var i = 0; i < propCount; i++)
+        {
+            var type = CodeGeneratorHelpers.NullableSelectorLeafType(first.PropertyPaths[i], supportsNullable);
+            _ = sb.Append("            global::System.Linq.Expressions.Expression<global::System.Func<").Append(first.SourceTypeFullName).Append(", ")
+                .Append(type).Append(">> property").Append(i + 1).AppendLine(",");
+        }
+
+        _ = sb.Append("            ").Append(GetWhenAnySelectorType(first)).AppendLine(" selector,");
+
+        if (stubHasExpressionParameters)
+        {
+            for (var i = 0; i < propCount; i++)
+            {
+                CodeGeneratorHelpers.AppendExpressionParameter(
+                    sb,
+                    $"property{i + 1}",
+                    $"property{i + 1}Expression",
+                    supportsCallerArgExpr);
+            }
+        }
+
+        _ = sb.AppendLine(CodeGeneratorHelpers.CallerInfoParameterList);
+    }
 
     /// <summary>Emits the if/else-if dispatch table that routes each matched WhenAny invocation to its generated method.</summary>
     /// <param name="sb">The string builder to append to.</param>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/WhenAnyCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/WhenAnyCodeGenerator.cs
@@ -271,12 +271,25 @@ internal static class WhenAnyCodeGenerator
         ImmutableArray<ClassBindingInfo> allClasses,
         in LanguageFeatures features)
     {
-        GenerateConcreteOverload(
-            sb,
-            group,
-            features.SupportsCallerArgExpr,
-            features.SupportsNullable,
-            features.StubHasExpressionParameters);
+        if (features.SupportsInterceptors)
+        {
+            InterceptorEmitter.GenerateInterceptors(
+                sb,
+                group,
+                Constants.WhenAnyMethodName,
+                ObservationMethodSuffix,
+                AppendWhenAnyParameters);
+        }
+        else
+        {
+            GenerateConcreteOverload(
+                sb,
+                group,
+                features.SupportsCallerArgExpr,
+                features.SupportsNullable,
+                features.StubHasExpressionParameters);
+        }
+
         _ = sb.AppendLine();
 
         for (var i = 0; i < group.Invocations.Length; i++)
@@ -289,6 +302,18 @@ internal static class WhenAnyCodeGenerator
                 ObservationMethodSuffix(inv));
         }
     }
+
+    /// <summary>Writes the parameters a WhenAny interceptor takes after the observed object.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="first">The invocation whose types the parameters are written from.</param>
+    /// <remarks>WhenAny always projects, so the projection closes the list rather than being optional.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AppendWhenAnyParameters(StringBuilder sb, InvocationInfo first) =>
+        InterceptorEmitter.AppendPropertyParameters(
+            sb,
+            first,
+            first.PropertyPaths.Length,
+            GetWhenAnySelectorType(first));
 
     /// <summary>Emits the if/else-if dispatch table that routes each matched WhenAny invocation to its generated method.</summary>
     /// <param name="sb">The string builder to append to.</param>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/WhenAnyObservableCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/WhenAnyObservableCodeGenerator.cs
@@ -335,12 +335,20 @@ internal static class WhenAnyObservableCodeGenerator
         ImmutableArray<ClassBindingInfo> allClasses,
         in LanguageFeatures features)
     {
-        GenerateConcreteOverload(
-            sb,
-            group,
-            features.SupportsCallerArgExpr,
-            features.SupportsNullable,
-            features.StubHasExpressionParameters);
+        if (features.SupportsInterceptors)
+        {
+            GenerateInterceptors(sb, group, features.SupportsNullable);
+        }
+        else
+        {
+            GenerateConcreteOverload(
+                sb,
+                group,
+                features.SupportsCallerArgExpr,
+                features.SupportsNullable,
+                features.StubHasExpressionParameters);
+        }
+
         _ = sb.AppendLine();
 
         for (var i = 0; i < group.Invocations.Length; i++)
@@ -351,6 +359,49 @@ internal static class WhenAnyObservableCodeGenerator
                 inv,
                 CodeGeneratorHelpers.ResolveObservedTypeInfo(allClasses, inv.SourceTypeFullName, inv.PropertyPaths[0]),
                 ObservationMethodSuffix(inv));
+        }
+    }
+
+    /// <summary>Emits one interceptor per generated observation, claiming every call site that reaches it.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="group">The group of call sites being claimed.</param>
+    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
+    private static void GenerateInterceptors(StringBuilder sb, TypeGroup group, bool supportsNullable)
+    {
+        foreach (var entry in InterceptorEmitter.GroupCallSites(
+            group.Invocations,
+            static x => x.Interceptor,
+            ObservationMethodSuffix))
+        {
+            var first = entry.Value[0];
+            var propCount = first.PropertyPaths.Length;
+
+            foreach (var callSite in entry.Value)
+            {
+                InterceptorEmitter.AppendAttribute(sb, callSite.Interceptor, "        ");
+            }
+
+            _ = sb.Append("        internal static global::System.IObservable<").Append(first.ReturnTypeFullName)
+                .Append("> __Intercept_WhenAnyObservable_").Append(entry.Key).AppendLine("(")
+                .Append("            ").Append(first.SourceTypeFullName).AppendLine(" objectToMonitor,");
+
+            for (var i = 0; i < propCount; i++)
+            {
+                var innerType = first.InnerObservableTypeFullNames[i];
+                var obsType = $"global::System.IObservable<{innerType}>{(supportsNullable ? "?" : string.Empty)}";
+                _ = sb.Append("            global::System.Linq.Expressions.Expression<global::System.Func<")
+                    .Append(first.SourceTypeFullName).Append(", ").Append(obsType).Append(">> obs").Append(i + 1).AppendLine(",");
+            }
+
+            if (first.HasSelector)
+            {
+                _ = sb.Append("            ").Append(GetSelectorType(first)).AppendLine(" selector,");
+            }
+
+            InterceptorEmitter.CloseParameterList(sb);
+
+            _ = sb.Append("            => __WhenAnyObservable_").Append(entry.Key).Append("(objectToMonitor")
+                .Append(first.HasSelector ? ", selector" : string.Empty).AppendLine(");").AppendLine();
         }
     }
 

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/WhenAnyObservableCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/WhenAnyObservableCodeGenerator.cs
@@ -68,39 +68,11 @@ internal static class WhenAnyObservableCodeGenerator
 
         _ = sb.AppendLine("        /// <summary>").Append("        /// Concrete typed overload for WhenAnyObservable on ")
             .Append(first.SourceTypeFullName).AppendLine(".").AppendLine("        /// </summary>")
-            .Append("        public static global::System.IObservable<").Append(first.ReturnTypeFullName).AppendLine("> WhenAnyObservable(")
-            .Append("            this ").Append(first.SourceTypeFullName).AppendLine(" objectToMonitor,");
+            .Append("        public static global::System.IObservable<").Append(first.ReturnTypeFullName).AppendLine("> WhenAnyObservable(");
 
-        for (var i = 0; i < propCount; i++)
-        {
-            var innerType = first.InnerObservableTypeFullNames[i];
-            var obsType = $"global::System.IObservable<{innerType}>{(supportsNullable ? "?" : string.Empty)}";
-            _ = sb.Append("            global::System.Linq.Expressions.Expression<global::System.Func<").Append(first.SourceTypeFullName).Append(", ")
-                .Append(obsType).Append(">> obs").Append(i + 1).AppendLine(",");
-        }
+        AppendParameterList(sb, first, supportsCallerArgExpr, supportsNullable, stubHasExpressionParameters);
 
-        if (hasSelector)
-        {
-            _ = sb.Append("            ").Append(GetSelectorType(first)).AppendLine(" selector,");
-        }
-
-        if (stubHasExpressionParameters)
-        {
-            for (var i = 0; i < propCount; i++)
-            {
-                CodeGeneratorHelpers.AppendExpressionParameter(
-                    sb,
-                    $"obs{i + 1}",
-                    $"obs{i + 1}Expression",
-                    supportsCallerArgExpr);
-            }
-        }
-
-        _ = sb.AppendLine("""
-                                  [global::System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = "",
-                                  [global::System.Runtime.CompilerServices.CallerLineNumber] int callerLineNumber = 0)
-                              {
-                      """);
+        _ = sb.AppendLine(GeneratedSyntax.MemberBodyOpen);
 
         CodeGeneratorHelpers.AppendIndexedStaticPrefixNormalization(sb, supportsCallerArgExpr, "obs", propCount);
         EmitDispatchTable(sb, group, supportsCallerArgExpr, propCount, hasSelector);
@@ -337,7 +309,7 @@ internal static class WhenAnyObservableCodeGenerator
     {
         if (features.SupportsInterceptors)
         {
-            GenerateInterceptors(sb, group, features.SupportsNullable);
+            GenerateInterceptors(sb, group, in features);
         }
         else
         {
@@ -365,44 +337,83 @@ internal static class WhenAnyObservableCodeGenerator
     /// <summary>Emits one interceptor per generated observation, claiming every call site that reaches it.</summary>
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The group of call sites being claimed.</param>
-    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
-    private static void GenerateInterceptors(StringBuilder sb, TypeGroup group, bool supportsNullable)
+    /// <param name="features">The consumer compilation's language-feature snapshot.</param>
+    private static void GenerateInterceptors(StringBuilder sb, TypeGroup group, in LanguageFeatures features)
     {
+        var supportsCallerArgExpr = features.SupportsCallerArgExpr;
+        var supportsNullable = features.SupportsNullable;
+        var stubHasExpressionParameters = features.StubHasExpressionParameters;
+
         foreach (var entry in InterceptorEmitter.GroupCallSites(
             group.Invocations,
             static x => x.Interceptor,
             ObservationMethodSuffix))
         {
             var first = entry.Value[0];
-            var propCount = first.PropertyPaths.Length;
 
             foreach (var callSite in entry.Value)
             {
-                InterceptorEmitter.AppendAttribute(sb, callSite.Interceptor, "        ");
+                InterceptorEmitter.AppendAttribute(sb, callSite.Interceptor, InterceptorEmitter.MemberIndent);
             }
 
             _ = sb.Append("        internal static global::System.IObservable<").Append(first.ReturnTypeFullName)
-                .Append("> __Intercept_WhenAnyObservable_").Append(entry.Key).AppendLine("(")
-                .Append("            ").Append(first.SourceTypeFullName).AppendLine(" objectToMonitor,");
+                .Append("> __Intercept_WhenAnyObservable_").Append(entry.Key).AppendLine("(");
 
-            for (var i = 0; i < propCount; i++)
-            {
-                var innerType = first.InnerObservableTypeFullNames[i];
-                var obsType = $"global::System.IObservable<{innerType}>{(supportsNullable ? "?" : string.Empty)}";
-                _ = sb.Append("            global::System.Linq.Expressions.Expression<global::System.Func<")
-                    .Append(first.SourceTypeFullName).Append(", ").Append(obsType).Append(">> obs").Append(i + 1).AppendLine(",");
-            }
-
-            if (first.HasSelector)
-            {
-                _ = sb.Append("            ").Append(GetSelectorType(first)).AppendLine(" selector,");
-            }
-
-            InterceptorEmitter.CloseParameterList(sb);
+            AppendParameterList(sb, first, supportsCallerArgExpr, supportsNullable, stubHasExpressionParameters);
 
             _ = sb.Append("            => __WhenAnyObservable_").Append(entry.Key).Append("(objectToMonitor")
                 .Append(first.HasSelector ? ", selector" : string.Empty).AppendLine(");").AppendLine();
         }
+    }
+
+    /// <summary>Writes the parameters a WhenAnyObservable member declares, closing the list.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="first">The invocation whose types the parameters are written from.</param>
+    /// <param name="supportsCallerArgExpr">Whether the target language version supports CallerArgumentExpression.</param>
+    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
+    /// <param name="stubHasExpressionParameters">Whether the runtime stub declares the expression parameters.</param>
+    /// <remarks>
+    /// One list serves the overload and the interceptor, because both have to be the stub's signature: the
+    /// overload only wins resolution against a candidate it is otherwise indistinguishable from, and an
+    /// interceptor is refused outright unless its signature is the intercepted method's.
+    /// </remarks>
+    private static void AppendParameterList(
+        StringBuilder sb,
+        WhenAnyObservableInvocationInfo first,
+        bool supportsCallerArgExpr,
+        bool supportsNullable,
+        bool stubHasExpressionParameters)
+    {
+        var propCount = first.PropertyPaths.Length;
+
+        _ = sb.Append("            this ").Append(first.SourceTypeFullName).AppendLine(" objectToMonitor,");
+
+        for (var i = 0; i < propCount; i++)
+        {
+            var innerType = first.InnerObservableTypeFullNames[i];
+            var obsType = $"global::System.IObservable<{innerType}>{(supportsNullable ? "?" : string.Empty)}";
+            _ = sb.Append("            global::System.Linq.Expressions.Expression<global::System.Func<").Append(first.SourceTypeFullName).Append(", ")
+                .Append(obsType).Append(">> obs").Append(i + 1).AppendLine(",");
+        }
+
+        if (first.HasSelector)
+        {
+            _ = sb.Append("            ").Append(GetSelectorType(first)).AppendLine(" selector,");
+        }
+
+        if (stubHasExpressionParameters)
+        {
+            for (var i = 0; i < propCount; i++)
+            {
+                CodeGeneratorHelpers.AppendExpressionParameter(
+                    sb,
+                    $"obs{i + 1}",
+                    $"obs{i + 1}Expression",
+                    supportsCallerArgExpr);
+            }
+        }
+
+        _ = sb.AppendLine(CodeGeneratorHelpers.CallerInfoParameterList);
     }
 
     /// <summary>Emits the if/else-if dispatch table that routes each matched invocation to its generated method.</summary>

--- a/src/ReactiveUI.Binding.SourceGenerators/Constants.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Constants.cs
@@ -58,6 +58,17 @@ internal static class Constants
     /// </summary>
     internal const string GeneratedNamespaceRoot = "ReactiveUI.Binding.Generated";
 
+    /// <summary>The namespace interceptors are emitted into.</summary>
+    /// <remarks>
+    /// Fixed rather than derived from the consumer, because nothing has to reach it: an interceptor claims its
+    /// call site by name and is never found by lookup. Being fixed is what lets the shipped props opt exactly
+    /// this namespace into interception without knowing anything about the project it is opting in.
+    /// </remarks>
+    internal const string InterceptorNamespace = "ReactiveUI.Binding.Generated.Interceptors";
+
+    /// <summary>The build property a consumer's compiler reads the interception opt-in from.</summary>
+    internal const string InterceptorsNamespacesFeature = "InterceptorsNamespaces";
+
     /// <summary>Fully qualified name of the attribute that exposes an assembly's internals to another.</summary>
     internal const string InternalsVisibleToAttributeFullName =
         "global::System.Runtime.CompilerServices.InternalsVisibleToAttribute";

--- a/src/ReactiveUI.Binding.SourceGenerators/DiagnosticWarnings.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/DiagnosticWarnings.cs
@@ -48,6 +48,16 @@ internal static class DiagnosticWarnings
         true,
         SilentPathLinkDescription);
 
+    /// <summary>RXUIBIND011: A binding call resolved to ReactiveUI's mixin rather than a generated overload.</summary>
+    internal static readonly DiagnosticDescriptor MixinShadowsGeneratedBinding = new(
+        "RXUIBIND011",
+        "Binding call resolved to ReactiveUI's own mixin",
+        "'{0}' resolved to ReactiveUI's '{1}', so this call generates nothing and takes the runtime expression engine",
+        UsageCategory,
+        DiagnosticSeverity.Warning,
+        true,
+        MixinShadowsGeneratedBindingDescription);
+
     /// <summary>RXUIBIND003: Expression contains private/protected member.</summary>
     internal static readonly DiagnosticDescriptor PrivateMember = new(
         "RXUIBIND003",
@@ -168,6 +178,15 @@ internal static class DiagnosticWarnings
     /// <summary>The string description of the invalid interaction type warning.</summary>
     private const string InvalidInteractionTypeDescription =
         "The property selected in the BindInteraction expression must implement IInteraction<TInput, TOutput>.";
+
+    /// <summary>The string description of the shadowed binding warning.</summary>
+    private const string MixinShadowsGeneratedBindingDescription =
+        "Which method a binding call reaches is decided by extension-method lookup. Where ReactiveUI's own "
+        + "namespace is imported and this package's is not, the call binds to ReactiveUI's mixin and the "
+        + "generator never sees it: no dispatch is emitted, and the call takes the runtime expression engine "
+        + "that a generated binding exists to avoid. Nothing else reports this, because the call was never "
+        + "recognised as one to generate for. Import 'ReactiveUI.Binding' in the file to restore the generated "
+        + "overload, which lookup prefers over the generic one.";
 
     /// <summary>The string description of the silent path link warning.</summary>
     private const string SilentPathLinkDescription =

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/BindToExtractor.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/BindToExtractor.cs
@@ -84,7 +84,8 @@ internal static class BindToExtractor
             targetPropertyTypeFullName,
             hasConversionHint,
             hasConverterOverride,
-            targetExpressionText);
+            targetExpressionText,
+            InterceptableLocationReader.Read(semanticModel, invocation, ct));
     }
 
     /// <summary>

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/BindToExtractor.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/BindToExtractor.cs
@@ -96,8 +96,7 @@ internal static class BindToExtractor
     /// <returns>The observable value type, or null if the receiver is not an observable.</returns>
     internal static ITypeSymbol? GetObservableValueType(ITypeSymbol? receiver)
     {
-        if (receiver is INamedTypeSymbol { Name: "IObservable", TypeArguments.Length: 1 } direct
-            && direct.ContainingNamespace?.ToDisplayString() == "System")
+        if (receiver is INamedTypeSymbol direct && IsFrameworkObservable(direct))
         {
             return direct.TypeArguments[0];
         }
@@ -106,8 +105,7 @@ internal static class BindToExtractor
         // that implements nothing; a separate guard for it could never be taken from the only caller.
         foreach (var iface in receiver?.AllInterfaces ?? System.Collections.Immutable.ImmutableArray<INamedTypeSymbol>.Empty)
         {
-            if (iface is { Name: "IObservable", TypeArguments.Length: 1 }
-                && iface.ContainingNamespace?.ToDisplayString() == "System")
+            if (IsFrameworkObservable(iface))
             {
                 return iface.TypeArguments[0];
             }
@@ -115,6 +113,17 @@ internal static class BindToExtractor
 
         return null;
     }
+
+    /// <summary>Determines whether a type is the framework's own <c>System.IObservable&lt;T&gt;</c>.</summary>
+    /// <param name="type">The type to judge.</param>
+    /// <returns><see langword="true"/> when it is that interface rather than one of the same name.</returns>
+    /// <remarks>
+    /// Asked of the receiver and of each interface it implements, so the shape and the namespace are described
+    /// once. A type belonging to no namespace at all - an array or a pointer - answers no rather than throwing.
+    /// </remarks>
+    private static bool IsFrameworkObservable(INamedTypeSymbol type) =>
+        type is { Name: "IObservable", TypeArguments.Length: 1 }
+        && type.ContainingNamespace?.ToDisplayString() == "System";
 
     /// <summary>
     /// Scans the method parameters to detect the presence of a <c>conversionHint</c> parameter

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/BindToExtractor.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/BindToExtractor.cs
@@ -119,11 +119,14 @@ internal static class BindToExtractor
     /// <returns><see langword="true"/> when it is that interface rather than one of the same name.</returns>
     /// <remarks>
     /// Asked of the receiver and of each interface it implements, so the shape and the namespace are described
-    /// once. A type belonging to no namespace at all - an array or a pointer - answers no rather than throwing.
+    /// once. Both a lookalike declared elsewhere and one of the same name taking a different number of type
+    /// arguments answer no. A named type always belongs to a namespace, the global one at worst, so there is
+    /// none to account for; the shapes that belong to no namespace - an array, a pointer, a function pointer -
+    /// are not named types and never arrive here.
     /// </remarks>
     private static bool IsFrameworkObservable(INamedTypeSymbol type) =>
         type is { Name: "IObservable", TypeArguments.Length: 1 }
-        && type.ContainingNamespace?.ToDisplayString() == "System";
+        && type.ContainingNamespace.ToDisplayString() == "System";
 
     /// <summary>
     /// Scans the method parameters to detect the presence of a <c>conversionHint</c> parameter

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/BindingExtractor.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/BindingExtractor.cs
@@ -86,7 +86,8 @@ internal static class BindingExtractor
             methodName,
             CodeGeneration.CodeGeneratorHelpers.NormalizeLambdaText(sourcePropertyArg.ToString()),
             CodeGeneration.CodeGeneratorHelpers.NormalizeLambdaText(targetPropertyArg.ToString()),
-            hasConverterOverride);
+            hasConverterOverride,
+            InterceptableLocationReader.Read(semanticModel, invocation, ct));
     }
 
     /// <summary>

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/CommandExtractor.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/CommandExtractor.cs
@@ -66,9 +66,6 @@ internal static class CommandExtractor
             return null;
         }
 
-        var commandTypeFullName = commandPropertyPath[^1].PropertyTypeFullName;
-        var controlTypeFullName = controlPropertyPath[^1].PropertyTypeFullName;
-
         // Determine parameter overload (Expression vs IObservable withParameter)
         var parameterOverload = DetectParameterOverload(methodSymbol, args, semanticModel, ct);
 
@@ -82,8 +79,8 @@ internal static class CommandExtractor
             viewModelTypeFullName,
             new(commandPropertyPath),
             new(controlPropertyPath),
-            commandTypeFullName,
-            controlTypeFullName,
+            commandPropertyPath[^1].PropertyTypeFullName,
+            controlPropertyPath[^1].PropertyTypeFullName,
             parameterOverload.HasObservableParameter,
             parameterOverload.HasExpressionParameter,
             parameterOverload.ParameterTypeFullName,
@@ -97,7 +94,8 @@ internal static class CommandExtractor
             parameterOverload.ParameterExpressionText,
             capabilities.HasCommand,
             capabilities.HasCommandParameter,
-            capabilities.HasEnabled);
+            capabilities.HasEnabled,
+            InterceptableLocationReader.Read(semanticModel, invocation, ct));
     }
 
     /// <summary>Searches invocation arguments for a valid <c>withParameter</c> lambda expression.</summary>

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/InteractionExtractor.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/InteractionExtractor.cs
@@ -87,7 +87,8 @@ internal static class InteractionExtractor
             dontCareTypeFullName,
             Constants.BindInteractionMethodName,
             expressionText,
-            viewClassInfo);
+            viewClassInfo,
+            InterceptableLocationReader.Read(semanticModel, invocation, ct));
     }
 
     /// <summary>Resolves the interaction's two type arguments, refusing a call site that names neither.</summary>

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/InterceptableLocationReader.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/InterceptableLocationReader.cs
@@ -66,6 +66,26 @@ internal static class InterceptableLocationReader
         return false;
     }
 
+    /// <summary>Determines whether an interceptor emitted for this compilation would be honoured.</summary>
+    /// <param name="parseOptions">The consumer's parse options, which carry the opt-in the build set.</param>
+    /// <returns><see langword="true"/> when this build can describe a call site and the project listed the namespace.</returns>
+    /// <remarks>
+    /// The one question both the generator and the analyzer ask before deciding whether the dispatch overloads
+    /// still matter, so the two answer it the same way. Which build is loaded settles the first half outright,
+    /// which is why the baseline never reads the options at all.
+    /// </remarks>
+    internal static bool IsInterceptionEnabled(ParseOptions parseOptions)
+    {
+#if ROSLYN_4_13
+        return IsOptedIn(parseOptions);
+#else
+
+        // The baseline compiler describes no call site, so there is no interceptor for a listing to honour.
+        _ = parseOptions;
+        return false;
+#endif
+    }
+
     /// <summary>Describes a call site, when the host compiler can.</summary>
     /// <param name="semanticModel">The model the invocation was bound in.</param>
     /// <param name="invocation">The call site.</param>

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/InterceptableLocationReader.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/InterceptableLocationReader.cs
@@ -1,0 +1,96 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using ReactiveUI.Binding.SourceGenerators.Models;
+
+namespace ReactiveUI.Binding.SourceGenerators.Helpers;
+
+/// <summary>Reads the call-site description an interceptor has to name.</summary>
+/// <remarks>
+/// The only place either build asks the compiler about interception. The 4.13 build has the API and answers;
+/// the baseline build has no such API to call and answers that it described nothing, which every caller
+/// already handles because a call site can be undescribable on a new compiler too.
+/// </remarks>
+internal static class InterceptableLocationReader
+{
+    /// <summary>Gets a value indicating whether this build can describe a call site at all.</summary>
+    /// <remarks>
+    /// Fixed when the generator is compiled, not read from the consumer: which of the two builds is loaded is
+    /// decided by the compiler's own version, through the analyzer slot the package was resolved from.
+    /// </remarks>
+    internal static bool IsSupported =>
+#if ROSLYN_4_13
+        true;
+#else
+        false;
+#endif
+
+    /// <summary>Determines whether the consumer has opted the generated namespace into interception.</summary>
+    /// <param name="parseOptions">The consumer's parse options, which carry the opt-in the build set.</param>
+    /// <returns><see langword="true"/> when an interceptor emitted here would be honoured.</returns>
+    /// <remarks>
+    /// Interception is refused outright for a namespace the project did not list, so emitting one without the
+    /// opt-in turns every call site into a build error. The package's own props lists the generated namespace,
+    /// which is why this is normally true; a consumer who clears the property gets the dispatch overloads back.
+    /// A listed namespace covers the ones nested under it, so a prefix counts as a match.
+    /// </remarks>
+    internal static bool IsOptedIn(ParseOptions parseOptions)
+    {
+        if (!parseOptions.Features.TryGetValue(Constants.InterceptorsNamespacesFeature, out var namespaces)
+            || string.IsNullOrEmpty(namespaces))
+        {
+            return false;
+        }
+
+        foreach (var candidate in namespaces.Split(';'))
+        {
+            var trimmed = candidate.Trim();
+            if (trimmed.Length == 0)
+            {
+                continue;
+            }
+
+            if (string.Equals(trimmed, Constants.InterceptorNamespace, StringComparison.Ordinal)
+                || (Constants.InterceptorNamespace.Length > trimmed.Length
+                    && Constants.InterceptorNamespace[trimmed.Length] == '.'
+                    && Constants.InterceptorNamespace.StartsWith(trimmed, StringComparison.Ordinal)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Describes a call site, when the host compiler can.</summary>
+    /// <param name="semanticModel">The model the invocation was bound in.</param>
+    /// <param name="invocation">The call site.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The description, or a location reporting that none was produced.</returns>
+    internal static InterceptorLocation Read(
+        SemanticModel semanticModel,
+        InvocationExpressionSyntax invocation,
+        CancellationToken cancellationToken)
+    {
+#if ROSLYN_4_13
+        var location = Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetInterceptableLocation(
+            semanticModel,
+            invocation,
+            cancellationToken);
+
+        return location is null ? default : new InterceptorLocation(location.Version, location.Data);
+#else
+
+        // The baseline compiler cannot describe a call site, so nothing here is interceptable. The arguments
+        // are read so the two builds keep one signature rather than diverging on what they accept.
+        _ = semanticModel;
+        _ = invocation;
+        _ = cancellationToken;
+        return default;
+#endif
+    }
+}

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/ObservationExtractor.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/ObservationExtractor.cs
@@ -123,7 +123,8 @@ internal static class ObservationExtractor
             isBeforeChange,
             hasSelector,
             expectedMethodName,
-            new([.. expressionTexts]));
+            new([.. expressionTexts]),
+            InterceptableLocationReader.Read(semanticModel, invocation, ct));
     }
 
     /// <summary>

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/WhenAnyObservableExtractor.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/WhenAnyObservableExtractor.cs
@@ -76,7 +76,8 @@ internal static class WhenAnyObservableExtractor
             new([.. innerObservableTypes]),
             returnTypeFullName,
             hasSelector,
-            new([.. expressionTexts]));
+            new([.. expressionTexts]),
+            InterceptableLocationReader.Read(semanticModel, invocation, ct));
     }
 
     /// <summary>

--- a/src/ReactiveUI.Binding.SourceGenerators/Invocations/BindInvocationGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Invocations/BindInvocationGenerator.cs
@@ -34,13 +34,11 @@ internal static class BindInvocationGenerator
                     data.Left.Left,
                     data.Left.Right,
                     data.Right,
-                    static (sb, group, f) => BindingEmitterHelpers.GenerateDispatchOverload(
+                    static (sb, group, f) => BindingEmitterHelpers.EmitOverloadOrInterceptors(
                         sb,
                         group,
                         BindCodeGenerator.DispatchApi,
-                        f.SupportsCallerArgExpr,
-                        f.SupportsNullable,
-                        f.StubHasExpressionParameters),
+                        in f),
                     static (sb, c) => BindCodeGenerator.GenerateBindMethod(
                         sb,
                         c.Invocation,

--- a/src/ReactiveUI.Binding.SourceGenerators/Invocations/BindOneWayInvocationGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Invocations/BindOneWayInvocationGenerator.cs
@@ -34,13 +34,11 @@ internal static class BindOneWayInvocationGenerator
                     data.Left.Left,
                     data.Left.Right,
                     data.Right,
-                    static (sb, group, f) => BindingEmitterHelpers.GenerateDispatchOverload(
+                    static (sb, group, f) => BindingEmitterHelpers.EmitOverloadOrInterceptors(
                         sb,
                         group,
                         BindOneWayCodeGenerator.DispatchApi,
-                        f.SupportsCallerArgExpr,
-                        f.SupportsNullable,
-                        f.StubHasExpressionParameters),
+                        in f),
                     static (sb, c) => BindOneWayCodeGenerator.GenerateBindOneWayMethod(
                         sb,
                         c.Invocation,

--- a/src/ReactiveUI.Binding.SourceGenerators/Invocations/BindTwoWayInvocationGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Invocations/BindTwoWayInvocationGenerator.cs
@@ -34,13 +34,11 @@ internal static class BindTwoWayInvocationGenerator
                     data.Left.Left,
                     data.Left.Right,
                     data.Right,
-                    static (sb, group, f) => BindingEmitterHelpers.GenerateDispatchOverload(
+                    static (sb, group, f) => BindingEmitterHelpers.EmitOverloadOrInterceptors(
                         sb,
                         group,
                         BindTwoWayCodeGenerator.DispatchApi,
-                        f.SupportsCallerArgExpr,
-                        f.SupportsNullable,
-                        f.StubHasExpressionParameters),
+                        in f),
                     static (sb, c) => BindTwoWayCodeGenerator.GenerateBindTwoWayMethod(
                         sb,
                         c.Invocation,

--- a/src/ReactiveUI.Binding.SourceGenerators/Invocations/OneWayBindInvocationGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Invocations/OneWayBindInvocationGenerator.cs
@@ -34,13 +34,11 @@ internal static class OneWayBindInvocationGenerator
                     data.Left.Left,
                     data.Left.Right,
                     data.Right,
-                    static (sb, group, f) => BindingEmitterHelpers.GenerateDispatchOverload(
+                    static (sb, group, f) => BindingEmitterHelpers.EmitOverloadOrInterceptors(
                         sb,
                         group,
                         OneWayBindCodeGenerator.DispatchApi,
-                        f.SupportsCallerArgExpr,
-                        f.SupportsNullable,
-                        f.StubHasExpressionParameters),
+                        in f),
                     static (sb, c) => OneWayBindCodeGenerator.GenerateOneWayBindMethod(
                         sb,
                         c.Invocation,

--- a/src/ReactiveUI.Binding.SourceGenerators/Models/BindCommandInvocationInfo.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Models/BindCommandInvocationInfo.cs
@@ -31,6 +31,9 @@ namespace ReactiveUI.Binding.SourceGenerators.Models;
 /// <param name="HasCommandProperty">Whether the control type has a settable Command property (ICommand).</param>
 /// <param name="HasCommandParameterProperty">Whether the control type has a settable CommandParameter property.</param>
 /// <param name="HasEnabledProperty">Whether the control type has a settable Enabled property (bool).</param>
+/// <param name="Interceptor">
+/// Where this call site is, for a build that claims call sites outright rather than competing for them.
+/// </param>
 internal sealed record BindCommandInvocationInfo(
     string CallerFilePath,
     int CallerLineNumber,
@@ -53,4 +56,5 @@ internal sealed record BindCommandInvocationInfo(
     string? ParameterExpressionText,
     bool HasCommandProperty,
     bool HasCommandParameterProperty,
-    bool HasEnabledProperty);
+    bool HasEnabledProperty,
+    InterceptorLocation Interceptor = default);

--- a/src/ReactiveUI.Binding.SourceGenerators/Models/BindInteractionInvocationInfo.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Models/BindInteractionInvocationInfo.cs
@@ -26,6 +26,9 @@ namespace ReactiveUI.Binding.SourceGenerators.Models;
 /// a referenced assembly is still followed through the view model it holds rather than reduced to the instance
 /// the call was handed.
 /// </param>
+/// <param name="Interceptor">
+/// Where this call site is, for a build that claims call sites outright rather than competing for them.
+/// </param>
 internal sealed record BindInteractionInvocationInfo(
     string CallerFilePath,
     int CallerLineNumber,
@@ -38,4 +41,5 @@ internal sealed record BindInteractionInvocationInfo(
     string? DontCareTypeFullName,
     string MethodName,
     string ExpressionText,
-    ClassBindingInfo? ViewClassInfo = null);
+    ClassBindingInfo? ViewClassInfo = null,
+    InterceptorLocation Interceptor = default);

--- a/src/ReactiveUI.Binding.SourceGenerators/Models/BindToInvocationInfo.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Models/BindToInvocationInfo.cs
@@ -18,6 +18,9 @@ namespace ReactiveUI.Binding.SourceGenerators.Models;
 /// <param name="HasConversionHint">Whether the invocation supplies a <c>conversionHint</c> argument.</param>
 /// <param name="HasConverterOverride">Whether the invocation supplies an explicit <c>IBindingTypeConverter</c> argument.</param>
 /// <param name="TargetExpressionText">The original expression text of the target lambda argument.</param>
+/// <param name="Interceptor">
+/// Where this call site is, for a build that claims call sites outright rather than competing for them.
+/// </param>
 internal sealed record BindToInvocationInfo(
     string CallerFilePath,
     int CallerLineNumber,
@@ -27,4 +30,5 @@ internal sealed record BindToInvocationInfo(
     string TargetPropertyTypeFullName,
     bool HasConversionHint,
     bool HasConverterOverride,
-    string TargetExpressionText);
+    string TargetExpressionText,
+    InterceptorLocation Interceptor = default);

--- a/src/ReactiveUI.Binding.SourceGenerators/Models/BindingInvocationInfo.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Models/BindingInvocationInfo.cs
@@ -24,6 +24,9 @@ namespace ReactiveUI.Binding.SourceGenerators.Models;
 /// <param name="SourceExpressionText">The original expression text of the source lambda argument.</param>
 /// <param name="TargetExpressionText">The original expression text of the target lambda argument.</param>
 /// <param name="HasConverterOverride">Whether the invocation uses an explicit <c>IBindingTypeConverter</c> parameter.</param>
+/// <param name="Interceptor">
+/// Where this call site is, for a build that claims call sites outright rather than competing for them.
+/// </param>
 internal sealed record BindingInvocationInfo(
     string CallerFilePath,
     int CallerLineNumber,
@@ -39,4 +42,5 @@ internal sealed record BindingInvocationInfo(
     string MethodName,
     string SourceExpressionText,
     string TargetExpressionText,
-    bool HasConverterOverride);
+    bool HasConverterOverride,
+    InterceptorLocation Interceptor = default);

--- a/src/ReactiveUI.Binding.SourceGenerators/Models/InterceptorLocation.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Models/InterceptorLocation.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Binding.SourceGenerators.Models;
+
+/// <summary>Where a call site sits, in the form the compiler accepts on an interceptor.</summary>
+/// <param name="Version">The encoding the compiler asked for, which travels with the data it produced.</param>
+/// <param name="Data">The opaque call-site description the compiler produced, empty when it described none.</param>
+/// <remarks>
+/// Two strings and an integer rather than the compiler's own type: a pipeline model has to compare by value
+/// and carry no symbol or syntax, and this is the whole of what an interceptor needs to name its call site.
+/// </remarks>
+internal readonly record struct InterceptorLocation(int Version, string? Data)
+{
+    /// <summary>Gets a value indicating whether the compiler described this call site.</summary>
+    /// <remarks>
+    /// A call site is undescribable when it is not an invocation the compiler can intercept - one written
+    /// through a type parameter, for instance - and when the host compiler predates interception entirely.
+    /// </remarks>
+    internal bool IsAvailable => !string.IsNullOrEmpty(Data);
+}

--- a/src/ReactiveUI.Binding.SourceGenerators/Models/InvocationInfo.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Models/InvocationInfo.cs
@@ -18,6 +18,11 @@ namespace ReactiveUI.Binding.SourceGenerators.Models;
 /// <param name="HasSelector">Whether the invocation includes a selector/projection function.</param>
 /// <param name="MethodName">The name of the invoked method (e.g., WhenChanged, WhenChanging, WhenAnyValue).</param>
 /// <param name="ExpressionTexts">The original expression text of each lambda argument, used for CallerArgumentExpression dispatch.</param>
+/// <param name="Interceptor">
+/// Where this call site is, for a build that claims call sites outright rather than competing for them.
+/// Reports that it describes nothing on a compiler that cannot describe one, and for a call the compiler
+/// refuses to let anything intercept.
+/// </param>
 internal sealed record InvocationInfo(
     string CallerFilePath,
     int CallerLineNumber,
@@ -27,4 +32,5 @@ internal sealed record InvocationInfo(
     bool IsBeforeChange,
     bool HasSelector,
     string MethodName,
-    EquatableArray<string> ExpressionTexts);
+    EquatableArray<string> ExpressionTexts,
+    InterceptorLocation Interceptor = default);

--- a/src/ReactiveUI.Binding.SourceGenerators/Models/LanguageFeatures.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Models/LanguageFeatures.cs
@@ -61,6 +61,13 @@ namespace ReactiveUI.Binding.SourceGenerators.Models;
 /// Primitives types, and only the ones that flavour actually offers are shifted onto it - the parts that ship in
 /// the shared core, the disposables among them, keep their names in both. Empty for a lean consumer.
 /// </param>
+/// <param name="SupportsInterceptors">
+/// Whether generated code claims each call site outright instead of competing for it. This needs both halves:
+/// a compiler that can describe a call site, which is settled by the analyzer slot the package resolved to, and
+/// a consumer that has opted the generated namespace into interception. Where it holds, none of the placement
+/// this record otherwise describes applies - lookup never sees an interceptor, so there is no namespace to
+/// reach, no import to emit, and no expression text to match at run time.
+/// </param>
 internal readonly record struct LanguageFeatures(
     bool SupportsCallerArgExpr,
     bool SupportsNullable,
@@ -70,4 +77,5 @@ internal readonly record struct LanguageFeatures(
     bool StubHasExpressionParameters = false,
     bool UsesReactiveRuntime = false,
     EquatableArray<string> RuntimeNamespaceMembers = default,
-    EquatableArray<string> PrimitivesNamespaceMembers = default);
+    EquatableArray<string> PrimitivesNamespaceMembers = default,
+    bool SupportsInterceptors = false);

--- a/src/ReactiveUI.Binding.SourceGenerators/Models/WhenAnyObservableInvocationInfo.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Models/WhenAnyObservableInvocationInfo.cs
@@ -17,6 +17,9 @@ namespace ReactiveUI.Binding.SourceGenerators.Models;
 /// <param name="ReturnTypeFullName">The fully qualified return type of the observation.</param>
 /// <param name="HasSelector">Whether the invocation includes a selector/projection function (CombineLatest variant).</param>
 /// <param name="ExpressionTexts">The original expression text of each lambda argument, used for CallerArgumentExpression dispatch.</param>
+/// <param name="Interceptor">
+/// Where this call site is, for a build that claims call sites outright rather than competing for them.
+/// </param>
 internal sealed record WhenAnyObservableInvocationInfo(
     string CallerFilePath,
     int CallerLineNumber,
@@ -25,4 +28,5 @@ internal sealed record WhenAnyObservableInvocationInfo(
     EquatableArray<string> InnerObservableTypeFullNames,
     string ReturnTypeFullName,
     bool HasSelector,
-    EquatableArray<string> ExpressionTexts);
+    EquatableArray<string> ExpressionTexts,
+    InterceptorLocation Interceptor = default);

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/AndroidWidgetEvents.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/AndroidWidgetEvents.cs
@@ -25,34 +25,65 @@ internal static class AndroidWidgetEvents
     /// <param name="propertyName">The property being observed.</param>
     /// <returns>The event name, or <see langword="null"/> when no widget reports that property.</returns>
     /// <remarks>
-    /// A switch rather than a lookup table: the set is closed and known here, so the compiler turns it into a
-    /// jump over the name with nothing built at startup and nothing held for the life of the generator.
+    /// Compared in order rather than looked up: the set is closed and known here, so nothing is built at
+    /// startup and nothing is held for the life of the generator.
     /// </remarks>
-    internal static string? FindChangeEvent(string propertyName) => propertyName switch
+    internal static string? FindChangeEvent(string propertyName)
     {
         // TextView and everything built on it.
-        "Text" => "TextChanged",
+        if (propertyName == "Text")
+        {
+            return "TextChanged";
+        }
 
         // NumberPicker.
-        "Value" => "ValueChanged",
+        if (propertyName == "Value")
+        {
+            return "ValueChanged";
+        }
 
         // RatingBar.
-        "Rating" => "RatingBarChange",
+        if (propertyName == "Rating")
+        {
+            return "RatingBarChange";
+        }
 
         // CompoundButton, and so CheckBox, RadioButton and Switch.
-        "Checked" => "CheckedChange",
+        if (propertyName == "Checked")
+        {
+            return "CheckedChange";
+        }
 
         // CalendarView.
-        "Date" => "DateChange",
+        if (propertyName == "Date")
+        {
+            return "DateChange";
+        }
 
         // TabHost.
-        "CurrentTab" => "TabChanged",
-
-        // TimePicker, whose hour and minute are named one way from API 23 and the other before it.
-        "Hour" or "Minute" or "CurrentHour" or "CurrentMinute" => "TimeChanged",
+        if (propertyName == "CurrentTab")
+        {
+            return "TabChanged";
+        }
 
         // AdapterView, and so Spinner and ListView.
-        "SelectedItem" => "ItemSelected",
-        _ => null,
-    };
+        if (propertyName == "SelectedItem")
+        {
+            return "ItemSelected";
+        }
+
+        return IsTimePickerField(propertyName) ? "TimeChanged" : null;
+    }
+
+    /// <summary>Determines whether a name is one of the fields TimePicker reports its time change for.</summary>
+    /// <param name="propertyName">The property being observed.</param>
+    /// <returns><see langword="true"/> when TimePicker reports it.</returns>
+    /// <remarks>
+    /// The one widget in the list that names the same two values two ways: the hour and the minute are
+    /// <c>Hour</c> and <c>Minute</c> from API 23, and <c>CurrentHour</c> and <c>CurrentMinute</c> before it.
+    /// All four report on the same event.
+    /// </remarks>
+    private static bool IsTimePickerField(string propertyName) =>
+        propertyName == "Hour" || propertyName == "Minute"
+        || propertyName == "CurrentHour" || propertyName == "CurrentMinute";
 }

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/AndroidWidgetEvents.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/AndroidWidgetEvents.cs
@@ -21,40 +21,38 @@ namespace ReactiveUI.Binding.SourceGenerators.Plugins.Observation;
 /// </remarks>
 internal static class AndroidWidgetEvents
 {
-    /// <summary>The property each reporting widget raises an event for, and the event it raises.</summary>
-    private static readonly Dictionary<string, string> _changeEvents = new(StringComparer.Ordinal)
-    {
-        // TextView and everything built on it.
-        ["Text"] = "TextChanged",
-
-        // NumberPicker.
-        ["Value"] = "ValueChanged",
-
-        // RatingBar.
-        ["Rating"] = "RatingBarChange",
-
-        // CompoundButton, and so CheckBox, RadioButton and Switch.
-        ["Checked"] = "CheckedChange",
-
-        // CalendarView.
-        ["Date"] = "DateChange",
-
-        // TabHost.
-        ["CurrentTab"] = "TabChanged",
-
-        // TimePicker, whose hour and minute are named one way from API 23 and the other before it.
-        ["Hour"] = "TimeChanged",
-        ["Minute"] = "TimeChanged",
-        ["CurrentHour"] = "TimeChanged",
-        ["CurrentMinute"] = "TimeChanged",
-
-        // AdapterView, and so Spinner and ListView.
-        ["SelectedItem"] = "ItemSelected",
-    };
-
     /// <summary>Finds the event a widget raises when the named property changes.</summary>
     /// <param name="propertyName">The property being observed.</param>
     /// <returns>The event name, or <see langword="null"/> when no widget reports that property.</returns>
-    internal static string? FindChangeEvent(string propertyName) =>
-        _changeEvents.TryGetValue(propertyName, out var changeEvent) ? changeEvent : null;
+    /// <remarks>
+    /// A switch rather than a lookup table: the set is closed and known here, so the compiler turns it into a
+    /// jump over the name with nothing built at startup and nothing held for the life of the generator.
+    /// </remarks>
+    internal static string? FindChangeEvent(string propertyName) => propertyName switch
+    {
+        // TextView and everything built on it.
+        "Text" => "TextChanged",
+
+        // NumberPicker.
+        "Value" => "ValueChanged",
+
+        // RatingBar.
+        "Rating" => "RatingBarChange",
+
+        // CompoundButton, and so CheckBox, RadioButton and Switch.
+        "Checked" => "CheckedChange",
+
+        // CalendarView.
+        "Date" => "DateChange",
+
+        // TabHost.
+        "CurrentTab" => "TabChanged",
+
+        // TimePicker, whose hour and minute are named one way from API 23 and the other before it.
+        "Hour" or "Minute" or "CurrentHour" or "CurrentMinute" => "TimeChanged",
+
+        // AdapterView, and so Spinner and ListView.
+        "SelectedItem" => "ItemSelected",
+        _ => null,
+    };
 }

--- a/src/ReactiveUI.Binding.SourceGenerators/ReactiveUI.Binding.SourceGenerators.csproj
+++ b/src/ReactiveUI.Binding.SourceGenerators/ReactiveUI.Binding.SourceGenerators.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ReactiveUI.Binding.SourceGenerators.Tests"/>
+    <InternalsVisibleTo Include="ReactiveUI.Binding.SourceGenerators.Tests.Roslyn413"/>
   </ItemGroup>
 
   <ItemGroup>
@@ -28,6 +29,9 @@
     <None Include="build\ReactiveUI.Binding.SourceGenerators.props"
           Pack="true"
           PackagePath="build\ReactiveUI.Binding.SourceGenerators.props;buildTransitive\ReactiveUI.Binding.SourceGenerators.props"/>
+    <None Include="build\ReactiveUI.Binding.SourceGenerators.targets"
+          Pack="true"
+          PackagePath="build\ReactiveUI.Binding.SourceGenerators.targets;buildTransitive\ReactiveUI.Binding.SourceGenerators.targets"/>
   </ItemGroup>
 
   <!-- Roslyn 4.8.0 baseline (VS 2022 17.8, .NET 8.0.1xx SDK). The generator ships in the

--- a/src/ReactiveUI.Binding.SourceGenerators/build/ReactiveUI.Binding.SourceGenerators.targets
+++ b/src/ReactiveUI.Binding.SourceGenerators/build/ReactiveUI.Binding.SourceGenerators.targets
@@ -1,0 +1,88 @@
+<Project>
+
+  <PropertyGroup>
+    <!--
+      Whether the generator claims each binding call site outright instead of offering an overload that has to
+      win extension-method lookup. Interception is what serves a call site the overloads cannot reach: a file
+      declared outside the root namespace, or a project below C# 10 whose assembly exposes its internals.
+
+      Set to false to keep the dispatch overloads on a compiler that could intercept:
+
+        <PropertyGroup>
+          <ReactiveUIBindingUseInterceptors>false</ReactiveUIBindingUseInterceptors>
+        </PropertyGroup>
+    -->
+    <ReactiveUIBindingUseInterceptors Condition="'$(ReactiveUIBindingUseInterceptors)' == ''">true</ReactiveUIBindingUseInterceptors>
+
+    <!-- The namespace the interceptors are generated into, and the one the compiler is asked to honour. -->
+    <_ReactiveUIBindingInterceptorNamespace>ReactiveUI.Binding.Generated.Interceptors</_ReactiveUIBindingInterceptorNamespace>
+
+    <!-- The oldest and the newest analyzers\dotnet\roslyn&lt;version&gt;\cs slot this package ships. -->
+    <_ReactiveUIBindingMinimumCompilerVersion>4.8</_ReactiveUIBindingMinimumCompilerVersion>
+    <_ReactiveUIBindingInterceptorCompilerVersion>4.13</_ReactiveUIBindingInterceptorCompilerVersion>
+  </PropertyGroup>
+
+  <!--
+    Settle which analyzer slot this build gets, and turn interception on where that slot can honour it.
+
+    Both halves need $(CompilerApiVersion), which the Roslyn targets set long after a .props file is
+    evaluated, so this is a target rather than a plain property group. Every guard is deliberately
+    fail-open: an unset, non-Roslyn or malformed value falls back to the oldest slot rather than breaking a
+    build we do not understand.
+  -->
+  <Target Name="ReactiveUIBindingSelectAnalyzerSlot"
+          BeforeTargets="CoreCompile"
+          Condition="'$(Language)' == 'C#'">
+    <PropertyGroup>
+      <_ReactiveUIBindingCompilerVersion Condition="'$(CompilerApiVersion)' != '' and $(CompilerApiVersion.StartsWith('roslyn'))">$(CompilerApiVersion.Substring(6))</_ReactiveUIBindingCompilerVersion>
+      <_ReactiveUIBindingCompilerVersion Condition="!$(_ReactiveUIBindingCompilerVersion.Contains('.'))">$(_ReactiveUIBindingMinimumCompilerVersion)</_ReactiveUIBindingCompilerVersion>
+
+      <_ReactiveUIBindingInterceptsCallSites>false</_ReactiveUIBindingInterceptsCallSites>
+      <_ReactiveUIBindingInterceptsCallSites Condition="'$([System.Version]::Parse($(_ReactiveUIBindingCompilerVersion)).CompareTo($([System.Version]::Parse($(_ReactiveUIBindingInterceptorCompilerVersion)))))' &gt;= '0'">true</_ReactiveUIBindingInterceptsCallSites>
+
+      <_ReactiveUIBindingSlot Condition="'$(_ReactiveUIBindingInterceptsCallSites)' == 'true'">roslyn$(_ReactiveUIBindingInterceptorCompilerVersion)</_ReactiveUIBindingSlot>
+      <_ReactiveUIBindingSlot Condition="'$(_ReactiveUIBindingSlot)' == ''">roslyn$(_ReactiveUIBindingMinimumCompilerVersion)</_ReactiveUIBindingSlot>
+    </PropertyGroup>
+
+    <!--
+      Only the .NET SDK narrows a package that ships several slots down to one: its ResolvePackageAssets task
+      picks the highest slot at or below $(CompilerApiVersion). A legacy non-SDK .csproj never runs that task,
+      so it receives every slot at once, loads the generator twice and emits every dispatch file twice.
+      Dropping the slots this compiler is not being served by gives both kinds of consumer the same single one.
+    -->
+    <ItemGroup>
+      <_ReactiveUIBindingAnalyzer Include="@(Analyzer)"
+                                  Condition="'%(Analyzer.Filename)' == 'ReactiveUI.Binding.SourceGenerators' or '%(Analyzer.Filename)' == 'ReactiveUI.Binding.Analyzer'">
+        <_Slot>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetDirectoryName('%(Analyzer.FullPath)'))))))</_Slot>
+      </_ReactiveUIBindingAnalyzer>
+
+      <Analyzer Remove="@(_ReactiveUIBindingAnalyzer)"
+                Condition="'%(_ReactiveUIBindingAnalyzer._Slot)' != '$(_ReactiveUIBindingSlot)'"/>
+    </ItemGroup>
+
+    <!--
+      Interception is refused outright for a namespace the project did not list, so the opt-in travels with
+      the generator that emits into it. Appended to whatever the project already listed, and written straight
+      into $(Features) because the friendly property was folded into it before this target runs.
+    -->
+    <PropertyGroup Condition="'$(_ReactiveUIBindingInterceptsCallSites)' == 'true' and '$(ReactiveUIBindingUseInterceptors)' == 'true'">
+      <_ReactiveUIBindingInterceptorsNamespaces>$(InterceptorsNamespaces)</_ReactiveUIBindingInterceptorsNamespaces>
+      <_ReactiveUIBindingInterceptorsNamespaces Condition="'$(_ReactiveUIBindingInterceptorsNamespaces)' != ''">$(_ReactiveUIBindingInterceptorsNamespaces);</_ReactiveUIBindingInterceptorsNamespaces>
+      <_ReactiveUIBindingInterceptorsNamespaces>$(_ReactiveUIBindingInterceptorsNamespaces)$(_ReactiveUIBindingInterceptorNamespace)</_ReactiveUIBindingInterceptorsNamespaces>
+      <Features>$(Features);InterceptorsNamespaces=$(_ReactiveUIBindingInterceptorsNamespaces)</Features>
+    </PropertyGroup>
+
+    <!--
+      Fail loudly on a compiler older than the oldest slot. NuGet asset selection drops a slot newer than the
+      host compiler without reporting anything, so such a consumer would otherwise get no generated bindings
+      and a runtime throw from every binding call with no hint at the cause.
+    -->
+    <Error Condition="'$(CompilerApiVersion)' != ''
+                      and $(CompilerApiVersion.StartsWith('roslyn'))
+                      and $(_ReactiveUIBindingCompilerVersion.Contains('.'))
+                      and '$([System.Version]::Parse($(_ReactiveUIBindingMinimumCompilerVersion)).CompareTo($([System.Version]::Parse($(_ReactiveUIBindingCompilerVersion)))))' &gt; '0'"
+           Code="RXUIBIND100"
+           Text="ReactiveUI.Binding's source generator requires Roslyn $(_ReactiveUIBindingMinimumCompilerVersion) or later (Visual Studio 2022 17.8+, or .NET SDK 8.0.100+), but this project is building with Roslyn $(_ReactiveUIBindingCompilerVersion). Upgrade the build tools to get compile-time bindings."/>
+  </Target>
+
+</Project>

--- a/src/ReactiveUI.Binding/ReactiveUI.Binding.csproj
+++ b/src/ReactiveUI.Binding/ReactiveUI.Binding.csproj
@@ -56,15 +56,25 @@
        generator is not run over this project's own source. -->
   <ItemGroup>
     <ProjectReference Include="..\ReactiveUI.Binding.SourceGenerators\ReactiveUI.Binding.SourceGenerators.csproj" PrivateAssets="all" ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="..\ReactiveUI.Binding.SourceGenerators.Roslyn413\ReactiveUI.Binding.SourceGenerators.Roslyn413.csproj" PrivateAssets="all" ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="..\ReactiveUI.Binding.Analyzer.Roslyn413\ReactiveUI.Binding.Analyzer.Roslyn413.csproj" PrivateAssets="all" ReferenceOutputAssembly="false"/>
   </ItemGroup>
 
   <!-- Packed as plain files rather than through TargetsForTfmSpecificContentInPackage: that hook runs once
        per target framework, and the analyzer folder is framework-agnostic, so it would offer the same path
-       six times over. -->
+       six times over.
+
+       One slot per compiler generation, because what the generator can do differs between them: the 4.13
+       build claims each call site with an interceptor, the 4.8 build offers an overload that has to win
+       extension-method lookup. The accompanying .targets is what keeps a consumer whose build does not
+       narrow the slots itself from loading both. -->
   <ItemGroup>
-    <None Include="..\ReactiveUI.Binding.SourceGenerators\bin\$(Configuration)\netstandard2.0\ReactiveUI.Binding.SourceGenerators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
-    <None Include="..\ReactiveUI.Binding.Analyzer\bin\$(Configuration)\netstandard2.0\ReactiveUI.Binding.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+    <None Include="..\ReactiveUI.Binding.SourceGenerators\bin\$(Configuration)\netstandard2.0\ReactiveUI.Binding.SourceGenerators.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.8/cs" Visible="false"/>
+    <None Include="..\ReactiveUI.Binding.Analyzer\bin\$(Configuration)\netstandard2.0\ReactiveUI.Binding.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.8/cs" Visible="false"/>
+    <None Include="..\ReactiveUI.Binding.SourceGenerators.Roslyn413\bin\$(Configuration)\netstandard2.0\ReactiveUI.Binding.SourceGenerators.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.13/cs" Visible="false"/>
+    <None Include="..\ReactiveUI.Binding.Analyzer.Roslyn413\bin\$(Configuration)\netstandard2.0\ReactiveUI.Binding.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.13/cs" Visible="false"/>
     <None Include="..\ReactiveUI.Binding.SourceGenerators\build\ReactiveUI.Binding.SourceGenerators.props" Pack="true" PackagePath="build\$(MSBuildProjectName).props;buildTransitive\$(MSBuildProjectName).props" Visible="false"/>
+    <None Include="..\ReactiveUI.Binding.SourceGenerators\build\ReactiveUI.Binding.SourceGenerators.targets" Pack="true" PackagePath="build\$(MSBuildProjectName).targets;buildTransitive\$(MSBuildProjectName).targets" Visible="false"/>
   </ItemGroup>
 
   <!-- DateOnly and TimeOnly only exist on .NET 6+. Their converters are guarded with

--- a/src/benchmarks/ReactiveUI.Binding.Generator.Benchmarks.Roslyn413/ReactiveUI.Binding.Generator.Benchmarks.Roslyn413.csproj
+++ b/src/benchmarks/ReactiveUI.Binding.Generator.Benchmarks.Roslyn413/ReactiveUI.Binding.Generator.Benchmarks.Roslyn413.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- The same measurements, taken against the generator built for Roslyn 4.13. That build is the one that
+         claims a call site outright, so it is the only one where the interceptor tier can be measured. -->
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0;net10.0;net11.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>ReactiveUI.Binding.Generator.Benchmarks.Roslyn413</AssemblyName>
+    <RootNamespace>ReactiveUI.Binding.Generator.Benchmarks</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp"/>
+    <PackageReference Include="Basic.Reference.Assemblies.Net80"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ReactiveUI.Binding.SourceGenerators.Roslyn413\ReactiveUI.Binding.SourceGenerators.Roslyn413.csproj"/>
+    <ProjectReference Include="..\..\ReactiveUI.Binding\ReactiveUI.Binding.csproj"/>
+  </ItemGroup>
+
+  <!-- No source of its own: it recompiles the baseline project's files against the other generator. -->
+  <ItemGroup>
+    <Compile Include="..\ReactiveUI.Binding.Generator.Benchmarks\**\*.cs"
+             Exclude="..\ReactiveUI.Binding.Generator.Benchmarks\obj\**\*.cs;..\ReactiveUI.Binding.Generator.Benchmarks\bin\**\*.cs"
+             Link="%(RecursiveDir)%(Filename)%(Extension)"/>
+  </ItemGroup>
+
+</Project>

--- a/src/benchmarks/ReactiveUI.Binding.Generator.Benchmarks/GenerationBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Binding.Generator.Benchmarks/GenerationBenchmarks.cs
@@ -26,12 +26,19 @@ public class GenerationBenchmarks
     public int Pairs { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the build lists the generated namespace, which is what decides
+    /// between claiming each call site outright and offering an overload that competes for them all.
+    /// </summary>
+    [Params(false, true)]
+    public bool Intercept { get; set; }
+
+    /// <summary>
     /// Builds the corpus compilation once per parameter set. Loading a framework's worth of metadata
     /// references costs far more than a generation pass and is work the host build does once, so measuring it
     /// per iteration would bury what this benchmark is for.
     /// </summary>
     [GlobalSetup]
-    public void Setup() => _compilation = GeneratorHarness.BuildCompilation(GeneratorCorpus.Build(Pairs));
+    public void Setup() => _compilation = GeneratorHarness.BuildCompilation(GeneratorCorpus.Build(Pairs), Intercept);
 
     /// <summary>Runs a whole cold generation: syntax scan, extraction, and emission.</summary>
     /// <returns>The number of generated characters, returned so the work cannot be optimized away.</returns>
@@ -41,7 +48,7 @@ public class GenerationBenchmarks
     {
         // A fresh driver per iteration: a reused one would serve the next iteration from its caches and
         // measure the incremental path rather than the cold generation a consumer's build pays for.
-        var driver = GeneratorHarness.CreateDriver();
+        var driver = GeneratorHarness.CreateDriver(Intercept);
         var result = driver.RunGenerators(_compilation).GetRunResult();
 
         var characters = 0;

--- a/src/benchmarks/ReactiveUI.Binding.Generator.Benchmarks/GeneratorHarness.cs
+++ b/src/benchmarks/ReactiveUI.Binding.Generator.Benchmarks/GeneratorHarness.cs
@@ -15,13 +15,34 @@ internal static class GeneratorHarness
     /// <summary>The assembly name given to the throwaway compilation the generator runs against.</summary>
     private const string CompilationAssemblyName = "Corpus";
 
-    /// <summary>Builds a compilation over the corpus source.</summary>
-    /// <param name="sourceText">The corpus source text.</param>
-    /// <returns>The compilation.</returns>
-    internal static CSharpCompilation BuildCompilation(string sourceText)
+    /// <summary>The feature a build lists interceptable namespaces under.</summary>
+    private const string InterceptorsNamespacesFeature = "InterceptorsNamespaces";
+
+    /// <summary>The namespace the generator emits interceptors into.</summary>
+    private const string InterceptorNamespace = "ReactiveUI.Binding.Generated.Interceptors";
+
+    /// <summary>
+    /// The parse options of a build that lists the generated namespace, which is what the shipped targets set
+    /// wherever the compiler can honour an interceptor emitted into it.
+    /// </summary>
+    /// <param name="intercept">Whether the build lists the namespace.</param>
+    /// <returns>The parse options.</returns>
+    internal static CSharpParseOptions ParseOptions(bool intercept)
     {
         var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp10);
-        var syntaxTree = CSharpSyntaxTree.ParseText(sourceText, parseOptions);
+
+        return intercept
+            ? parseOptions.WithFeatures([new KeyValuePair<string, string>(InterceptorsNamespacesFeature, InterceptorNamespace)])
+            : parseOptions;
+    }
+
+    /// <summary>Builds a compilation over the corpus source.</summary>
+    /// <param name="sourceText">The corpus source text.</param>
+    /// <param name="intercept">Whether the build lists the generated namespace for interception.</param>
+    /// <returns>The compilation.</returns>
+    internal static CSharpCompilation BuildCompilation(string sourceText, bool intercept)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(sourceText, ParseOptions(intercept));
 
         var references = new List<MetadataReference>(Basic.Reference.Assemblies.Net80.References.All)
         {
@@ -38,12 +59,13 @@ internal static class GeneratorHarness
     }
 
     /// <summary>Creates a cold generator driver, carrying no caches from a previous run.</summary>
+    /// <param name="intercept">Whether the build lists the generated namespace for interception.</param>
     /// <returns>The generator driver.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static GeneratorDriver CreateDriver() =>
+    internal static GeneratorDriver CreateDriver(bool intercept) =>
         CSharpGeneratorDriver.Create(
             [new BindingGenerator().AsSourceGenerator()],
             null,
-            new(LanguageVersion.CSharp10),
+            ParseOptions(intercept),
             null);
 }

--- a/src/tests/ReactiveUI.Binding.Analyzer.Tests.Roslyn413/ReactiveUI.Binding.Analyzer.Tests.Roslyn413.csproj
+++ b/src/tests/ReactiveUI.Binding.Analyzer.Tests.Roslyn413/ReactiveUI.Binding.Analyzer.Tests.Roslyn413.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- The same tests, run against the analyzer built for Roslyn 4.13. That build knows the generator
+         travelling with it claims call sites outright, which changes what it has to report. -->
     <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
@@ -17,10 +19,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\ReactiveUI.Binding.Analyzer\ReactiveUI.Binding.Analyzer.csproj"/>
+    <ProjectReference Include="..\..\ReactiveUI.Binding.Analyzer.Roslyn413\ReactiveUI.Binding.Analyzer.Roslyn413.csproj"/>
   </ItemGroup>
 
+  <!-- No test source of its own: it recompiles the baseline project's files against the other analyzer. -->
   <ItemGroup>
+    <Compile Include="..\ReactiveUI.Binding.Analyzer.Tests\**\*.cs"
+             Exclude="..\ReactiveUI.Binding.Analyzer.Tests\obj\**\*.cs;..\ReactiveUI.Binding.Analyzer.Tests\bin\**\*.cs"
+             Link="%(RecursiveDir)%(Filename)%(Extension)"/>
     <Compile Include="..\Shared\TransitiveAssemblyResolver.cs" Link="Shared\TransitiveAssemblyResolver.cs"/>
     <Compile Include="..\Shared\RoslynSymbolProbe.cs" Link="Shared\RoslynSymbolProbe.cs"/>
   </ItemGroup>

--- a/src/tests/ReactiveUI.Binding.Analyzer.Tests/DispatchReachAnalyzerTests.cs
+++ b/src/tests/ReactiveUI.Binding.Analyzer.Tests/DispatchReachAnalyzerTests.cs
@@ -5,6 +5,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using ReactiveUI.Binding.Analyzer.Analyzers;
 using ReactiveUI.Binding.Analyzer.Tests.Helpers;
+using ReactiveUI.Binding.SourceGenerators.Helpers;
 
 namespace ReactiveUI.Binding.Analyzer.Tests;
 
@@ -120,6 +121,43 @@ public class DispatchReachAnalyzerTests
             RootNamespace);
 
         await Assert.That(diagnostics.Any(static d => d.Id == DiagnosticId)).IsFalse();
+    }
+
+    /// <summary>
+    /// The reach of a dispatch overload decides nothing where the call site is claimed outright, so a build
+    /// that lists the generated namespace is not warned - on the compiler that can honour the listing. On one
+    /// that cannot, the overloads are still what serves the call and the warning stands.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task ListingTheGeneratedNamespace_IsReportedOnlyWhereInterceptionCannotBeHonoured()
+    {
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<DispatchReachAnalyzer>(
+            SourceIn(UnrelatedNamespace, GrantsInternals),
+            AnalyzerTestHelper.InterceptingParseOptionsFor(LanguageVersion.CSharp7_3),
+            RootNamespace);
+
+        await Assert.That(diagnostics.Any(static d => d.Id == DiagnosticId))
+            .IsEqualTo(!InterceptableLocationReader.IsSupported);
+    }
+
+    /// <summary>
+    /// Listing another package's namespace is not this package's opt-in, so the call is reported whichever
+    /// compiler is building it.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task ListingAnotherPackagesNamespace_IsReported()
+    {
+        var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp7_3)
+            .WithFeatures([new KeyValuePair<string, string>("InterceptorsNamespaces", "Some.Other.Package")]);
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<DispatchReachAnalyzer>(
+            SourceIn(UnrelatedNamespace, GrantsInternals),
+            parseOptions,
+            RootNamespace);
+
+        await Assert.That(diagnostics.Count(static d => d.Id == DiagnosticId)).IsEqualTo(1);
     }
 
     /// <summary>With no root namespace there is nowhere else to emit, so the shared namespace is kept.</summary>

--- a/src/tests/ReactiveUI.Binding.Analyzer.Tests/Helpers/AnalyzerHelpersTests.cs
+++ b/src/tests/ReactiveUI.Binding.Analyzer.Tests/Helpers/AnalyzerHelpersTests.cs
@@ -5,8 +5,8 @@
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using NSubstitute;
 using ReactiveUI.Binding.Analyzer.Analyzers;
+using ReactiveUI.Binding.Tests.Shared;
 
 namespace ReactiveUI.Binding.Analyzer.Tests.Helpers;
 
@@ -86,21 +86,19 @@ public class AnalyzerHelpersTests
     [Test]
     public async Task IsBindingExtensionMethod_NullContainingType_ReturnsFalse()
     {
-        var methodSymbol = Substitute.For<IMethodSymbol>();
-        _ = methodSymbol.ContainingType.Returns((INamedTypeSymbol?)null);
+        var methodSymbol = RoslynSymbolProbe.MethodWithNoContainingType();
 
         var result = AnalyzerHelpers.IsBindingExtensionMethod(methodSymbol);
 
         await Assert.That(result).IsFalse();
     }
 
-    /// <summary>Verifies that ExtractFirstTypeArgument returns null when TypeArguments is empty (using a substitute method symbol).</summary>
+    /// <summary>Verifies that ExtractFirstTypeArgument returns null for a method that names no type arguments.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task ExtractFirstTypeArgument_EmptyTypeArguments_ReturnsNull_Substitute()
+    public async Task ExtractFirstTypeArgument_MethodNamesNoTypeArguments_ReturnsNull()
     {
-        var methodSymbol = Substitute.For<IMethodSymbol>();
-        _ = methodSymbol.TypeArguments.Returns([]);
+        var methodSymbol = RoslynSymbolProbe.MethodWithNoContainingType();
 
         var result = AnalyzerHelpers.ExtractFirstTypeArgument(methodSymbol);
 

--- a/src/tests/ReactiveUI.Binding.Analyzer.Tests/Helpers/AnalyzerTestHelper.cs
+++ b/src/tests/ReactiveUI.Binding.Analyzer.Tests/Helpers/AnalyzerTestHelper.cs
@@ -24,7 +24,7 @@ public static class AnalyzerTestHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync<TAnalyzer>(string source)
         where TAnalyzer : DiagnosticAnalyzer, new() =>
-        GetDiagnosticsAsync<TAnalyzer>(source, null, null);
+        GetDiagnosticsAsync<TAnalyzer>(source, (LanguageVersion?)null, null);
 
     /// <summary>
     /// Runs an analyzer against source compiled at a given language version, with the root namespace reported
@@ -36,13 +36,31 @@ public static class AnalyzerTestHelper
     /// <param name="rootNamespace">The root namespace the build exposes, or null for none.</param>
     /// <returns>The analyzer diagnostics.</returns>
     [SuppressMessage("Design", "SST2307:Type parameter is not inferable", Justification = "the analyzer under test is specified explicitly by the caller")]
-    public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync<TAnalyzer>(
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync<TAnalyzer>(
         string source,
         LanguageVersion? languageVersion,
         string? rootNamespace)
+        where TAnalyzer : DiagnosticAnalyzer, new() =>
+        GetDiagnosticsAsync<TAnalyzer>(source, ParseOptionsFor(languageVersion), rootNamespace);
+
+    /// <summary>
+    /// Runs an analyzer against source parsed exactly as the caller asks, which is how a scenario reaches the
+    /// options a language version alone cannot express.
+    /// </summary>
+    /// <typeparam name="TAnalyzer">The analyzer to run.</typeparam>
+    /// <param name="source">The source to analyze.</param>
+    /// <param name="parseOptions">The options the source is parsed with, or null for the default.</param>
+    /// <param name="rootNamespace">The root namespace the build exposes, or null for none.</param>
+    /// <returns>The analyzer diagnostics.</returns>
+    [SuppressMessage("Design", "SST2307:Type parameter is not inferable", Justification = "the analyzer under test is specified explicitly by the caller")]
+    public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync<TAnalyzer>(
+        string source,
+        CSharpParseOptions? parseOptions,
+        string? rootNamespace)
         where TAnalyzer : DiagnosticAnalyzer, new()
     {
-        var compilation = CreateCompilation(source, languageVersion);
+        var compilation = CreateCompilation(source, parseOptions);
         var analyzer = new TAnalyzer();
 
         AnalyzerOptions? analyzerOptions = rootNamespace is null
@@ -61,19 +79,46 @@ public static class AnalyzerTestHelper
         ];
     }
 
+    /// <summary>The parse options a build produces from a language version, which is what the tests usually name.</summary>
+    /// <param name="languageVersion">The language version, or null for the default.</param>
+    /// <returns>The parse options, or null for the default.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static CSharpParseOptions? ParseOptionsFor(LanguageVersion? languageVersion) =>
+        languageVersion.HasValue ? new CSharpParseOptions(languageVersion.Value) : null;
+
+    /// <summary>
+    /// The parse options of a build that has the package's targets on it, which list the generated namespace so
+    /// the compiler honours an interceptor emitted into it.
+    /// </summary>
+    /// <param name="languageVersion">The language version, or null for the default.</param>
+    /// <returns>The parse options, carrying the opt-in.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static CSharpParseOptions InterceptingParseOptionsFor(LanguageVersion? languageVersion) =>
+        (ParseOptionsFor(languageVersion) ?? new CSharpParseOptions())
+            .WithFeatures([new KeyValuePair<string, string>(
+                SourceGenerators.Constants.InterceptorsNamespacesFeature,
+                SourceGenerators.Constants.InterceptorNamespace)]);
+
     /// <summary>Creates a CSharpCompilation from the specified source code with required assembly references.</summary>
     /// <param name="source">The source code to compile into a CSharpCompilation.</param>
     /// <returns>A CSharpCompilation object representing the compiled source code.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static CSharpCompilation CreateCompilation(string source) => CreateCompilation(source, null);
+    internal static CSharpCompilation CreateCompilation(string source) => CreateCompilation(source, (LanguageVersion?)null);
 
     /// <summary>Creates a compilation from source at a given language version.</summary>
     /// <param name="source">The source to compile.</param>
     /// <param name="languageVersion">The language version, or null for the default.</param>
     /// <returns>The compilation.</returns>
-    internal static CSharpCompilation CreateCompilation(string source, LanguageVersion? languageVersion)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static CSharpCompilation CreateCompilation(string source, LanguageVersion? languageVersion) =>
+        CreateCompilation(source, ParseOptionsFor(languageVersion));
+
+    /// <summary>Creates a compilation from source parsed exactly as the caller asks.</summary>
+    /// <param name="source">The source to compile.</param>
+    /// <param name="parseOptions">The options the source is parsed with, or null for the default.</param>
+    /// <returns>The compilation.</returns>
+    internal static CSharpCompilation CreateCompilation(string source, CSharpParseOptions? parseOptions)
     {
-        var parseOptions = languageVersion.HasValue ? new CSharpParseOptions(languageVersion.Value) : null;
         var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
 
         var addedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/tests/ReactiveUI.Binding.Analyzer.Tests/MixinShadowAnalyzerTests.cs
+++ b/src/tests/ReactiveUI.Binding.Analyzer.Tests/MixinShadowAnalyzerTests.cs
@@ -1,0 +1,295 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Binding.Analyzer.Analyzers;
+using ReactiveUI.Binding.Analyzer.Tests.Helpers;
+
+namespace ReactiveUI.Binding.Analyzer.Tests;
+
+/// <summary>
+/// Covers RXUIBIND011, which reports a binding call answered by ReactiveUI's own mixin. Without it the call
+/// generates nothing and takes the runtime expression engine, and no other diagnostic has anything to say
+/// because the call was never recognised as one to generate for.
+/// </summary>
+public class MixinShadowAnalyzerTests
+{
+    /// <summary>The diagnostic this analyzer reports.</summary>
+    private const string DiagnosticId = "RXUIBIND011";
+
+    /// <summary>The namespace ReactiveUI declares its own mixins in.</summary>
+    private const string ReactiveUiNamespace = "ReactiveUI";
+
+    /// <summary>One of the APIs this package generates bindings for.</summary>
+    private const string GeneratedApi = "WhenAnyValue";
+
+    /// <summary>A declaration of this package's stub class, which is how the analyzer knows it is referenced.</summary>
+    private const string BindingPackage = """
+
+                                          namespace ReactiveUI.Binding
+                                          {
+                                              public static class ReactiveUIBindingExtensions
+                                              {
+                                              }
+                                          }
+                                          """;
+
+    /// <summary>A consumer whose call reaches this package's own extension rather than ReactiveUI's.</summary>
+    private const string GeneratedOverloadSource = """
+                                                   using System;
+                                                   using System.ComponentModel;
+                                                   using System.Linq.Expressions;
+                                                   using ReactiveUI.Binding;
+
+                                                   namespace ReactiveUI.Binding
+                                                   {
+                                                       public static class ReactiveUIBindingExtensions
+                                                       {
+                                                           public static IObservable<TRet> WhenAnyValue<TSender, TRet>(
+                                                               this TSender sender,
+                                                               Expression<Func<TSender, TRet>> property)
+                                                               where TSender : class
+                                                               => throw new NotImplementedException();
+                                                       }
+                                                   }
+
+                                                   namespace Consumer
+                                                   {
+                                                       public class ConsumerViewModel : INotifyPropertyChanged
+                                                       {
+                                                           public event PropertyChangedEventHandler PropertyChanged;
+
+                                                           public string Name { get; set; }
+                                                       }
+
+                                                       public static class Usage
+                                                       {
+                                                           public static IObservable<string> Observe(ConsumerViewModel viewModel)
+                                                           {
+                                                               return viewModel.WhenAnyValue(x => x.Name);
+                                                           }
+                                                       }
+                                                   }
+                                                   """;
+
+    /// <summary>A mixin declared in the global namespace, which belongs to nobody in particular.</summary>
+    private const string GlobalNamespaceMixinSource = """
+                                                      using System;
+                                                      using System.ComponentModel;
+                                                      using System.Linq.Expressions;
+
+                                                      public static class WhenAnyMixins
+                                                      {
+                                                          public static IObservable<TRet> WhenAnyValue<TSender, TRet>(
+                                                              this TSender sender,
+                                                              Expression<Func<TSender, TRet>> property)
+                                                              where TSender : class
+                                                              => throw new NotImplementedException();
+                                                      }
+
+                                                      namespace ReactiveUI.Binding
+                                                      {
+                                                          public static class ReactiveUIBindingExtensions
+                                                          {
+                                                          }
+                                                      }
+
+                                                      namespace Consumer
+                                                      {
+                                                          public class ConsumerViewModel : INotifyPropertyChanged
+                                                          {
+                                                              public event PropertyChangedEventHandler PropertyChanged;
+
+                                                              public string Name { get; set; }
+                                                          }
+
+                                                          public static class Usage
+                                                          {
+                                                              public static IObservable<string> Observe(ConsumerViewModel viewModel)
+                                                              {
+                                                                  return viewModel.WhenAnyValue(x => x.Name);
+                                                              }
+                                                          }
+                                                      }
+                                                      """;
+
+    /// <summary>A mixin reached through a type nested inside the one the consumer would name.</summary>
+    private const string NestedMixinSource = """
+                                             using System;
+                                             using System.ComponentModel;
+                                             using System.Linq.Expressions;
+
+                                             namespace ReactiveUI
+                                             {
+                                                 public static class WhenAnyMixins
+                                                 {
+                                                     public static class Grouping
+                                                     {
+                                                         public static IObservable<TRet> WhenAnyValue<TSender, TRet>(
+                                                             TSender sender,
+                                                             Expression<Func<TSender, TRet>> property)
+                                                             where TSender : class
+                                                             => throw new NotImplementedException();
+                                                     }
+                                                 }
+                                             }
+
+                                             namespace ReactiveUI.Binding
+                                             {
+                                                 public static class ReactiveUIBindingExtensions
+                                                 {
+                                                     }
+                                             }
+
+                                             namespace Consumer
+                                             {
+                                                 public class ConsumerViewModel : INotifyPropertyChanged
+                                                 {
+                                                     public event PropertyChangedEventHandler PropertyChanged;
+
+                                                     public string Name { get; set; }
+                                                 }
+
+                                                 public static class Usage
+                                                 {
+                                                     public static IObservable<string> Observe(ConsumerViewModel viewModel)
+                                                     {
+                                                         return ReactiveUI.WhenAnyMixins.Grouping.WhenAnyValue(viewModel, x => x.Name);
+                                                     }
+                                                 }
+                                             }
+                                             """;
+
+    /// <summary>A call ReactiveUI's mixin answered, in a project that references this package.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task MixinCall_WithTheBindingPackageReferenced_IsReported()
+    {
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<MixinShadowAnalyzer>(
+            Source(ReactiveUiNamespace, GeneratedApi, BindingPackage));
+
+        await Assert.That(diagnostics.Count(static d => d.Id == DiagnosticId)).IsEqualTo(1);
+    }
+
+    /// <summary>Without this package there is no generated overload to have lost, so nothing is reported.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task MixinCall_WithoutTheBindingPackage_IsNotReported()
+    {
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<MixinShadowAnalyzer>(
+            Source(ReactiveUiNamespace, GeneratedApi, string.Empty));
+
+        await Assert.That(diagnostics.Any(static d => d.Id == DiagnosticId)).IsFalse();
+    }
+
+    /// <summary>A method this package does not generate for is ReactiveUI's business alone.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task MixinCall_WithAMethodThisPackageDoesNotGenerate_IsNotReported()
+    {
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<MixinShadowAnalyzer>(
+            Source(ReactiveUiNamespace, "Observe", BindingPackage));
+
+        await Assert.That(diagnostics.Any(static d => d.Id == DiagnosticId)).IsFalse();
+    }
+
+    /// <summary>A same-named method belonging to somebody else entirely is not ReactiveUI's mixin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task MixinCall_FromAnUnrelatedNamespace_IsNotReported()
+    {
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<MixinShadowAnalyzer>(
+            Source("Fabrikam", GeneratedApi, BindingPackage));
+
+        await Assert.That(diagnostics.Any(static d => d.Id == DiagnosticId)).IsFalse();
+    }
+
+    /// <summary>A namespace merely ending in ReactiveUI is somebody else's, so it is left alone.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task MixinCall_FromANamespaceNestedUnderAnother_IsNotReported()
+    {
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<MixinShadowAnalyzer>(
+            Source($"Contoso.{ReactiveUiNamespace}", GeneratedApi, BindingPackage));
+
+        await Assert.That(diagnostics.Any(static d => d.Id == DiagnosticId)).IsFalse();
+    }
+
+    /// <summary>A call that reached this package's own extension is the outcome being asked for.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task GeneratedOverload_IsNotReported()
+    {
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<MixinShadowAnalyzer>(
+            GeneratedOverloadSource);
+
+        await Assert.That(diagnostics.Any(static d => d.Id == DiagnosticId)).IsFalse();
+    }
+
+    /// <summary>A mixin in the global namespace is nobody's, so it is left alone.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task MixinCall_FromTheGlobalNamespace_IsNotReported()
+    {
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<MixinShadowAnalyzer>(
+            GlobalNamespaceMixinSource);
+
+        await Assert.That(diagnostics.Any(static d => d.Id == DiagnosticId)).IsFalse();
+    }
+
+    /// <summary>
+    /// A method declared in a type nested inside the mixin class is still ReactiveUI's, which is the shape an
+    /// extension block produces: its members belong to a synthesized type the consumer never wrote.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task MixinCall_ThroughANestedType_IsReported()
+    {
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<MixinShadowAnalyzer>(NestedMixinSource);
+
+        await Assert.That(diagnostics.Count(static d => d.Id == DiagnosticId)).IsEqualTo(1);
+    }
+
+    /// <summary>Builds a consumer whose call is answered by a mixin in the named namespace.</summary>
+    /// <param name="mixinNamespace">The namespace the mixin is declared in.</param>
+    /// <param name="methodName">The name the mixin exposes, and the name the consumer calls.</param>
+    /// <param name="bindingPackage">A declaration of this package's stub class, or an empty string.</param>
+    /// <returns>The source to analyze.</returns>
+    private static string Source(string mixinNamespace, string methodName, string bindingPackage) => $$"""
+        using System;
+        using System.ComponentModel;
+        using System.Linq.Expressions;
+        using {{mixinNamespace}};
+
+        namespace {{mixinNamespace}}
+        {
+            public static class WhenAnyMixins
+            {
+                public static IObservable<TRet> {{methodName}}<TSender, TRet>(
+                    this TSender sender,
+                    Expression<Func<TSender, TRet>> property)
+                    where TSender : class
+                    => throw new NotImplementedException();
+            }
+        }
+        {{bindingPackage}}
+
+        namespace Consumer
+        {
+            public class ConsumerViewModel : INotifyPropertyChanged
+            {
+                public event PropertyChangedEventHandler PropertyChanged;
+
+                public string Name { get; set; }
+            }
+
+            public static class Usage
+            {
+                public static IObservable<string> Observe(ConsumerViewModel viewModel)
+                {
+                    return viewModel.{{methodName}}(x => x.Name);
+                }
+            }
+        }
+        """;
+}

--- a/src/tests/ReactiveUI.Binding.Analyzer.Tests/TypeAnalyzerTests.cs
+++ b/src/tests/ReactiveUI.Binding.Analyzer.Tests/TypeAnalyzerTests.cs
@@ -989,4 +989,52 @@ public class TypeAnalyzerTests
         var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<TypeAnalyzer>(Source);
         await Assert.That(diagnostics.Length).IsEqualTo(0);
     }
+
+    /// <summary>
+    /// Verifies RXUIBIND002 stays silent for <c>BindTo</c>, whose first type argument is the value type of a
+    /// stream the caller already built rather than an object anything observes.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RXUIBIND002_BindToStreamOfPlainValues_NoDiagnostic()
+    {
+        const string Source = """
+                              using System;
+                              using System.ComponentModel;
+                              using System.Linq.Expressions;
+
+                              namespace ReactiveUI.Binding
+                              {
+                                  public static class __ReactiveUIGeneratedBindings
+                                  {
+                                      public static IDisposable BindTo<TValue, TTarget, TTargetValue>(
+                                          this IObservable<TValue> source,
+                                          TTarget target,
+                                          Expression<Func<TTarget, TTargetValue>> property)
+                                          => throw new NotImplementedException();
+                                  }
+                              }
+
+                              namespace TestApp
+                              {
+                                  public class MyView : INotifyPropertyChanged
+                                  {
+                                      public event PropertyChangedEventHandler? PropertyChanged;
+                                      public string Caption { get; set; } = "";
+                                  }
+
+                                  public class Usage
+                                  {
+                                      public void Test(IObservable<string> names)
+                                      {
+                                          var view = new MyView();
+                                          ReactiveUI.Binding.__ReactiveUIGeneratedBindings.BindTo(names, view, v => v.Caption);
+                                      }
+                                  }
+                              }
+                              """;
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync<TypeAnalyzer>(Source);
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
 }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests.Roslyn413/ReactiveUI.Binding.SourceGenerators.Tests.Roslyn413.csproj
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests.Roslyn413/ReactiveUI.Binding.SourceGenerators.Tests.Roslyn413.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- The same tests, run against the generator built for Roslyn 4.13. That build is the one that can
+         describe a call site, so it is the only one where the interceptor tier is reachable at all. -->
     <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
@@ -21,9 +23,14 @@
   <ItemGroup>
     <ProjectReference Include="..\..\ReactiveUI.Binding\ReactiveUI.Binding.csproj"/>
     <ProjectReference Include="..\..\ReactiveUI.Binding.Reactive\ReactiveUI.Binding.Reactive.csproj"/>
-    <ProjectReference Include="..\..\ReactiveUI.Binding.SourceGenerators\ReactiveUI.Binding.SourceGenerators.csproj"/>
+    <ProjectReference Include="..\..\ReactiveUI.Binding.SourceGenerators.Roslyn413\ReactiveUI.Binding.SourceGenerators.Roslyn413.csproj"/>
   </ItemGroup>
+
+  <!-- No test source of its own: it recompiles the baseline project's files against the other generator. -->
   <ItemGroup>
+    <Compile Include="..\ReactiveUI.Binding.SourceGenerators.Tests\**\*.cs"
+             Exclude="..\ReactiveUI.Binding.SourceGenerators.Tests\obj\**\*.cs;..\ReactiveUI.Binding.SourceGenerators.Tests\bin\**\*.cs;..\ReactiveUI.Binding.SourceGenerators.Tests\**\*.verified.cs"
+             Link="%(RecursiveDir)%(Filename)%(Extension)"/>
     <Compile Include="..\Shared\TransitiveAssemblyResolver.cs" Link="Shared\TransitiveAssemblyResolver.cs"/>
     <Compile Include="..\Shared\RoslynSymbolProbe.cs" Link="Shared\RoslynSymbolProbe.cs"/>
   </ItemGroup>
@@ -37,23 +44,6 @@
     <None Include="$(SharedScenariosPath)**\*.cs"
           CopyToOutputDirectory="PreserveNewest"
           LinkBase="SharedScenarios"/>
-  </ItemGroup>
-
-  <!-- Verified snapshot files: don't compile, nest under test classes -->
-  <ItemGroup>
-    <Compile Remove="**/*.verified.cs"/>
-    <None Include="**/*.verified.cs"/>
-    <None Update="BG.*.verified.cs" DependentUpon="BindGeneratorTests.cs"/>
-    <None Update="BOG.*.verified.cs" DependentUpon="BindOneWayGeneratorTests.cs"/>
-    <None Update="BTG.*.verified.cs" DependentUpon="BindTwoWayGeneratorTests.cs"/>
-    <None Update="OBG.*.verified.cs" DependentUpon="OneWayBindGeneratorTests.cs"/>
-    <None Update="WAG.*.verified.cs" DependentUpon="WhenAnyGeneratorTests.cs"/>
-    <None Update="WAOG.*.verified.cs" DependentUpon="WhenAnyObservableGeneratorTests.cs"/>
-    <None Update="WAVG.*.verified.cs" DependentUpon="WhenAnyValueGeneratorTests.cs"/>
-    <None Update="WCG.*.verified.cs" DependentUpon="WhenChangedGeneratorTests.cs"/>
-    <None Update="WCnG.*.verified.cs" DependentUpon="WhenChangingGeneratorTests.cs"/>
-    <None Update="BToG.*.verified.cs" DependentUpon="BindToGeneratorTests.cs"/>
-    <None Update="PDS.*.verified.cs" DependentUpon="PlatformDetectionSnapshotTests.cs"/>
   </ItemGroup>
 
 </Project>

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/AnalyzerPackagingTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/AnalyzerPackagingTests.cs
@@ -1,0 +1,186 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+
+namespace ReactiveUI.Binding.SourceGenerators.Tests;
+
+/// <summary>Tests the analyzer layout of the runtime packages.</summary>
+/// <remarks>
+/// What the generator can do differs between compiler generations, so each runtime package ships one
+/// <c>analyzers/dotnet/roslyn&lt;version&gt;/cs</c> slot per generation. Only the .NET SDK narrows that down to
+/// one: its <c>ResolvePackageAssets</c> task picks the highest slot at or below <c>$(CompilerApiVersion)</c>. A
+/// build that never runs that task receives every slot at once, loads the generator twice and emits every
+/// dispatch file twice, which the shipped targets prevent by dropping the slots the compiler is not served by.
+/// The versions in the layout and in those targets therefore have to agree, which is asserted here rather than
+/// left to a convention a later change can quietly break.
+/// </remarks>
+public class AnalyzerPackagingTests
+{
+    /// <summary>The property in the shipped targets naming the oldest slot.</summary>
+    private const string MinimumCompilerVersionProperty = "_ReactiveUIBindingMinimumCompilerVersion";
+
+    /// <summary>The property in the shipped targets naming the slot that can intercept.</summary>
+    private const string InterceptorCompilerVersionProperty = "_ReactiveUIBindingInterceptorCompilerVersion";
+
+    /// <summary>The shipped targets, relative to the source root.</summary>
+    private const string TargetsPath =
+        "ReactiveUI.Binding.SourceGenerators/build/ReactiveUI.Binding.SourceGenerators.targets";
+
+    /// <summary>The separators a project spells a path with, whichever platform reads it.</summary>
+    private static readonly SearchValues<char> PathSeparators = SearchValues.Create(['\\', '/']);
+
+    /// <summary>The assemblies every slot has to carry.</summary>
+    private static readonly string[] SlotAssemblies =
+    [
+        "ReactiveUI.Binding.Analyzer.dll",
+        "ReactiveUI.Binding.SourceGenerators.dll",
+    ];
+
+    /// <summary>The runtime packages that carry the analyzers.</summary>
+    private static readonly string[] RuntimePackages =
+    [
+        "ReactiveUI.Binding/ReactiveUI.Binding.csproj",
+        "ReactiveUI.Binding.Reactive/ReactiveUI.Binding.Reactive.csproj",
+    ];
+
+    /// <summary>Every package ships the same slots, and the versions the targets name are exactly those.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task PackagesShipTheSlotsTheTargetsSelectBetween()
+    {
+        var expected = string.Join(
+            ", ",
+            new[]
+            {
+                $"analyzers/dotnet/roslyn{ReadTargetsProperty(MinimumCompilerVersionProperty)}/cs",
+                $"analyzers/dotnet/roslyn{ReadTargetsProperty(InterceptorCompilerVersionProperty)}/cs",
+            }.Order(StringComparer.OrdinalIgnoreCase));
+
+        foreach (var package in RuntimePackages)
+        {
+            var slots = PackagedAnalyzers(package)
+                .Select(static analyzer => analyzer.PackagePath)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Order(StringComparer.OrdinalIgnoreCase);
+
+            // Joined rather than compared element-wise so a stray extra slot shows up in the diff.
+            await Assert.That(string.Join(", ", slots)).IsEqualTo(expected);
+        }
+    }
+
+    /// <summary>A slot missing an assembly would leave that compiler generation without it.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task EverySlotCarriesTheGeneratorAndTheAnalyzer()
+    {
+        foreach (var package in RuntimePackages)
+        {
+            foreach (var slot in PackagedAnalyzers(package).GroupBy(static analyzer => analyzer.PackagePath, StringComparer.OrdinalIgnoreCase))
+            {
+                var assemblies = slot.Select(static analyzer => analyzer.FileName)
+                    .Order(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                await Assert.That(assemblies).IsEquivalentTo(SlotAssemblies);
+            }
+        }
+    }
+
+    /// <summary>Two copies of one assembly in a package load as two generators, whichever folder they sit in.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task NoAssemblyIsShippedTwiceWithinASlot()
+    {
+        foreach (var package in RuntimePackages)
+        {
+            var duplicated = PackagedAnalyzers(package)
+                .GroupBy(static analyzer => $"{analyzer.PackagePath}/{analyzer.FileName}", StringComparer.OrdinalIgnoreCase)
+                .Where(static group => group.Count() > 1)
+                .Select(static group => group.Key)
+                .ToArray();
+
+            await Assert.That(duplicated).IsEmpty();
+        }
+    }
+
+    /// <summary>The targets and the props both travel with every package that ships a slot.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task EveryPackageShippingASlotAlsoShipsTheTargetsThatSelectIt()
+    {
+        foreach (var package in RuntimePackages)
+        {
+            var packed = PackedNoneItems(package)
+                .Select(static item => FileNameOf(item.FileName))
+                .ToArray();
+
+            await Assert.That(packed).Contains("ReactiveUI.Binding.SourceGenerators.targets");
+            await Assert.That(packed).Contains("ReactiveUI.Binding.SourceGenerators.props");
+        }
+    }
+
+    /// <summary>Reads a property value out of the shipped targets.</summary>
+    /// <param name="propertyName">The property to read.</param>
+    /// <returns>The declared value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string ReadTargetsProperty(string propertyName) =>
+        XDocument.Load(SourcePath(TargetsPath))
+            .Descendants()
+            .Where(element => element.Name.LocalName == propertyName)
+            .Select(static element => element.Value.Trim())
+            .Single();
+
+    /// <summary>Reads the analyzer files a package packs, and the slot each lands in.</summary>
+    /// <param name="projectPath">The package project, relative to the source root.</param>
+    /// <returns>Each packed file, as the package path it lands in and the file it was packed from.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static IEnumerable<(string PackagePath, string FileName)> PackedNoneItems(string projectPath) =>
+        XDocument.Load(SourcePath(projectPath))
+            .Descendants()
+            .Where(static element => element.Name.LocalName == "None"
+                && string.Equals(element.Attribute("Pack")?.Value, "true", StringComparison.OrdinalIgnoreCase))
+            .Select(static element => (
+                PackagePath: element.Attribute("PackagePath")?.Value ?? string.Empty,
+                FileName: element.Attribute("Include")?.Value ?? string.Empty));
+
+    /// <summary>Reads the analyzer assemblies a package packs into a slot.</summary>
+    /// <param name="projectPath">The package project, relative to the source root.</param>
+    /// <returns>Each packed analyzer, as the slot it lands in and the file name it lands under.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static IEnumerable<(string PackagePath, string FileName)> PackagedAnalyzers(string projectPath) =>
+        PackedNoneItems(projectPath)
+            .Where(static item => item.PackagePath.StartsWith("analyzers/", StringComparison.OrdinalIgnoreCase))
+            .Select(static item => (item.PackagePath, FileNameOf(item.FileName)));
+
+    /// <summary>
+    /// Reads the file name off a path a project wrote, which spells its separators the way MSBuild does rather
+    /// than the way the running platform does.
+    /// </summary>
+    /// <param name="path">The path as the project spells it.</param>
+    /// <returns>The file name.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string FileNameOf(string path) =>
+        path[(path.AsSpan().LastIndexOfAny(PathSeparators) + 1)..];
+
+    /// <summary>Resolves a path under the source root, found by walking out of the test output directory.</summary>
+    /// <param name="relativePath">The path relative to the source root.</param>
+    /// <returns>The absolute path.</returns>
+    /// <exception cref="InvalidOperationException">The source root was not found above the test output.</exception>
+    private static string SourcePath(string relativePath)
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            var candidate = Path.Combine(directory.FullName, relativePath);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        throw new InvalidOperationException($"'{relativePath}' was not found above '{AppContext.BaseDirectory}'.");
+    }
+}

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/BindToExtractorTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/BindToExtractorTests.cs
@@ -2,10 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using NSubstitute;
 using ReactiveUI.Binding.SourceGenerators.Helpers;
 
 namespace ReactiveUI.Binding.SourceGenerators.Tests.Helpers;
@@ -63,44 +61,11 @@ public class BindToExtractorTests
     public async Task GetObservableValueType_ReceiverImplementsLookalikeInterface_ReturnsNull() =>
         await Assert.That(BindToExtractor.GetObservableValueType(FieldType("Probe.Lookalike"))).IsNull();
 
-    /// <summary>
-    /// A type with no containing namespace is not taken for the framework interface. Source cannot produce
-    /// one - every declared type lands in the global namespace at worst - so the guard is asserted directly.
-    /// </summary>
+    /// <summary>A type belonging to no namespace at all is not taken for the framework interface.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
     public async Task GetObservableValueType_ReceiverHasNoContainingNamespace_ReturnsNull() =>
-        await Assert.That(BindToExtractor.GetObservableValueType(NamespacelessObservable())).IsNull();
-
-    /// <summary>An implemented interface with no containing namespace is likewise not the framework one.</summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task GetObservableValueType_ImplementedInterfaceHasNoContainingNamespace_ReturnsNull()
-    {
-        // The interface is built first: NSubstitute rejects configuring one substitute inside another's Returns.
-        var lookalike = NamespacelessObservable();
-        var interfaces = ImmutableArray.Create(lookalike);
-
-        var receiver = Substitute.For<INamedTypeSymbol>();
-        _ = receiver.Name.Returns("Holder");
-        _ = receiver.AllInterfaces.Returns(interfaces);
-
-        await Assert.That(BindToExtractor.GetObservableValueType(receiver)).IsNull();
-    }
-
-    /// <summary>Builds a single-argument type named like the framework interface but belonging to no namespace.</summary>
-    /// <returns>The namespaceless type.</returns>
-    private static INamedTypeSymbol NamespacelessObservable()
-    {
-        var element = Substitute.For<ITypeSymbol>();
-        var type = Substitute.For<INamedTypeSymbol>();
-        _ = type.Name.Returns("IObservable");
-        _ = type.TypeArguments.Returns([element]);
-        _ = type.ContainingNamespace.Returns((INamespaceSymbol?)null);
-        _ = type.AllInterfaces.Returns(ImmutableArray<INamedTypeSymbol>.Empty);
-
-        return type;
-    }
+        await Assert.That(BindToExtractor.GetObservableValueType(FieldType("string[]"))).IsNull();
 
     /// <summary>Resolves a type by declaring a field of it in a probe compilation.</summary>
     /// <param name="declaredType">The type to resolve, as it is written in source.</param>

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/BindToExtractorTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/BindToExtractorTests.cs
@@ -61,11 +61,23 @@ public class BindToExtractorTests
     public async Task GetObservableValueType_ReceiverImplementsLookalikeInterface_ReturnsNull() =>
         await Assert.That(BindToExtractor.GetObservableValueType(FieldType("Probe.Lookalike"))).IsNull();
 
-    /// <summary>A type belonging to no namespace at all is not taken for the framework interface.</summary>
+    /// <summary>
+    /// An array is no named type, so it is neither the interface nor a candidate for implementing it, and the
+    /// walk over its interfaces finds only the ones every array carries.
+    /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task GetObservableValueType_ReceiverHasNoContainingNamespace_ReturnsNull() =>
+    public async Task GetObservableValueType_ReceiverIsArray_ReturnsNull() =>
         await Assert.That(BindToExtractor.GetObservableValueType(FieldType("string[]"))).IsNull();
+
+    /// <summary>
+    /// The framework interface takes exactly one type argument, so one of the same name and namespace taking
+    /// another number is a different contract and carries no element type to bind.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task GetObservableValueType_ReceiverIsSameNameWithTwoTypeArguments_ReturnsNull() =>
+        await Assert.That(BindToExtractor.GetObservableValueType(FieldType("System.IObservable<int, string>"))).IsNull();
 
     /// <summary>Resolves a type by declaring a field of it in a probe compilation.</summary>
     /// <param name="declaredType">The type to resolve, as it is written in source.</param>
@@ -75,6 +87,13 @@ public class BindToExtractorTests
     {
         var compilation = TestHelper.CreateCompilation(
             $$"""
+              namespace System
+              {
+                  public interface IObservable<T1, T2>
+                  {
+                  }
+              }
+
               namespace Probe
               {
                   public class Feed : System.IObservable<int>

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/ExtractorValidationTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/ExtractorValidationTests.cs
@@ -5,8 +5,8 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using NSubstitute;
 using ReactiveUI.Binding.SourceGenerators.Helpers;
+using ReactiveUI.Binding.Tests.Shared;
 
 namespace ReactiveUI.Binding.SourceGenerators.Tests.Helpers;
 
@@ -19,8 +19,36 @@ public class ExtractorValidationTests
     /// <summary>The <c>string</c> name these tests generate against.</summary>
     private const string StringName = "string";
 
+    /// <summary>The <c>int</c> name these tests generate against.</summary>
+    private const string IntName = "int";
+
     /// <summary>A class name no recognized extension class uses.</summary>
     private const string UnknownClassName = "CustomExtensions";
+
+    /// <summary>A class declaring one parameter under each name and shape these tests look for.</summary>
+    private const string SelectorProbeSource = """
+                                               namespace Probe
+                                               {
+                                                   public class Holder
+                                                   {
+                                                       public void TakesSelector(System.Func<string> selector)
+                                                       {
+                                                       }
+
+                                                       public void TakesAnotherName(System.Func<string> otherParam)
+                                                       {
+                                                       }
+
+                                                       public void TakesConversion(System.Func<int> conversionFunc)
+                                                       {
+                                                       }
+
+                                                       public void TakesPlainType(string selector)
+                                                       {
+                                                       }
+                                                   }
+                                               }
+                                               """;
 
     /// <summary>Verifies that the stub extension class name is recognized.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
@@ -265,17 +293,7 @@ public class ExtractorValidationTests
     [Test]
     public async Task FindSelectorReturnType_NoMatchingParameter_ReturnsNull()
     {
-        var typeArg = Substitute.For<ITypeSymbol>();
-        _ = typeArg.ToDisplayString(Arg.Any<SymbolDisplayFormat>()).Returns(StringName);
-
-        var funcType = Substitute.For<INamedTypeSymbol>();
-        _ = funcType.TypeArguments.Returns([typeArg]);
-
-        var param = Substitute.For<IParameterSymbol>();
-        _ = param.Name.Returns("otherParam");
-        _ = param.Type.Returns(funcType);
-
-        var parameters = ImmutableArray.Create(param);
+        var parameters = RoslynSymbolProbe.MethodParameters(SelectorProbeSource, "TakesAnotherName");
 
         var result = ExtractorValidation.FindSelectorReturnType(parameters, SelectorName);
 
@@ -287,17 +305,7 @@ public class ExtractorValidationTests
     [Test]
     public async Task FindSelectorReturnType_MatchingParameter_ReturnsType()
     {
-        var typeArg = Substitute.For<ITypeSymbol>();
-        _ = typeArg.ToDisplayString(Arg.Any<SymbolDisplayFormat>()).Returns(StringName);
-
-        var funcType = Substitute.For<INamedTypeSymbol>();
-        _ = funcType.TypeArguments.Returns([typeArg]);
-
-        var param = Substitute.For<IParameterSymbol>();
-        _ = param.Name.Returns(SelectorName);
-        _ = param.Type.Returns(funcType);
-
-        var parameters = ImmutableArray.Create(param);
+        var parameters = RoslynSymbolProbe.MethodParameters(SelectorProbeSource, "TakesSelector");
 
         var result = ExtractorValidation.FindSelectorReturnType(parameters, SelectorName);
 
@@ -309,21 +317,11 @@ public class ExtractorValidationTests
     [Test]
     public async Task FindSelectorReturnType_MultipleNames_MatchesSecondName()
     {
-        var typeArg = Substitute.For<ITypeSymbol>();
-        _ = typeArg.ToDisplayString(Arg.Any<SymbolDisplayFormat>()).Returns("int");
-
-        var funcType = Substitute.For<INamedTypeSymbol>();
-        _ = funcType.TypeArguments.Returns([typeArg]);
-
-        var param = Substitute.For<IParameterSymbol>();
-        _ = param.Name.Returns("conversionFunc");
-        _ = param.Type.Returns(funcType);
-
-        var parameters = ImmutableArray.Create(param);
+        var parameters = RoslynSymbolProbe.MethodParameters(SelectorProbeSource, "TakesConversion");
 
         var result = ExtractorValidation.FindSelectorReturnType(parameters, SelectorName, "conversionFunc");
 
-        await Assert.That(result).IsEqualTo("int");
+        await Assert.That(result).IsEqualTo(IntName);
     }
 
     /// <summary>Verifies that FindSelectorReturnType skips parameters with non-generic types.</summary>
@@ -331,14 +329,7 @@ public class ExtractorValidationTests
     [Test]
     public async Task FindSelectorReturnType_NonGenericType_ReturnsNull()
     {
-        var nonGenericType = Substitute.For<INamedTypeSymbol>();
-        _ = nonGenericType.TypeArguments.Returns([]);
-
-        var param = Substitute.For<IParameterSymbol>();
-        _ = param.Name.Returns(SelectorName);
-        _ = param.Type.Returns(nonGenericType);
-
-        var parameters = ImmutableArray.Create(param);
+        var parameters = RoslynSymbolProbe.MethodParameters(SelectorProbeSource, "TakesPlainType");
 
         var result = ExtractorValidation.FindSelectorReturnType(parameters, SelectorName);
 
@@ -367,18 +358,6 @@ public class ExtractorValidationTests
         var result = ExtractorValidation.IsRecognizedExtensionClass(UnnamedGroupingIn(UnknownClassName));
 
         await Assert.That(result).IsFalse();
-    }
-
-    /// <summary>A grouping type with nothing enclosing it has no name to be judged by.</summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task IsRecognizedExtensionClass_UnnamedGroupingWithNoEnclosingClass_ReturnsFalse()
-    {
-        var orphan = Substitute.For<INamedTypeSymbol>();
-        _ = orphan.Name.Returns(string.Empty);
-        _ = orphan.ContainingType.Returns((INamedTypeSymbol?)null);
-
-        await Assert.That(ExtractorValidation.IsRecognizedExtensionClass(orphan)).IsFalse();
     }
 
     /// <summary>
@@ -450,20 +429,40 @@ public class ExtractorValidationTests
     }
 
     /// <summary>
-    /// Builds a grouping type with no name of its own, nested in a class of the given name. A source-declared
-    /// extension block takes this shape, which no compiled identifier can spell.
+    /// Compiles an extension block and returns the grouping type the compiler declares its members in: a type
+    /// with no name of its own, nested one level inside the class that names the API. Read from source rather
+    /// than from an emitted image, which is the spelling that has no name at all.
     /// </summary>
-    /// <param name="className">The name to give the enclosing class.</param>
+    /// <param name="className">The name to give the enclosing static class.</param>
     /// <returns>The unnamed grouping type.</returns>
+    /// <exception cref="InvalidOperationException">The compiler declared no unnamed nested type.</exception>
     private static INamedTypeSymbol UnnamedGroupingIn(string className)
     {
-        var enclosing = Substitute.For<INamedTypeSymbol>();
-        _ = enclosing.Name.Returns(className);
+        var compilation = TestHelper.CreateCompilation(
+            $$"""
+              public static class {{className}}
+              {
+                  extension(int value)
+                  {
+                      public int Doubled => value * 2;
+                  }
+              }
+              """,
+            LanguageVersion.Preview);
 
-        var grouping = Substitute.For<INamedTypeSymbol>();
-        _ = grouping.Name.Returns(string.Empty);
-        _ = grouping.ContainingType.Returns(enclosing);
+        var outer = compilation.GetTypeByMetadataName(className)
+            ?? throw new InvalidOperationException($"'{className}' did not compile.");
 
-        return grouping;
+        var nested = outer.GetTypeMembers();
+        for (var i = 0; i < nested.Length; i++)
+        {
+            if (nested[i].Name.Length == 0)
+            {
+                return nested[i];
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"The compiler declared no unnamed grouping type inside '{className}'.");
     }
 }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/ExtractorValidationTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/ExtractorValidationTests.cs
@@ -448,7 +448,7 @@ public class ExtractorValidationTests
                   }
               }
               """,
-            LanguageVersion.Preview);
+            LanguageVersion.CSharp14);
 
         var outer = compilation.GetTypeByMetadataName(className)
             ?? throw new InvalidOperationException($"'{className}' did not compile.");

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/InterceptableLocationReaderTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/InterceptableLocationReaderTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using ReactiveUI.Binding.SourceGenerators.Helpers;
+
+namespace ReactiveUI.Binding.SourceGenerators.Tests.Helpers;
+
+/// <summary>Tests for <see cref="InterceptableLocationReader"/>, which is where both builds answer about interception.</summary>
+public class InterceptableLocationReaderTests
+{
+    /// <summary>The namespace the generator emits interceptors into.</summary>
+    private const string GeneratedNamespace = Constants.InterceptorNamespace;
+
+    /// <summary>The feature name a build lists interceptable namespaces under.</summary>
+    private const string FeatureName = Constants.InterceptorsNamespacesFeature;
+
+    /// <summary>A build that lists nothing has not opted in.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task IsOptedIn_NoFeature_ReturnsFalse() =>
+        await Assert.That(InterceptableLocationReader.IsOptedIn(new CSharpParseOptions())).IsFalse();
+
+    /// <summary>An empty list is the same as no list.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task IsOptedIn_EmptyFeature_ReturnsFalse() =>
+        await Assert.That(InterceptableLocationReader.IsOptedIn(WithNamespaces(string.Empty))).IsFalse();
+
+    /// <summary>The generated namespace named exactly is an opt-in.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task IsOptedIn_ExactNamespace_ReturnsTrue() =>
+        await Assert.That(InterceptableLocationReader.IsOptedIn(WithNamespaces(GeneratedNamespace))).IsTrue();
+
+    /// <summary>A listed namespace covers the ones nested under it, so a parent counts.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task IsOptedIn_EnclosingNamespace_ReturnsTrue() =>
+        await Assert.That(InterceptableLocationReader.IsOptedIn(WithNamespaces("ReactiveUI.Binding"))).IsTrue();
+
+    /// <summary>A namespace that merely starts with the same characters is a different namespace.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task IsOptedIn_NamespaceSharingAPrefix_ReturnsFalse() =>
+        await Assert.That(InterceptableLocationReader.IsOptedIn(WithNamespaces("ReactiveUI.Bind"))).IsFalse();
+
+    /// <summary>Another package's namespace is not this one's opt-in.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task IsOptedIn_UnrelatedNamespace_ReturnsFalse() =>
+        await Assert.That(InterceptableLocationReader.IsOptedIn(WithNamespaces("Some.Other.Package"))).IsFalse();
+
+    /// <summary>The listed namespaces are read out of a list, so the entry can be anywhere in it.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task IsOptedIn_ListedAlongsideOthers_ReturnsTrue() =>
+        await Assert.That(InterceptableLocationReader.IsOptedIn(
+            WithNamespaces($"Some.Other.Package;{GeneratedNamespace};Third.Package"))).IsTrue();
+
+    /// <summary>A separator with nothing between it and the next is skipped rather than matched.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task IsOptedIn_ListWithEmptyEntries_ReturnsTrue() =>
+        await Assert.That(InterceptableLocationReader.IsOptedIn(WithNamespaces($";;{GeneratedNamespace};"))).IsTrue();
+
+    /// <summary>A list of nothing but separators names no namespace at all.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task IsOptedIn_ListOfSeparators_ReturnsFalse() =>
+        await Assert.That(InterceptableLocationReader.IsOptedIn(WithNamespaces(";; ;"))).IsFalse();
+
+    /// <summary>
+    /// A call site is described where the compiler can describe one, and reported as undescribed where it
+    /// cannot. Both answers are handled the same way by every caller, so both are asserted here.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Read_CallSite_MatchesWhatThisBuildSupports()
+    {
+        const string Source = """
+                              namespace Probe
+                              {
+                                  public static class Holder
+                                  {
+                                      public static string Read() => 1.ToString();
+                                  }
+                              }
+                              """;
+
+        var compilation = TestHelper.CreateCompilation(Source, LanguageVersion.CSharp10);
+        var tree = compilation.SyntaxTrees.First();
+        var root = await tree.GetRootAsync();
+        var invocation = root.DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+
+        var location = InterceptableLocationReader.Read(
+            compilation.GetSemanticModel(tree),
+            invocation,
+            CancellationToken.None);
+
+        await Assert.That(location.IsAvailable).IsEqualTo(InterceptableLocationReader.IsSupported);
+    }
+
+    /// <summary>An undescribed call site carries no data, whichever build produced it.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task IsAvailable_DefaultLocation_ReturnsFalse() =>
+        await Assert.That(default(SourceGenerators.Models.InterceptorLocation).IsAvailable).IsFalse();
+
+    /// <summary>Builds parse options listing the given namespaces for interception.</summary>
+    /// <param name="namespaces">The value the build sets.</param>
+    /// <returns>The parse options.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static CSharpParseOptions WithNamespaces(string namespaces) =>
+        new CSharpParseOptions().WithFeatures([new KeyValuePair<string, string>(FeatureName, namespaces)]);
+}

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/InterceptableLocationReaderTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/InterceptableLocationReaderTests.cs
@@ -105,6 +105,40 @@ public class InterceptableLocationReaderTests
         await Assert.That(location.IsAvailable).IsEqualTo(InterceptableLocationReader.IsSupported);
     }
 
+    /// <summary>
+    /// A call the compiler declines to describe reports that nothing was described, on either build. The
+    /// callee here is an element of an array of delegates rather than a name the compiler can attach an
+    /// interceptor to, which is a shape no interceptor can claim however new the compiler is.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Read_CallSiteTheCompilerCannotDescribe_ReportsNothingDescribed()
+    {
+        const string Source = """
+                              namespace Probe
+                              {
+                                  public static class Holder
+                                  {
+                                      public static System.Func<int, string>[] Table = null!;
+
+                                      public static string Read() => Table[0](1);
+                                  }
+                              }
+                              """;
+
+        var compilation = TestHelper.CreateCompilation(Source, LanguageVersion.CSharp10);
+        var tree = compilation.SyntaxTrees.First();
+        var root = await tree.GetRootAsync();
+        var invocation = root.DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+
+        var location = InterceptableLocationReader.Read(
+            compilation.GetSemanticModel(tree),
+            invocation,
+            CancellationToken.None);
+
+        await Assert.That(location.IsAvailable).IsFalse();
+    }
+
     /// <summary>An undescribed call site carries no data, whichever build produced it.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/TestHelper.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/TestHelper.cs
@@ -72,17 +72,32 @@ public static class TestHelper
     /// <param name="assemblyName">The name to give the compilation's own assembly.</param>
     /// <param name="additionalReferences">References to add on top of the framework and runtime ones.</param>
     /// <returns>A compilation ready for testing.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Compilation CreateCompilation(
         string source,
         LanguageVersion? languageVersion,
         bool useReactiveRuntime,
         string assemblyName,
+        ImmutableArray<MetadataReference> additionalReferences) =>
+        CreateCompilation(source, ParseOptionsFor(languageVersion), useReactiveRuntime, assemblyName, additionalReferences);
+
+    /// <summary>
+    /// Creates a compilation from source code parsed exactly as the caller asks, which is how a scenario reaches
+    /// the options a language version alone cannot express.
+    /// </summary>
+    /// <param name="source">The source code to compile.</param>
+    /// <param name="parseOptions">The options the consumer's source is parsed with.</param>
+    /// <param name="useReactiveRuntime">Whether to reference the System.Reactive flavour rather than the lean one.</param>
+    /// <param name="assemblyName">The name to give the compilation's own assembly.</param>
+    /// <param name="additionalReferences">References to add on top of the framework and runtime ones.</param>
+    /// <returns>A compilation ready for testing.</returns>
+    public static Compilation CreateCompilation(
+        string source,
+        CSharpParseOptions parseOptions,
+        bool useReactiveRuntime,
+        string assemblyName,
         ImmutableArray<MetadataReference> additionalReferences)
     {
-        var parseOptions = languageVersion.HasValue
-            ? new CSharpParseOptions(languageVersion.Value)
-            : new CSharpParseOptions(LanguageVersion.CSharp7_3);
-
         var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
 
 #if NET11_0_OR_GREATER
@@ -123,6 +138,24 @@ public static class TestHelper
             allReferences,
             new(OutputKind.DynamicallyLinkedLibrary));
     }
+
+    /// <summary>The parse options a build produces from a language version, which is what the tests usually name.</summary>
+    /// <param name="languageVersion">The C# language version to target, or <see langword="null"/> for C# 7.3.</param>
+    /// <returns>The parse options.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static CSharpParseOptions ParseOptionsFor(LanguageVersion? languageVersion) =>
+        new(languageVersion ?? LanguageVersion.CSharp7_3);
+
+    /// <summary>
+    /// The parse options of a build that has the package's targets on it, which list the generated namespace so
+    /// the compiler honours an interceptor emitted into it.
+    /// </summary>
+    /// <param name="languageVersion">The C# language version to target, or <see langword="null"/> for C# 7.3.</param>
+    /// <returns>The parse options, carrying the opt-in.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static CSharpParseOptions InterceptingParseOptionsFor(LanguageVersion? languageVersion) =>
+        ParseOptionsFor(languageVersion)
+            .WithFeatures([new KeyValuePair<string, string>("InterceptorsNamespaces", "ReactiveUI.Binding.Generated.Interceptors")]);
 
     /// <summary>
     /// Compiles source into a metadata reference, standing in for a type the consumer references rather than
@@ -370,16 +403,27 @@ public static class TestHelper
     /// <param name="rootNamespace">The root namespace the build exposes, or <see langword="null"/> for none.</param>
     /// <param name="emitGeneratedCodeMarkers">Whether the build asks for the generated-file markers.</param>
     /// <returns>A <see cref="GeneratorTestResult"/> containing driver, compilation, and diagnostics.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static GeneratorTestResult RunGenerator(
         Compilation compilation,
         LanguageVersion? languageVersion,
         string? rootNamespace,
+        bool emitGeneratedCodeMarkers) =>
+        RunGenerator(compilation, ParseOptionsFor(languageVersion), rootNamespace, emitGeneratedCodeMarkers);
+
+    /// <summary>Runs the source generator with the parse options the caller names, for both input and output.</summary>
+    /// <param name="compilation">The compilation to generate against.</param>
+    /// <param name="parseOptions">The options generated code is parsed with, and that the generator reads.</param>
+    /// <param name="rootNamespace">The root namespace the build exposes, or <see langword="null"/> for none.</param>
+    /// <param name="emitGeneratedCodeMarkers">Whether the build asks for the generated-file markers.</param>
+    /// <returns>A <see cref="GeneratorTestResult"/> containing driver, compilation, and diagnostics.</returns>
+    public static GeneratorTestResult RunGenerator(
+        Compilation compilation,
+        CSharpParseOptions parseOptions,
+        string? rootNamespace,
         bool emitGeneratedCodeMarkers)
     {
         var generator = new BindingGenerator();
-        var parseOptions = languageVersion.HasValue
-            ? new CSharpParseOptions(languageVersion.Value)
-            : new CSharpParseOptions(LanguageVersion.CSharp7_3);
 
         GeneratorDriver driver = CSharpGeneratorDriver.Create(
             [generator.AsSourceGenerator()],

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/InterceptedCallSiteTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/InterceptedCallSiteTests.cs
@@ -111,6 +111,139 @@ public class InterceptedCallSiteTests
                                               }
                                               """;
 
+    /// <summary>One call site per generated API, so every emitter's tier is settled by the same build.</summary>
+    private const string EveryApiScenario = """
+                                            using System;
+                                            using System.ComponentModel;
+                                            using System.Threading.Tasks;
+                                            using System.Windows.Input;
+                                            using ReactiveUI.Binding;
+
+                                            namespace TestApp
+                                            {
+                                                public class Person : INotifyPropertyChanged, INotifyPropertyChanging
+                                                {
+                                                    public event PropertyChangedEventHandler PropertyChanged;
+
+                                                    public event PropertyChangingEventHandler PropertyChanging;
+
+                                                    public string Name { get; set; }
+
+                                                    public int Age { get; set; }
+
+                                                    public ICommand Save { get; set; }
+
+                                                    public IInteraction<string, bool> Confirm { get; set; }
+
+                                                    public IObservable<int> Ticks { get; set; }
+                                                }
+
+                                                public class Button
+                                                {
+                                                    public event EventHandler Click;
+
+                                                    public string Text { get; set; }
+                                                }
+
+                                                public class PersonView : INotifyPropertyChanged, IViewFor<Person>
+                                                {
+                                                    public event PropertyChangedEventHandler PropertyChanged;
+
+                                                    public Person ViewModel { get; set; }
+
+                                                    object IViewFor.ViewModel
+                                                    {
+                                                        get { return ViewModel; }
+                                                        set { ViewModel = (Person)value; }
+                                                    }
+
+                                                    public Button SaveButton { get; set; }
+
+                                                    public string Display { get; set; }
+
+                                                    public string Summary { get; set; }
+                                                }
+
+                                                public class Usage
+                                                {
+                                                    public void Bind(Person person, PersonView view, IObservable<string> names)
+                                                    {
+                                                        GC.KeepAlive(person.WhenChanged(x => x.Name));
+                                                        GC.KeepAlive(person.WhenChanging(x => x.Name));
+                                                        GC.KeepAlive(person.WhenAnyValue(x => x.Age));
+                                                        GC.KeepAlive(person.WhenAny(x => x.Name, c => c.Value));
+                                                        GC.KeepAlive(person.WhenAnyObservable(x => x.Ticks));
+
+                                                        person.BindOneWay(view, x => x.Name, v => v.Display);
+                                                        person.BindTwoWay(view, x => x.Name, v => v.Display);
+                                                        view.OneWayBind(person, x => x.Name, v => v.Summary);
+                                                        view.Bind(person, x => x.Name, v => v.Display);
+                                                        names.BindTo(view, v => v.Display);
+                                                        view.BindCommand(person, x => x.Save, v => v.SaveButton);
+                                                        view.BindInteraction(person, x => x.Confirm, Handle);
+                                                    }
+
+                                                    private static Task Handle(IInteractionContext<string, bool> context)
+                                                    {
+                                                        context.SetOutput(true);
+                                                        return Task.CompletedTask;
+                                                    }
+                                                }
+                                            }
+                                            """;
+
+    /// <summary>The dispatch file each generated binding API emits.</summary>
+    /// <remarks>
+    /// Named rather than matched on a suffix, because the view locator emits one too and it claims no call
+    /// site. An API that stopped emitting its file would drop silently out of a pattern.
+    /// </remarks>
+    private static readonly string[] ApiDispatchFiles =
+    [
+        "WhenChangedDispatch.g.cs",
+        "WhenChangingDispatch.g.cs",
+        "WhenAnyValueDispatch.g.cs",
+        "WhenAnyDispatch.g.cs",
+        "WhenAnyObservableDispatch.g.cs",
+        "BindOneWayDispatch.g.cs",
+        "BindTwoWayDispatch.g.cs",
+        "OneWayBindDispatch.g.cs",
+        "BindDispatch.g.cs",
+        "BindToDispatch.g.cs",
+        "BindCommandDispatch.g.cs",
+        "BindInteractionDispatch.g.cs",
+    ];
+
+    /// <summary>Every generated API is claimed the same way, so each emitter's tier follows one decision.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OptedInBuild_ClaimsEveryGeneratedApi()
+    {
+        var result = Generate(EveryApiScenario, LanguageVersion.CSharp10, optIn: true, RootNamespace);
+
+        await Assert.That(result.CompilationErrors).IsEmpty();
+
+        foreach (var file in ApiDispatchFiles)
+        {
+            await Assert.That(result.GeneratedSources.ContainsKey(file)).IsTrue();
+
+            await Assert.That(result.GeneratedSources[file].Contains(InterceptsAttribute, StringComparison.Ordinal))
+                .IsEqualTo(InterceptableLocationReader.IsSupported);
+        }
+    }
+
+    /// <summary>Emission checks an interceptor against the call it replaces, so every API is emitted here.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OptedInBuild_EmitsWithEveryApiClaimed()
+    {
+        var result = Generate(EveryApiScenario, LanguageVersion.CSharp10, optIn: true, RootNamespace);
+
+        var (_, context) = TestHelper.EmitAndLoad(result);
+        context.Unload();
+
+        await Assert.That(result.CompilationErrors).IsEmpty();
+    }
+
     /// <summary>A build listing the generated namespace gets the tier its compiler can honour.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/InterceptedCallSiteTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/InterceptedCallSiteTests.cs
@@ -1,0 +1,256 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using ReactiveUI.Binding.SourceGenerators.Helpers;
+using ReactiveUI.Binding.SourceGenerators.Tests.Helpers;
+
+namespace ReactiveUI.Binding.SourceGenerators.Tests;
+
+/// <summary>
+/// Tests the tier that claims a binding call site outright instead of offering an overload that has to win
+/// extension-method lookup.
+/// </summary>
+/// <remarks>
+/// Which tier a build gets is settled by the compiler hosting the generator and by whether the project lists
+/// the generated namespace, so every test here states the outcome for both and the suite runs against both
+/// generator builds. That is what keeps the assertions honest on a compiler that cannot describe a call site
+/// at all, where the overloads are still the only thing that can be emitted.
+/// </remarks>
+public class InterceptedCallSiteTests
+{
+    /// <summary>The attribute text an interceptor carries.</summary>
+    private const string InterceptsAttribute = "InterceptsLocation(";
+
+    /// <summary>The declaration text a dispatch overload carries.</summary>
+    private const string OverloadDeclaration = "public static global::System.IObservable<";
+
+    /// <summary>The dispatch file these tests read.</summary>
+    private const string DispatchFileName = "WhenChangedDispatch.g.cs";
+
+    /// <summary>The root namespace the scenarios build under.</summary>
+    private const string RootNamespace = "TestApp";
+
+    /// <summary>The type the scenario exposes its binding through.</summary>
+    private const string UsageTypeName = $"{RootNamespace}.Usage";
+
+    /// <summary>A binding whose value can be read back out of the emitted assembly.</summary>
+    private const string Scenario = """
+                                    using System;
+                                    using System.ComponentModel;
+                                    using ReactiveUI.Binding;
+
+                                    namespace TestApp
+                                    {
+                                        public class MyViewModel : INotifyPropertyChanged
+                                        {
+                                            private string _name = "start";
+
+                                            public event PropertyChangedEventHandler PropertyChanged;
+
+                                            public string Name
+                                            {
+                                                get { return _name; }
+                                                set
+                                                {
+                                                    _name = value;
+                                                    var handler = PropertyChanged;
+                                                    if (handler != null)
+                                                    {
+                                                        handler(this, new PropertyChangedEventArgs("Name"));
+                                                    }
+                                                }
+                                            }
+                                        }
+
+                                        public static class Usage
+                                        {
+                                            public static string Observe()
+                                            {
+                                                var viewModel = new MyViewModel();
+                                                string seen = null;
+                                                var subscription = global::ReactiveUI.Primitives.SubscribeExtensions.Subscribe(
+                                                    viewModel.WhenChanged(x => x.Name),
+                                                    delegate(string value) { seen = value; });
+                                                viewModel.Name = "changed";
+                                                subscription.Dispose();
+                                                return seen;
+                                            }
+                                        }
+                                    }
+                                    """;
+
+    /// <summary>The same binding written in a namespace no root namespace encloses.</summary>
+    private const string OutOfReachScenario = """
+                                              using System;
+                                              using System.ComponentModel;
+                                              using ReactiveUI.Binding;
+
+                                              namespace Elsewhere
+                                              {
+                                                  public class MyViewModel : INotifyPropertyChanged
+                                                  {
+                                                      public event PropertyChangedEventHandler PropertyChanged;
+
+                                                      public string Name { get; set; }
+                                                  }
+
+                                                  public class Usage
+                                                  {
+                                                      public void Bind()
+                                                      {
+                                                          var viewModel = new MyViewModel();
+                                                          var observable = viewModel.WhenChanged(x => x.Name);
+                                                          GC.KeepAlive(observable);
+                                                      }
+                                                  }
+                                              }
+                                              """;
+
+    /// <summary>A build listing the generated namespace gets the tier its compiler can honour.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OptedInBuild_EmitsInterceptorsWhereTheCompilerCanDescribeACallSite()
+    {
+        var dispatch = GenerateDispatch(Scenario, LanguageVersion.CSharp10, optIn: true);
+
+        await Assert.That(dispatch.Contains(InterceptsAttribute, StringComparison.Ordinal))
+            .IsEqualTo(InterceptableLocationReader.IsSupported);
+        await Assert.That(dispatch.Contains(OverloadDeclaration, StringComparison.Ordinal))
+            .IsEqualTo(!InterceptableLocationReader.IsSupported);
+    }
+
+    /// <summary>The opt-in is what turns the tier on; without it the overloads are emitted either way.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BuildWithoutTheOptIn_EmitsTheDispatchOverload()
+    {
+        var dispatch = GenerateDispatch(Scenario, LanguageVersion.CSharp10, optIn: false);
+
+        await Assert.That(dispatch).DoesNotContain(InterceptsAttribute);
+        await Assert.That(dispatch).Contains(OverloadDeclaration);
+    }
+
+    /// <summary>
+    /// A project below C# 10 is served the same way. Interception is refused on a language version, not chosen
+    /// by one, which is what puts a compile-time binding in reach of a consumer the overloads cannot serve.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OptedInBuild_BelowCSharp10_StillClaimsTheCallSite()
+    {
+        var dispatch = GenerateDispatch(Scenario, LanguageVersion.CSharp7_3, optIn: true);
+
+        await Assert.That(dispatch.Contains(InterceptsAttribute, StringComparison.Ordinal))
+            .IsEqualTo(InterceptableLocationReader.IsSupported);
+        await Assert.That(dispatch.Contains(OverloadDeclaration, StringComparison.Ordinal))
+            .IsEqualTo(!InterceptableLocationReader.IsSupported);
+    }
+
+    /// <summary>
+    /// A file declared outside the root namespace is out of the overloads' reach, and is claimed anyway. This is
+    /// the case the tier exists for: nothing about an interceptor goes through extension-method lookup.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OptedInBuild_ClaimsACallSiteOutsideTheRootNamespace()
+    {
+        var dispatch = GenerateDispatch(OutOfReachScenario, LanguageVersion.CSharp7_3, optIn: true);
+
+        await Assert.That(dispatch.Contains(InterceptsAttribute, StringComparison.Ordinal))
+            .IsEqualTo(InterceptableLocationReader.IsSupported);
+    }
+
+    /// <summary>
+    /// The emitted assembly runs the binding. Emission is where the compiler checks an interceptor against the
+    /// call it replaces, so a signature that does not match fails here rather than being noticed downstream.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OptedInBuild_RunsTheBindingItClaimed()
+    {
+        var result = Generate(Scenario, LanguageVersion.CSharp10, optIn: true, RootNamespace);
+
+        await Assert.That(result.CompilationErrors).IsEmpty();
+
+        var (assembly, context) = TestHelper.EmitAndLoad(result);
+        var observe = assembly.GetType(UsageTypeName)?.GetMethod(
+            "Observe",
+            BindingFlags.Public | BindingFlags.Static);
+
+        await Assert.That(observe).IsNotNull();
+        await Assert.That(observe!.Invoke(null, null)).IsEqualTo("changed");
+
+        context.Unload();
+    }
+
+    /// <summary>The same binding runs when the overloads are what the build got.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BuildWithoutTheOptIn_RunsTheBindingItDispatched()
+    {
+        var result = Generate(Scenario, LanguageVersion.CSharp10, optIn: false, RootNamespace);
+
+        await Assert.That(result.CompilationErrors).IsEmpty();
+
+        var (assembly, context) = TestHelper.EmitAndLoad(result);
+        var observe = assembly.GetType(UsageTypeName)?.GetMethod(
+            "Observe",
+            BindingFlags.Public | BindingFlags.Static);
+
+        await Assert.That(observe).IsNotNull();
+        await Assert.That(observe!.Invoke(null, null)).IsEqualTo("changed");
+
+        context.Unload();
+    }
+
+    /// <summary>The generated namespace is what the opt-in has to name.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OptedInBuild_GeneratesIntoTheInterceptedNamespace()
+    {
+        var dispatch = GenerateDispatch(Scenario, LanguageVersion.CSharp10, optIn: true);
+
+        await Assert.That(dispatch.Contains($"namespace {Constants.InterceptorNamespace}", StringComparison.Ordinal))
+            .IsEqualTo(InterceptableLocationReader.IsSupported);
+    }
+
+    /// <summary>Runs the generator and returns the dispatch file it produced.</summary>
+    /// <param name="source">The consumer source.</param>
+    /// <param name="languageVersion">The language version the consumer builds at.</param>
+    /// <param name="optIn">Whether the build lists the generated namespace for interception.</param>
+    /// <param name="rootNamespace">The root namespace the build exposes.</param>
+    /// <returns>The generated dispatch file.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string GenerateDispatch(
+        string source,
+        LanguageVersion languageVersion,
+        bool optIn,
+        string? rootNamespace = RootNamespace) =>
+        Generate(source, languageVersion, optIn, rootNamespace).GeneratedSources[DispatchFileName];
+
+    /// <summary>Runs the generator over a compilation parsed the way the build in question parses.</summary>
+    /// <param name="source">The consumer source.</param>
+    /// <param name="languageVersion">The language version the consumer builds at.</param>
+    /// <param name="optIn">Whether the build lists the generated namespace for interception.</param>
+    /// <param name="rootNamespace">The root namespace the build exposes.</param>
+    /// <returns>The generator result.</returns>
+    private static GeneratorTestResult Generate(
+        string source,
+        LanguageVersion languageVersion,
+        bool optIn,
+        string? rootNamespace)
+    {
+        var parseOptions = optIn
+            ? TestHelper.InterceptingParseOptionsFor(languageVersion)
+            : TestHelper.ParseOptionsFor(languageVersion);
+
+        var compilation = TestHelper.CreateCompilation(source, parseOptions, false, "TestAssembly", []);
+
+        return TestHelper.RunGenerator(compilation, parseOptions, rootNamespace, true);
+    }
+}

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/InterceptedCallSiteTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/InterceptedCallSiteTests.cs
@@ -136,6 +136,8 @@ public class InterceptedCallSiteTests
                                                     public IInteraction<string, bool> Confirm { get; set; }
 
                                                     public IObservable<int> Ticks { get; set; }
+
+                                                    public IObservable<int> Pulses { get; set; }
                                                 }
 
                                                 public class Button
@@ -173,6 +175,7 @@ public class InterceptedCallSiteTests
                                                         GC.KeepAlive(person.WhenAnyValue(x => x.Age));
                                                         GC.KeepAlive(person.WhenAny(x => x.Name, c => c.Value));
                                                         GC.KeepAlive(person.WhenAnyObservable(x => x.Ticks));
+                                                        GC.KeepAlive(person.WhenAnyObservable(x => x.Ticks, x => x.Pulses, (a, b) => a + b));
 
                                                         person.BindOneWay(view, x => x.Name, v => v.Display);
                                                         person.BindTwoWay(view, x => x.Name, v => v.Display);
@@ -180,6 +183,7 @@ public class InterceptedCallSiteTests
                                                         view.Bind(person, x => x.Name, v => v.Display);
                                                         names.BindTo(view, v => v.Display);
                                                         view.BindCommand(person, x => x.Save, v => v.SaveButton);
+                                                        view.BindCommand(person, x => x.Save, v => v.SaveButton, names);
                                                         view.BindInteraction(person, x => x.Confirm, Handle);
                                                     }
 

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/RuntimeExecution/SchedulerOverloadRuntimeTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/RuntimeExecution/SchedulerOverloadRuntimeTests.cs
@@ -139,7 +139,7 @@ public class SchedulerOverloadRuntimeTests
     [Test]
     public async Task BindOneWay_WithASchedulerOnTheLatestLanguageVersion_DispatchesToGeneratedCode()
     {
-        var result = TestHelper.RunGenerator(SchedulerOverloadSource, LanguageVersion.Preview);
+        var result = TestHelper.RunGenerator(SchedulerOverloadSource, LanguageVersion.CSharp14);
 
         await result.CompilationSucceeds();
         await result.GeneratedSourceContains(DispatchFileName, SchedulerParameter);

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/SchedulerBindingDispatchTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/SchedulerBindingDispatchTests.cs
@@ -73,7 +73,7 @@ public class SchedulerBindingDispatchTests
     {
         var result = TestHelper.RunGenerator(
             SchedulerBindingSource,
-            LanguageVersion.Preview,
+            LanguageVersion.CSharp14,
             "SchedulerProbe");
 
         await result.CompilationSucceeds();
@@ -87,7 +87,7 @@ public class SchedulerBindingDispatchTests
     {
         var result = TestHelper.RunGenerator(
             SchedulerBindingSource,
-            LanguageVersion.Preview,
+            LanguageVersion.CSharp14,
             "SchedulerProbe");
 
         await result.CompilationSucceeds();

--- a/src/tests/Shared/RoslynSymbolProbe.cs
+++ b/src/tests/Shared/RoslynSymbolProbe.cs
@@ -38,7 +38,7 @@ internal static class RoslynSymbolProbe
 
         return CSharpCompilation.Create(
             "SymbolProbe",
-            [CSharpSyntaxTree.ParseText(source, new(LanguageVersion.Latest))],
+            [CSharpSyntaxTree.ParseText(source, new(LanguageVersion.CSharp14))],
             references,
             new(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
     }

--- a/src/tests/Shared/RoslynSymbolProbe.cs
+++ b/src/tests/Shared/RoslynSymbolProbe.cs
@@ -1,0 +1,91 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ReactiveUI.Binding.Tests.Shared;
+
+/// <summary>Resolves real symbols from a throwaway compilation, for helpers that take one directly.</summary>
+/// <remarks>
+/// The compiler's symbol interfaces cannot be implemented outside Roslyn itself, so a helper taking an
+/// <see cref="ISymbol"/> is exercised by compiling source that produces the symbol wanted and handing the
+/// real one over. That also keeps the tests honest: a shape source cannot express is a shape the generator
+/// will never meet. The exotic ones still have a source form - a function pointer's signature belongs to no
+/// type, and an array type to no namespace - which is how the guards against those are reached.
+/// </remarks>
+internal static class RoslynSymbolProbe
+{
+    /// <summary>The name given to the class every probe declares its members on.</summary>
+    internal const string HolderTypeName = "Probe.Holder";
+
+    /// <summary>Compiles probe source against the framework reference set.</summary>
+    /// <param name="source">The source to compile.</param>
+    /// <returns>The compilation.</returns>
+    internal static CSharpCompilation Compile(string source)
+    {
+        var references = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") is string paths
+            ? paths.Split(System.IO.Path.PathSeparator)
+                .Where(static p => p.EndsWith(".dll", StringComparison.Ordinal))
+                .Select(static p => MetadataReference.CreateFromFile(p))
+                .Cast<MetadataReference>()
+                .ToImmutableArray()
+            : ImmutableArray<MetadataReference>.Empty;
+
+        return CSharpCompilation.Create(
+            "SymbolProbe",
+            [CSharpSyntaxTree.ParseText(source, new(LanguageVersion.Latest))],
+            references,
+            new(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+    }
+
+    /// <summary>Resolves the type of a field declared on the probe's holder class.</summary>
+    /// <param name="source">The source declaring the holder class.</param>
+    /// <param name="fieldName">The field whose type is wanted.</param>
+    /// <returns>The field's type.</returns>
+    /// <exception cref="InvalidOperationException">The holder class or the field is not in the source.</exception>
+    internal static ITypeSymbol FieldType(string source, string fieldName) =>
+        Holder(source).GetMembers(fieldName).OfType<IFieldSymbol>().FirstOrDefault()?.Type
+        ?? throw new InvalidOperationException($"The probe declares no field named '{fieldName}'.");
+
+    /// <summary>Resolves the parameters of a method declared on the probe's holder class.</summary>
+    /// <param name="source">The source declaring the holder class.</param>
+    /// <param name="methodName">The method whose parameters are wanted.</param>
+    /// <returns>The method's parameters.</returns>
+    /// <exception cref="InvalidOperationException">The holder class or the method is not in the source.</exception>
+    internal static ImmutableArray<IParameterSymbol> MethodParameters(string source, string methodName) =>
+        Holder(source).GetMembers(methodName).OfType<IMethodSymbol>().FirstOrDefault()?.Parameters
+        ?? throw new InvalidOperationException($"The probe declares no method named '{methodName}'.");
+
+    /// <summary>A method belonging to no type, which a function pointer's signature is and no declaration is.</summary>
+    /// <returns>The method.</returns>
+    /// <exception cref="InvalidOperationException">The probe did not produce a function pointer type.</exception>
+    internal static IMethodSymbol MethodWithNoContainingType()
+    {
+        const string Source = """
+                              namespace Probe
+                              {
+                                  public unsafe class Holder
+                                  {
+                                      public delegate*<int, string> Callback;
+                                  }
+                              }
+                              """;
+
+        return FieldType(Source, "Callback") is IFunctionPointerTypeSymbol pointer
+            ? pointer.Signature
+            : throw new InvalidOperationException("The probe did not produce a function pointer type.");
+    }
+
+    /// <summary>Resolves the probe's holder class.</summary>
+    /// <param name="source">The source declaring it.</param>
+    /// <returns>The holder class.</returns>
+    /// <exception cref="InvalidOperationException">The holder class is not in the source.</exception>
+    private static INamedTypeSymbol Holder(string source) =>
+        Compile(source).GetTypeByMetadataName(HolderTypeName)
+        ?? throw new InvalidOperationException($"The probe source declares no {HolderTypeName}.");
+}

--- a/src/tests/SharedScenarios/WhenAnyValue/SinglePropertyReactiveObject/Scenario.cs
+++ b/src/tests/SharedScenarios/WhenAnyValue/SinglePropertyReactiveObject/Scenario.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
-using ReactiveUI;
+using ReactiveUI.Binding;
 
 namespace SharedScenarios.WhenAnyValue.SinglePropertyReactiveObject;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: compile-time bindings reach every call site, plus the analyzer diagnostic for the calls that never
reached the generator at all.

## What is the new behavior?

**A binding call site is claimed by an interceptor wherever the compiler can honour one.**

- From Roslyn 4.13 the generator describes each call site to the compiler and attaches the generated method to
  it. Nothing about the redirection goes through extension-method lookup, so it serves the call sites an
  overload cannot: a file declared outside the project's root namespace, and a project below C# 10 whose
  assembly exposes its internals.
- Interception is refused on a language version rather than chosen by one, so a
  `<LangVersion>7.3</LangVersion>` project on a current SDK gets it.
- All twelve generated APIs are claimed: `WhenChanged`, `WhenChanging`, `WhenAnyValue`, `WhenAny`,
  `WhenAnyObservable`, `BindOneWay`, `BindTwoWay`, `OneWayBind`, `Bind`, `BindTo`, `BindCommand` and
  `BindInteraction`.
- Each interceptor carries the signature of the stub it replaces, including the receiver and the caller-info
  parameters, which is what the compiler requires of one. Each API writes that list once, and the same writer
  serves its dispatch overload.
- `<ReactiveUIBindingUseInterceptors>false</ReactiveUIBindingUseInterceptors>` keeps the overloads on a
  compiler that could intercept.

**Each runtime package carries the generator and its analyzer once per compiler generation.**

- `analyzers/dotnet/roslyn4.8/cs` and `analyzers/dotnet/roslyn4.13/cs`. The .NET SDK resolves the highest slot
  at or below the compiler building the project.
- A build that never narrows the slots itself is handed every one. The packaged targets drop the slots that
  compiler is not served by, so the generator is not loaded twice and no dispatch file is emitted twice.
- A compiler older than Roslyn 4.8 receives no slot, which would leave every binding call throwing at run time
  with nothing to point at. The targets fail the build with `RXUIBIND100` naming both versions instead.

**RXUIBIND011 reports a binding call that ReactiveUI's own mixin answered.**

- Which method a call reaches is decided by extension-method lookup. A file that imports `ReactiveUI` and not
  `ReactiveUI.Binding` binds to ReactiveUI's mixin, and every extractor recognises a call by its declaring
  type, so that call is not one of ours: no dispatch is generated and no other diagnostic has anything to say
  about it.
- The declaring type is read after walking out of any nested type, so an extension declared in an extension
  block is recognised by the class the consumer wrote rather than the synthesized one its members belong to.
- The diagnostic only registers for a compilation that references this package.

**RXUIBIND009 stays silent where the call site is claimed outright.** The reach of a dispatch overload decides
nothing when no overload is what serves the call.

**RXUIBIND002 stays silent behind `BindTo`,** whose first type argument names the value type of a stream the
caller already built rather than an object anything observes.

**The suites run against both compiler builds.** The generator and analyzer test projects each have a mirror
compiled against Roslyn 4.13, so the tier a build gets is asserted on the build that gets it.

**NSubstitute is gone.** The symbol shapes those tests needed come from a compilation instead: a function
pointer's signature belongs to no type, an array type to no namespace, and an extension block declares its
members in a type with no name.

## What is the current behavior?

Every call site is reached by a concrete overload competing in extension-method lookup. A file outside the root
namespace, or a project below C# 10 whose assembly exposes its internals, is out of that overload's reach and
falls through to the runtime stub - which throws.

Closes #81
Closes #87

## What might this PR break?

- A project that deliberately calls ReactiveUI's mixins while referencing this package sees a warning per call
  site from RXUIBIND011.
- A compiler older than Roslyn 4.8 now fails the build with RXUIBIND100 rather than building without a
  generator.
- Generated code moves to the `ReactiveUI.Binding.Generated.Interceptors` namespace where interception is in
  effect. Anything reaching into the generated dispatch class by name would not find it there; nothing in the
  public surface does.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Verified against real builds rather than only the suite, since which tier a project gets is decided by the
compiler and not by anything in the repository:

| Sample                       | SDK / compiler | Slot resolved | Tier emitted | Outcome                                   |
|------------------------------|----------------|---------------|--------------|-------------------------------------------|
| `net10.0`                    | 11 / 4.13+     | roslyn4.13    | interceptors | six bindings observed and written         |
| `net462`, `<LangVersion>7.3` | 8.0.4xx / 4.11 | roslyn4.8     | overloads    | six bindings, run on Windows 11           |
| `net462`, both slots handed over | 11 / 4.13+ | roslyn4.13    | interceptors | one generator loaded, build clean         |
| `net462`                     | 7.0.4xx / 4.7  | none          | none         | RXUIBIND100                               |

A generation pass measured with the EventPipe `GcVerbose` profiler allocates the same either way - 1.92 MB at
one view-model pair, 29.54 MB at sixteen, 118.1 MB at sixty-four - and the trace attributes no allocation site
to this package at all. Every one it names is Roslyn binding the call: extension-method type-argument
inference, alpha renaming and parameter substitution.

