### PR TITLE
fix(generator): correct which call sites the dispatch claims

### DIFF
--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindCommandCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindCommandCodeGenerator.cs
@@ -456,7 +456,7 @@ internal static class BindCommandCodeGenerator
         ImmutableArray<ClassBindingInfo> allClasses,
         in LanguageFeatures features)
     {
-        var collapsed = features.SupportsCallerArgExpr
+        var collapsed = features.CollapsesIndistinguishableCallSites
             ? group with
             {
                 Invocations = CodeGeneratorHelpers.CollapseIndistinguishableCallSites(

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindInteractionCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindInteractionCodeGenerator.cs
@@ -301,7 +301,7 @@ internal static class BindInteractionCodeGenerator
         ImmutableArray<ClassBindingInfo> allClasses,
         in LanguageFeatures features)
     {
-        var collapsed = features.SupportsCallerArgExpr
+        var collapsed = features.CollapsesIndistinguishableCallSites
             ? group with
             {
                 Invocations = CodeGeneratorHelpers.CollapseIndistinguishableCallSites(

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindToCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindToCodeGenerator.cs
@@ -52,7 +52,7 @@ internal static class BindToCodeGenerator
 
         for (var g = 0; g < groups.Count; g++)
         {
-            var group = supportsCallerArgExpr
+            var group = features.CollapsesIndistinguishableCallSites
                 ? groups[g] with
                 {
                     Invocations = CodeGeneratorHelpers.CollapseIndistinguishableCallSites(

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindingEmitterHelpers.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindingEmitterHelpers.cs
@@ -61,7 +61,7 @@ internal static class BindingEmitterHelpers
 
         for (var g = 0; g < groups.Count; g++)
         {
-            var group = snapshot.SupportsCallerArgExpr
+            var group = snapshot.CollapsesIndistinguishableCallSites
                 ? groups[g] with
                 {
                     Invocations = CodeGeneratorHelpers.CollapseIndistinguishableCallSites(

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/ExtractorValidation.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/ExtractorValidation.cs
@@ -90,14 +90,23 @@ internal static class ExtractorValidation
     /// <param name="type">The type symbol, which may be null.</param>
     /// <returns>The fully qualified type name, or <see langword="null"/> when no overload could name it.</returns>
     /// <remarks>
+    /// <para>
     /// A call made through a type parameter binds to whatever closes it, which the call site does not name.
     /// Writing the parameter's own name into an overload puts an identifier no consumer declared into their
     /// build, so the whole compilation fails over generated code they cannot edit - including every unrelated
     /// call site in the project. Declining the call site leaves it on the runtime stub instead.
+    /// </para>
+    /// <para>
+    /// A static type fails the same way and reaches here by a different route: a call written through the
+    /// stub's declaring class - <c>ReactiveUIBindingExtensions.WhenChanged(vm, x => x.Name)</c> - puts that
+    /// class where the observed object goes, and no member can declare a parameter of it or close a generic
+    /// over it. Such a call resolves against that class's own members, so neither a generated overload nor an
+    /// interceptor matching the call written on an instance is a candidate for it either way.
+    /// </para>
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static string? GetDeclarableTypeDisplayName(ITypeSymbol? type) =>
-        type is INamedTypeSymbol named ? GetTypeDisplayName(named) : null;
+        type is INamedTypeSymbol { IsStatic: false } named ? GetTypeDisplayName(named) : null;
 
     /// <summary>
     /// Searches method parameters for a selector or conversion function parameter

--- a/src/ReactiveUI.Binding.SourceGenerators/Models/LanguageFeatures.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Models/LanguageFeatures.cs
@@ -78,4 +78,16 @@ internal readonly record struct LanguageFeatures(
     bool UsesReactiveRuntime = false,
     EquatableArray<string> RuntimeNamespaceMembers = default,
     EquatableArray<string> PrimitivesNamespaceMembers = default,
-    bool SupportsInterceptors = false);
+    bool SupportsInterceptors = false)
+{
+    /// <summary>Gets a value indicating whether call sites a dispatch cannot tell apart collapse to one.</summary>
+    /// <remarks>
+    /// Binding the same pair of properties from more than one place is ordinary, and expression-text dispatch
+    /// keys on the selectors as written: the first matching branch wins, so the later ones are unreachable and
+    /// only drag a binding method along. An interceptor instead names the call site it replaces, so dropping one
+    /// leaves it carrying no attribute - on the runtime engine while the call site beside it is generated. The
+    /// rule lives here because each API would otherwise decide it separately, and the one that forgot would
+    /// silently lose a binding rather than fail to compile.
+    /// </remarks>
+    internal bool CollapsesIndistinguishableCallSites => SupportsCallerArgExpr && !SupportsInterceptors;
+}

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/DeclaringClassInvocationTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/DeclaringClassInvocationTests.cs
@@ -1,0 +1,290 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.CSharp;
+using ReactiveUI.Binding.SourceGenerators.Tests.Helpers;
+
+namespace ReactiveUI.Binding.SourceGenerators.Tests;
+
+/// <summary>
+/// Tests the binding calls a consumer writes through the stub's declaring class -
+/// <c>ReactiveUIBindingExtensions.WhenChanged(vm, x => x.Name)</c> rather than <c>vm.WhenChanged(x => x.Name)</c>.
+/// </summary>
+/// <remarks>
+/// Every extractor reads the bound object from the receiver and the lambdas from the arguments after it, which
+/// a call naming the class shifts by one: the receiver is the class itself and each argument sits one place
+/// along. Generating from that produces a member declaring a parameter of a static type, which does not
+/// compile - so the consumer's whole build fails over generated code they cannot edit, including every
+/// unrelated call site in the project. Nothing could serve these call sites anyway: a call that names the
+/// class resolves against that class's members, so neither a generated overload nor an interceptor matching
+/// the reduced form is a candidate. They belong on the runtime stub.
+/// </remarks>
+public class DeclaringClassInvocationTests
+{
+    /// <summary>The <c>WhenChangedDispatch.g.cs</c> name these tests generate against.</summary>
+    private const string WhenChangedDispatchFileName = "WhenChangedDispatch.g.cs";
+
+    /// <summary>The <c>WhenAnyObservableDispatch.g.cs</c> name these tests generate against.</summary>
+    private const string WhenAnyObservableDispatchFileName = "WhenAnyObservableDispatch.g.cs";
+
+    /// <summary>The <c>BindOneWayDispatch.g.cs</c> name these tests generate against.</summary>
+    private const string BindOneWayDispatchFileName = "BindOneWayDispatch.g.cs";
+
+    /// <summary>The <c>BindToDispatch.g.cs</c> name these tests generate against.</summary>
+    private const string BindToDispatchFileName = "BindToDispatch.g.cs";
+
+    /// <summary>The <c>BindCommandDispatch.g.cs</c> name these tests generate against.</summary>
+    private const string BindCommandDispatchFileName = "BindCommandDispatch.g.cs";
+
+    /// <summary>The <c>BindInteractionDispatch.g.cs</c> name these tests generate against.</summary>
+    private const string BindInteractionDispatchFileName = "BindInteractionDispatch.g.cs";
+
+    /// <summary>A <c>WhenChanged</c> call named through its declaring class emits no dispatch.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenChanged_NamedThroughItsDeclaringClass_GeneratesNoDispatch()
+    {
+        const string source = """
+                              using System;
+                              using System.ComponentModel;
+                              using ReactiveUI.Binding;
+
+                              namespace TestApp
+                              {
+                                  public class MyViewModel : INotifyPropertyChanged
+                                  {
+                                      public event PropertyChangedEventHandler? PropertyChanged;
+
+                                      public string Name { get; set; } = "";
+                                  }
+
+                                  public static class Scenario
+                                  {
+                                      public static IObservable<string> Execute(MyViewModel vm)
+                                      {
+                                          return ReactiveUIBindingExtensions.WhenChanged(vm, x => x.Name);
+                                      }
+                                  }
+                              }
+                              """;
+
+        var result = TestHelper.RunGenerator(source, LanguageVersion.CSharp10);
+
+        await result.HasNoGeneratorDiagnostics();
+        await result.CompilationSucceeds();
+        await result.DoesNotHaveGeneratedSource(WhenChangedDispatchFileName);
+    }
+
+    /// <summary>A <c>WhenAnyObservable</c> call named through its declaring class emits no dispatch.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyObservable_NamedThroughItsDeclaringClass_GeneratesNoDispatch()
+    {
+        const string source = """
+                              using System;
+                              using System.ComponentModel;
+                              using ReactiveUI.Binding;
+
+                              namespace TestApp
+                              {
+                                  public class MyViewModel : INotifyPropertyChanged
+                                  {
+                                      public event PropertyChangedEventHandler? PropertyChanged;
+
+                                      public IObservable<int>? Signal { get; set; }
+                                  }
+
+                                  public static class Scenario
+                                  {
+                                      public static IObservable<int> Execute(MyViewModel vm)
+                                      {
+                                          return ReactiveUIBindingExtensions.WhenAnyObservable(vm, x => x.Signal);
+                                      }
+                                  }
+                              }
+                              """;
+
+        var result = TestHelper.RunGenerator(source, LanguageVersion.CSharp10);
+
+        await result.HasNoGeneratorDiagnostics();
+        await result.CompilationSucceeds();
+        await result.DoesNotHaveGeneratedSource(WhenAnyObservableDispatchFileName);
+    }
+
+    /// <summary>A <c>BindOneWay</c> call named through its declaring class emits no dispatch.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindOneWay_NamedThroughItsDeclaringClass_GeneratesNoDispatch()
+    {
+        const string source = """
+                              using System;
+                              using System.ComponentModel;
+                              using ReactiveUI.Binding;
+
+                              namespace TestApp
+                              {
+                                  public class MyViewModel : INotifyPropertyChanged
+                                  {
+                                      public event PropertyChangedEventHandler? PropertyChanged;
+
+                                      public string Name { get; set; } = "";
+                                  }
+
+                                  public class MyView : INotifyPropertyChanged
+                                  {
+                                      public event PropertyChangedEventHandler? PropertyChanged;
+
+                                      public string DisplayName { get; set; } = "";
+                                  }
+
+                                  public static class Scenario
+                                  {
+                                      public static IDisposable Execute(MyViewModel vm, MyView view)
+                                      {
+                                          return ReactiveUIBindingExtensions.BindOneWay(vm, view, x => x.Name, x => x.DisplayName);
+                                      }
+                                  }
+                              }
+                              """;
+
+        var result = TestHelper.RunGenerator(source, LanguageVersion.CSharp10);
+
+        await result.HasNoGeneratorDiagnostics();
+        await result.CompilationSucceeds();
+        await result.DoesNotHaveGeneratedSource(BindOneWayDispatchFileName);
+    }
+
+    /// <summary>A <c>BindTo</c> call named through its declaring class emits no dispatch.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTo_NamedThroughItsDeclaringClass_GeneratesNoDispatch()
+    {
+        const string source = """
+                              using System;
+                              using System.ComponentModel;
+                              using ReactiveUI.Binding;
+
+                              namespace TestApp
+                              {
+                                  public class MyView : INotifyPropertyChanged
+                                  {
+                                      public event PropertyChangedEventHandler? PropertyChanged;
+
+                                      public string DisplayName { get; set; } = "";
+                                  }
+
+                                  public static class Scenario
+                                  {
+                                      public static IDisposable Execute(IObservable<string> values, MyView view)
+                                      {
+                                          return ReactiveUIBindingExtensions.BindTo(values, view, x => x.DisplayName);
+                                      }
+                                  }
+                              }
+                              """;
+
+        var result = TestHelper.RunGenerator(source, LanguageVersion.CSharp10);
+
+        await result.HasNoGeneratorDiagnostics();
+        await result.CompilationSucceeds();
+        await result.DoesNotHaveGeneratedSource(BindToDispatchFileName);
+    }
+
+    /// <summary>A <c>BindCommand</c> call named through its declaring class emits no dispatch.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommand_NamedThroughItsDeclaringClass_GeneratesNoDispatch()
+    {
+        const string source = """
+                              using System;
+                              using System.ComponentModel;
+                              using System.Windows.Input;
+                              using ReactiveUI.Binding;
+
+                              namespace TestApp
+                              {
+                                  public class MyButton
+                                  {
+                                      public event EventHandler? Click;
+                                  }
+
+                                  public class MyViewModel : INotifyPropertyChanged
+                                  {
+                                      public event PropertyChangedEventHandler? PropertyChanged;
+
+                                      public ICommand? Save { get; set; }
+                                  }
+
+                                  public class MyView : IViewFor
+                                  {
+                                      public object? ViewModel { get; set; }
+
+                                      public MyButton SaveButton { get; set; } = new MyButton();
+                                  }
+
+                                  public static class Scenario
+                                  {
+                                      public static IDisposable Execute(MyViewModel vm, MyView view)
+                                      {
+                                          return ReactiveUIBindingExtensions.BindCommand(view, vm, x => x.Save, x => x.SaveButton);
+                                      }
+                                  }
+                              }
+                              """;
+
+        var result = TestHelper.RunGenerator(source, LanguageVersion.CSharp10);
+
+        await result.HasNoGeneratorDiagnostics();
+        await result.CompilationSucceeds();
+        await result.DoesNotHaveGeneratedSource(BindCommandDispatchFileName);
+    }
+
+    /// <summary>A <c>BindInteraction</c> call named through its declaring class emits no dispatch.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindInteraction_NamedThroughItsDeclaringClass_GeneratesNoDispatch()
+    {
+        const string source = """
+                              using System;
+                              using System.ComponentModel;
+                              using System.Threading.Tasks;
+                              using ReactiveUI.Binding;
+
+                              namespace TestApp
+                              {
+                                  public class MyViewModel : INotifyPropertyChanged
+                                  {
+                                      public event PropertyChangedEventHandler? PropertyChanged;
+
+                                      public Interaction<string, bool> Confirm { get; set; } = new Interaction<string, bool>();
+                                  }
+
+                                  public class MyView : IViewFor
+                                  {
+                                      public object? ViewModel { get; set; }
+                                  }
+
+                                  public static class Scenario
+                                  {
+                                      public static IDisposable Execute(MyViewModel vm, MyView view)
+                                      {
+                                          return ReactiveUIBindingExtensions.BindInteraction(view, vm, x => x.Confirm, Handle);
+                                      }
+
+                                      private static Task Handle(IInteractionContext<string, bool> context)
+                                      {
+                                          context.SetOutput(true);
+                                          return Task.CompletedTask;
+                                      }
+                                  }
+                              }
+                              """;
+
+        var result = TestHelper.RunGenerator(source, LanguageVersion.CSharp10);
+
+        await result.HasNoGeneratorDiagnostics();
+        await result.CompilationSucceeds();
+        await result.DoesNotHaveGeneratedSource(BindInteractionDispatchFileName);
+    }
+}

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/RepeatedCallSiteDispatchTests.Interception.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/RepeatedCallSiteDispatchTests.Interception.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis.CSharp;
+using ReactiveUI.Binding.SourceGenerators.Helpers;
+using ReactiveUI.Binding.SourceGenerators.Tests.Helpers;
+
+namespace ReactiveUI.Binding.SourceGenerators.Tests;
+
+/// <summary>
+/// The same repeated call sites, generated for a build that claims each one by name. Collapsing a group to one
+/// call site per distinct pair of selectors is right where dispatch keys on that text, because the later
+/// branches are unreachable - but an interceptor names the call site it replaces, so a dropped one carries no
+/// attribute and takes the runtime engine while its twin is generated.
+/// </summary>
+public partial class RepeatedCallSiteDispatchTests
+{
+    /// <summary>The attribute text that claims one call site.</summary>
+    private const string InterceptsAttribute = "InterceptsLocation(";
+
+    /// <summary>The number of call sites each repeated scenario writes.</summary>
+    private const int CallSitesPerScenario = 2;
+
+    /// <summary>Both BindOneWay call sites are claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task RepeatedCallSites_UnderInterception_ClaimEveryCallSite() =>
+        AssertEveryCallSiteIsClaimed(RepeatedBindingSource, DispatchFileName);
+
+    /// <summary>Both BindTo call sites are claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task RepeatedBindTo_UnderInterception_ClaimsEveryCallSite() =>
+        AssertEveryCallSiteIsClaimed(RepeatedBindToSource, "BindToDispatch.g.cs");
+
+    /// <summary>Both BindCommand call sites are claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task RepeatedBindCommand_UnderInterception_ClaimsEveryCallSite() =>
+        AssertEveryCallSiteIsClaimed(RepeatedBindCommandSource, "BindCommandDispatch.g.cs");
+
+    /// <summary>Both BindInteraction call sites are claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task RepeatedBindInteraction_UnderInterception_ClaimsEveryCallSite() =>
+        AssertEveryCallSiteIsClaimed(RepeatedBindInteractionSource, "BindInteractionDispatch.g.cs");
+
+    /// <summary>Generates a scenario for an opted-in build and counts the call sites it claimed.</summary>
+    /// <param name="source">The consumer source, which writes the same call site twice.</param>
+    /// <param name="dispatchFileName">The dispatch file the API generates into.</param>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    /// <remarks>
+    /// A compiler that describes no call site emits the overloads instead, where collapsing is what should
+    /// happen, so the expected count is stated for both builds rather than skipped on one. The assembly is
+    /// emitted because that is where the compiler checks an interceptor against the call it replaces - two
+    /// attributes that both claim the same call site pass every other check.
+    /// </remarks>
+    private static async Task AssertEveryCallSiteIsClaimed(string source, string dispatchFileName)
+    {
+        var parseOptions = TestHelper.InterceptingParseOptionsFor(LanguageVersion.CSharp10);
+        var compilation = TestHelper.CreateCompilation(source, parseOptions, false, "TestAssembly", []);
+        var result = TestHelper.RunGenerator(compilation, parseOptions, ProbeRootNamespace, true);
+
+        await result.CompilationSucceeds();
+
+        var expected = InterceptableLocationReader.IsSupported ? CallSitesPerScenario : 0;
+
+        await result.GeneratedSourceContainsCount(dispatchFileName, InterceptsAttribute, expected);
+
+        var (_, context) = TestHelper.EmitAndLoad(result);
+        context.Unload();
+    }
+}

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/RepeatedCallSiteDispatchTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/RepeatedCallSiteDispatchTests.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Binding.SourceGenerators.Tests;
 /// mechanisms can tell apart differs: expression text is shared by such call sites, while file and line are
 /// not. These scenarios pin that each mechanism generates exactly the bodies it can actually reach.
 /// </summary>
-public class RepeatedCallSiteDispatchTests
+public partial class RepeatedCallSiteDispatchTests
 {
     /// <summary>The dispatch file BindOneWay call sites are generated into.</summary>
     private const string DispatchFileName = "BindOneWayDispatch.g.cs";
@@ -70,42 +70,8 @@ public class RepeatedCallSiteDispatchTests
                                                  }
                                                  """;
 
-    /// <summary>
-    /// Expression-text dispatch cannot tell the two call sites apart, so a second body would be unreachable
-    /// and is not emitted.
-    /// </summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task RepeatedCallSites_UnderExpressionDispatch_GenerateOneBindingMethod()
-    {
-        var result = TestHelper.RunGenerator(
-            RepeatedBindingSource,
-            LanguageVersion.CSharp10,
-            ProbeRootNamespace);
-
-        await result.CompilationSucceeds();
-        await result.GeneratedSourceContainsCount(DispatchFileName, BindingMethodDeclaration, 1);
-    }
-
-    /// <summary>File-and-line dispatch reaches each call site separately, so both keep a body of their own.</summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task RepeatedCallSites_UnderFileAndLineDispatch_GenerateABindingMethodEach()
-    {
-        var result = TestHelper.RunGenerator(
-            RepeatedBindingSource,
-            LanguageVersion.CSharp7_3,
-            ProbeRootNamespace);
-
-        await result.GeneratedSourceContainsCount(DispatchFileName, BindingMethodDeclaration, BodyPerCallSite);
-    }
-
-    /// <summary>Two BindTo call sites spelled identically share one generated binding method.</summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task RepeatedBindTo_UnderExpressionDispatch_GeneratesOneBindingMethod()
-    {
-        const string source = """
+    /// <summary>Two BindTo call sites applying the same stream to the same property, spelled identically.</summary>
+    private const string RepeatedBindToSource = """
                               using System;
                               using System.ComponentModel;
                               using ReactiveUI.Binding;
@@ -134,21 +100,8 @@ public class RepeatedCallSiteDispatchTests
                               }
                               """;
 
-        var result = TestHelper.RunGenerator(source, LanguageVersion.CSharp10, ProbeRootNamespace);
-
-        await result.CompilationSucceeds();
-        await result.GeneratedSourceContainsCount(
-            "BindToDispatch.g.cs",
-            "private static global::System.IDisposable __BindTo_",
-            1);
-    }
-
-    /// <summary>Two BindCommand call sites spelled identically share one generated binding method.</summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task RepeatedBindCommand_UnderExpressionDispatch_GeneratesOneBindingMethod()
-    {
-        const string source = """
+    /// <summary>Two BindCommand call sites binding the same command to the same control, spelled identically.</summary>
+    private const string RepeatedBindCommandSource = """
                               using System;
                               using System.ComponentModel;
                               using System.Windows.Input;
@@ -198,20 +151,8 @@ public class RepeatedCallSiteDispatchTests
                               }
                               """;
 
-        var result = TestHelper.RunGenerator(source, LanguageVersion.CSharp10, ProbeRootNamespace);
-
-        await result.GeneratedSourceContainsCount(
-            "BindCommandDispatch.g.cs",
-            "__BindCommand_",
-            NamedOncePerBranchAndDeclaration);
-    }
-
-    /// <summary>Two BindInteraction call sites spelled identically share one generated binding method.</summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task RepeatedBindInteraction_UnderExpressionDispatch_GeneratesOneBindingMethod()
-    {
-        const string source = """
+    /// <summary>Two BindInteraction call sites binding the same interaction, spelled identically.</summary>
+    private const string RepeatedBindInteractionSource = """
                               using System;
                               using System.ComponentModel;
                               using System.Threading.Tasks;
@@ -252,7 +193,69 @@ public class RepeatedCallSiteDispatchTests
                               }
                               """;
 
-        var result = TestHelper.RunGenerator(source, LanguageVersion.CSharp10, ProbeRootNamespace);
+    /// <summary>
+    /// Expression-text dispatch cannot tell the two call sites apart, so a second body would be unreachable
+    /// and is not emitted.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RepeatedCallSites_UnderExpressionDispatch_GenerateOneBindingMethod()
+    {
+        var result = TestHelper.RunGenerator(
+            RepeatedBindingSource,
+            LanguageVersion.CSharp10,
+            ProbeRootNamespace);
+
+        await result.CompilationSucceeds();
+        await result.GeneratedSourceContainsCount(DispatchFileName, BindingMethodDeclaration, 1);
+    }
+
+    /// <summary>File-and-line dispatch reaches each call site separately, so both keep a body of their own.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RepeatedCallSites_UnderFileAndLineDispatch_GenerateABindingMethodEach()
+    {
+        var result = TestHelper.RunGenerator(
+            RepeatedBindingSource,
+            LanguageVersion.CSharp7_3,
+            ProbeRootNamespace);
+
+        await result.GeneratedSourceContainsCount(DispatchFileName, BindingMethodDeclaration, BodyPerCallSite);
+    }
+
+    /// <summary>Two BindTo call sites spelled identically share one generated binding method.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RepeatedBindTo_UnderExpressionDispatch_GeneratesOneBindingMethod()
+    {
+        var result = TestHelper.RunGenerator(RepeatedBindToSource, LanguageVersion.CSharp10, ProbeRootNamespace);
+
+        await result.CompilationSucceeds();
+        await result.GeneratedSourceContainsCount(
+            "BindToDispatch.g.cs",
+            "private static global::System.IDisposable __BindTo_",
+            1);
+    }
+
+    /// <summary>Two BindCommand call sites spelled identically share one generated binding method.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RepeatedBindCommand_UnderExpressionDispatch_GeneratesOneBindingMethod()
+    {
+        var result = TestHelper.RunGenerator(RepeatedBindCommandSource, LanguageVersion.CSharp10, ProbeRootNamespace);
+
+        await result.GeneratedSourceContainsCount(
+            "BindCommandDispatch.g.cs",
+            "__BindCommand_",
+            NamedOncePerBranchAndDeclaration);
+    }
+
+    /// <summary>Two BindInteraction call sites spelled identically share one generated binding method.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RepeatedBindInteraction_UnderExpressionDispatch_GeneratesOneBindingMethod()
+    {
+        var result = TestHelper.RunGenerator(RepeatedBindInteractionSource, LanguageVersion.CSharp10, ProbeRootNamespace);
 
         await result.GeneratedSourceContainsCount(
             "BindInteractionDispatch.g.cs",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Two defects in which call sites a dispatch claims.

## What is the new behavior?

**Every call site an interception build can name is claimed.**

- Call sites spelling the same selectors each carry their own attribute, so binding the same pair of properties from two places generates both. Collapsing stays where it belongs: expression-text dispatch keys on the selectors as written, so its later branches really are unreachable.
- The rule is stated once on the feature snapshot rather than decided separately by each API.

**A binding call written through the stub's declaring class compiles.**

- `ReactiveUIBindingExtensions.WhenChanged(vm, x => x.Name)` and the same shape on every other binding API generate no dispatch, and the call takes the runtime engine like any other shape the generator cannot serve.
- The shared receiver guard declines a static type alongside a type parameter, so every API is covered from one place: each extractor reads the bound object through it.

## What is the current behavior?

**A repeated call site silently loses its generated binding.** Under interception the group is collapsed before the attributes are emitted, so the second call site is left on the runtime expression engine while the one beside it is generated - a whole screen of a view at a time, with the build green.

**A call naming the class fails the consumer's whole build.** The class itself is read as the observed object, so the emitted worker declares a parameter of a static type and takes it as a type argument: `CS0721` and `CS0718` on generated code the consumer cannot edit, which fails every unrelated call site in the project with it.

## What might this PR break?

**None.**

- Nothing could serve the call sites that are now declined. A call that names the class resolves against that class's members, so neither the generated overload nor an interceptor matching the call written on an instance is a candidate for it.
- Interception now emits one binding method per claimed call site where two were spelled identically, which is what file-and-line dispatch already does.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

One test per extractor pins the declined shape, so an API whose argument reading shifts by one is caught where it would otherwise emit uncompilable code. The interception tests emit the assembly, because that is where the compiler checks an interceptor against the call it replaces.
