### PR TITLE
feat!: resolve reflection only through Unsafe overloads

### DIFF
--- a/.github/workflows/native-aot.yml
+++ b/.github/workflows/native-aot.yml
@@ -1,0 +1,21 @@
+name: Native AOT
+
+on:
+    push:
+        branches: [ main ]
+    pull_request:
+        branches: [ main ]
+
+permissions:
+    contents: read
+
+jobs:
+    native-aot-smoke:
+        uses: reactiveui/actions-common/.github/workflows/workflow-common-aot-smoke.yml@main
+        with:
+            projectFile: src/tests/ReactiveUI.Binding.AotValidation/ReactiveUI.Binding.AotValidation.csproj
+
+    trimmed-smoke:
+        uses: reactiveui/actions-common/.github/workflows/workflow-common-aot-smoke.yml@main
+        with:
+            projectFile: src/tests/ReactiveUI.Binding.TrimValidation/ReactiveUI.Binding.TrimValidation.csproj

--- a/.github/workflows/native-aot.yml
+++ b/.github/workflows/native-aot.yml
@@ -14,8 +14,3 @@ jobs:
         uses: reactiveui/actions-common/.github/workflows/workflow-common-aot-smoke.yml@main
         with:
             projectFile: src/tests/ReactiveUI.Binding.AotValidation/ReactiveUI.Binding.AotValidation.csproj
-
-    trimmed-smoke:
-        uses: reactiveui/actions-common/.github/workflows/workflow-common-aot-smoke.yml@main
-        with:
-            projectFile: src/tests/ReactiveUI.Binding.TrimValidation/ReactiveUI.Binding.TrimValidation.csproj

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -25,7 +25,7 @@ jobs:
             # CombineLatest observables are one class per arity; each repetition is what makes the call site
             # allocation-free and reflection-free, so collapsing them is not an option. The platform packages
             # implement the same small abstractions against different UI frameworks.
-            sonarCpdExclusions: '**/tests/**,**/benchmarks/**,**/*.WideArity.cs,**/Observables/CombineLatest*Observable.cs,**/ReactiveUI.Binding.Maui.Shared/**,**/ReactiveUI.Binding.Wpf.Shared/**,**/ReactiveUI.Binding.WinForms.Shared/**,**/ReactiveUI.Binding.Platform.Shared/**'
+            sonarCpdExclusions: '**/tests/**,**/benchmarks/**,**/*.WideArity.cs,**/*.WideArity.Unsafe.cs,**/Observables/CombineLatest*Observable.cs,**/ReactiveUI.Binding.Maui.Shared/**,**/ReactiveUI.Binding.Wpf.Shared/**,**/ReactiveUI.Binding.WinForms.Shared/**,**/ReactiveUI.Binding.Platform.Shared/**'
             sonarTestExclusions: '**/tests/**,**/benchmarks/**'
             # Matches ci-build.yml: the MTP/TUnit suite is far slower on Windows net10
             # than on net8/9, so allow generous headroom for the coverage run.

--- a/.github/workflows/trimmed.yml
+++ b/.github/workflows/trimmed.yml
@@ -1,0 +1,19 @@
+name: Trimmed
+
+# The shared smoke workflow keys its concurrency group on github.workflow, so the trimmed harness runs from
+# its own file. Both in one file share a group, and whichever starts second cancels the other.
+
+on:
+    push:
+        branches: [ main ]
+    pull_request:
+        branches: [ main ]
+
+permissions:
+    contents: read
+
+jobs:
+    trimmed-smoke:
+        uses: reactiveui/actions-common/.github/workflows/workflow-common-aot-smoke.yml@main
+        with:
+            projectFile: src/tests/ReactiveUI.Binding.TrimValidation/ReactiveUI.Binding.TrimValidation.csproj

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ generation. Zero reflection, fully AOT/trimming safe, 3-7x faster than the legac
 - [What does it do?](#what-does-it-do)
 - [How does it work?](#how-does-it-work)
 - [How a call site reaches its generated code](#how-a-call-site-reaches-its-generated-code)
+- [When nothing claims the call](#when-nothing-claims-the-call)
 - [How do I install?](#how-do-i-install)
 - [Supported APIs](#supported-apis)
 - [Usage Examples](#usage-examples)
@@ -118,6 +119,48 @@ will not.
 
 Either way the same generated method runs, so bindings behave identically.
 
+## When nothing claims the call
+
+A generated overload wins overload resolution for every call site of its types, including the ones whose lambdas it
+could not read - an expression held in a variable, one assembled at run time, or a receiver typed as a type parameter.
+Those calls reach the runtime stub, which throws and names the overload that does resolve them:
+
+```csharp
+Expression<Func<MyViewModel, string>> selector = x => x.Name;
+
+vm.WhenChanged(selector);        // throws: no generated WhenChanged dispatch matched this call site
+vm.WhenChangedUnsafe(selector);  // walks the chain by reflection
+```
+
+Every API has an `Unsafe` twin:
+
+| Compile-time      | Reflection                                                     |
+|-------------------|----------------------------------------------------------------|
+| `WhenChanged`     | `WhenChangedUnsafe`                                            |
+| `WhenChanging`    | `WhenChangingUnsafe`                                           |
+| `WhenAnyValue`    | `WhenAnyValueUnsafe`                                           |
+| `BindOneWay`      | `BindOneWayUnsafe`                                             |
+| `BindTwoWay`      | `BindTwoWayUnsafe`                                             |
+| `Bind`            | `BindUnsafe`                                                   |
+| `OneWayBind`      | `OneWayBindUnsafe`                                             |
+| `BindTo`          | `BindToUnsafe`                                                 |
+| `BindCommand`     | `BindCommandUnsafe`                                            |
+| `BindInteraction` | `BindInteractionUnsafe`                                        |
+| `InvokeCommand`   | `InvokeCommandUnsafe`                                          |
+| `WhenAny`         | `WhenAnyUnsafe`                                                |
+| `WhenAnyObservable` | `WhenAnyObservableUnsafe`                                    |
+
+Every `Unsafe` overload carries `[RequiresUnreferencedCode]` and the unsuffixed names carry none, so a `PublishTrimmed`
+or `PublishAot` build reports the reflection at the call sites that asked for it and says nothing about the rest. That
+is what keeps a fully generated application free of IL2026 while leaving the runtime engine available to the call sites
+that need it. `RXUIBIND001`, `RXUIBIND006` and `RXUIBIND009` name those call sites while you build, before the throw.
+
+The scheduler overloads follow the same split, in `ReactiveSchedulerUnsafeExtensions`.
+
+`WhenAnyDynamic` is the one API with no twin. It takes the chain as an `Expression` the caller built, so there is
+never a lambda for the generator to read and no compile-time half to offer - the unsuffixed overloads carry the
+annotation themselves.
+
 ### What the package ships
 
 The generator and its analyzer are packed once per compiler generation:
@@ -190,6 +233,9 @@ Platform-specific packages provide DependencyProperty observation and other plat
 
 All APIs support single properties, deep property chains (e.g. `x => x.Address.City`), and multi-property observation (
 up to 12 properties for `WhenAnyValue`/`WhenChanged`).
+
+Each of them also has an `Unsafe` twin that resolves the expression by reflection, for the call sites the generator
+cannot read - see [When nothing claims the call](#when-nothing-claims-the-call).
 
 ## Usage Examples
 
@@ -519,15 +565,15 @@ The separate analyzer package reports the following diagnostics:
 
 | ID          | Severity | Description                                                                                                                                                              |
 |-------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| RXUIBIND001 | Info     | Expression must be an inline lambda for compile-time optimisation. Variable or method references fall back to runtime.                                                   |
+| RXUIBIND001 | Info     | Expression must be an inline lambda for compile-time optimisation. A variable or method reference needs the `Unsafe` overload.                                           |
 | RXUIBIND002 | Warning  | Type has no observable properties and does not implement any observable notification mechanism.                                                                          |
 | RXUIBIND003 | Warning  | Expression accesses a private or protected member which cannot be observed by a generated extension method.                                                              |
 | RXUIBIND004 | Warning  | Type does not support before-change notifications (WhenChanging). WPF DependencyObjects, WinForms Components, and Android Views only support after-change notifications. |
 | RXUIBIND005 | Info     | Source type implements INotifyDataErrorInfo; validation state propagation is not generated and requires runtime engine or manual ErrorsChanged subscription.             |
-| RXUIBIND006 | Warning  | Expression contains an unsupported path segment (indexer, field, or method call). Only simple property access chains can be observed by the source generator.            |
+| RXUIBIND006 | Warning  | Expression contains an unsupported path segment (indexer, field, or method call). Only simple property access chains are generated; the rest need the `Unsafe` overload.  |
 | RXUIBIND007 | Warning  | BindCommand control has no bindable event. Specify the `toEvent` parameter explicitly.                                                                                   |
 | RXUIBIND008 | Warning  | The property selected in a BindInteraction expression does not implement `IInteraction<TInput, TOutput>`.                                                                |
-| RXUIBIND009 | Warning  | The generated binding dispatch is out of reach from this file, so the call falls back to the runtime stub. Not reported where the call site is claimed by an interceptor. |
+| RXUIBIND009 | Warning  | The generated binding dispatch is out of reach from this file, so the call reaches the throwing stub. Not reported where the call site is claimed by an interceptor.      |
 | RXUIBIND010 | Warning  | The observed path passes through a type that raises no notification, so it is read once and the observation stops following the path there.                              |
 | RXUIBIND011 | Warning  | The call resolved to ReactiveUI's own mixin, so nothing is generated for it and it takes the runtime expression engine. Import `ReactiveUI.Binding` in the file.          |
 
@@ -561,7 +607,8 @@ first, and the view's own first value is then weighed against what was just writ
 A generated overload has to name the bound types, and a call made through a type parameter names none - the
 type is only known once something closes it. Those call sites are left to the runtime stub, so a generic
 binding helper compiles and throws when it runs rather than emitting an overload naming a type parameter,
-which would fail the consumer's build outright.
+which would fail the consumer's build outright. Calling the `Unsafe` twin from the helper binds it by
+reflection instead, and marks the helper as the reflection boundary it is.
 
 ### A silent link in a path is reported at compile time, not at run time
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <!-- StyleSharp.Analyzers, PerformanceSharp.Analyzers and SecuritySharp.Analyzers ship from the
          same release pipeline and always share a version. -->
-    <RoslynCommonAnalyzersVersion>3.46.2</RoslynCommonAnalyzersVersion>
+    <RoslynCommonAnalyzersVersion>4.0.4</RoslynCommonAnalyzersVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Binding.Reactive/ReactiveUI.Binding.Reactive.csproj
+++ b/src/ReactiveUI.Binding.Reactive/ReactiveUI.Binding.Reactive.csproj
@@ -9,6 +9,13 @@
     <PackageTags>reactiveui;binding;system.reactive;scheduler</PackageTags>
   </PropertyGroup>
 
+  <!-- The same link and ahead-of-time gate the lean leaf carries, over the same source. Only the frameworks
+       that have a linker - net4x has neither a trimmer nor an AOT compiler. -->
+  <PropertyGroup Condition="!$(TargetFramework.StartsWith('net4'))">
+    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\ReactiveUI.Binding.Shared\**\*.cs" Link="ReactiveUI.Binding.Shared\%(RecursiveDir)%(Filename)%(Extension)"/>
   </ItemGroup>

--- a/src/ReactiveUI.Binding.Shared/Bindings/Converters/BindingFallbackConverterRegistry.cs
+++ b/src/ReactiveUI.Binding.Shared/Bindings/Converters/BindingFallbackConverterRegistry.cs
@@ -61,7 +61,7 @@ public sealed class BindingFallbackConverterRegistry
 
         lock (_gate)
         {
-            var snap = _snapshot ?? new Snapshot(new(InitialRegistryCapacity));
+            var snap = _snapshot ?? new Snapshot([with(InitialRegistryCapacity)]);
 
             // Copy-on-write update: clone the list
             var newList = new List<IBindingFallbackConverter>(snap.Converters) { converter };

--- a/src/ReactiveUI.Binding.Shared/Bindings/Converters/BindingTypeConverterRegistry.cs
+++ b/src/ReactiveUI.Binding.Shared/Bindings/Converters/BindingTypeConverterRegistry.cs
@@ -66,14 +66,14 @@ public sealed class BindingTypeConverterRegistry
 
         lock (_gate)
         {
-            var snap = _snapshot ?? new Snapshot(new(InitialRegistryCapacity));
+            var snap = _snapshot ?? new Snapshot([with(InitialRegistryCapacity)]);
 
             // Copy-on-write update: clone the dictionary shallowly
             var newDict = CloneRegistryShallow(snap.ConvertersByTypePair);
 
             List<IBindingTypeConverter>? list =
                 !newDict.TryGetValue(key, out list)
-                    ? new(InitialConverterListCapacity)
+                    ? [with(InitialConverterListCapacity)]
                     : [.. list];
 
             list.Add(converter);

--- a/src/ReactiveUI.Binding.Shared/Bindings/Converters/SetMethodBindingConverterRegistry.cs
+++ b/src/ReactiveUI.Binding.Shared/Bindings/Converters/SetMethodBindingConverterRegistry.cs
@@ -54,7 +54,7 @@ public sealed class SetMethodBindingConverterRegistry
 
         lock (_gate)
         {
-            var snap = _snapshot ?? new Snapshot(new(InitialRegistryCapacity));
+            var snap = _snapshot ?? new Snapshot([with(InitialRegistryCapacity)]);
 
             // Copy-on-write update: clone the list
             var newList = new List<ISetMethodBindingConverter>(snap.Converters) { converter };

--- a/src/ReactiveUI.Binding.Shared/Fallback/RuntimeBindingConverter.cs
+++ b/src/ReactiveUI.Binding.Shared/Fallback/RuntimeBindingConverter.cs
@@ -31,7 +31,15 @@ public static class RuntimeBindingConverter
     /// <param name="converterOverride">An optional explicit converter that takes precedence over the registry.</param>
     /// <param name="result">The converted value when conversion succeeds.</param>
     /// <returns><see langword="true"/> if conversion succeeded; otherwise <see langword="false"/>.</returns>
-    public static bool TryConvert<TFrom, TTo>(
+    /// <remarks>
+    /// The converter is resolved from the declared types rather than from the value's runtime type. A runtime
+    /// <see cref="Type"/> cannot satisfy the annotations the converter registry declares, so resolving from one
+    /// would put a trimming requirement on every generated binding that converts. The declared types are what
+    /// the generator bound, so they are what the registry is asked about.
+    /// </remarks>
+    public static bool TryConvert<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TFrom,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TTo>(
         TFrom value,
         object? conversionHint,
         IBindingTypeConverter? converterOverride,
@@ -39,7 +47,7 @@ public static class RuntimeBindingConverter
     {
         var toType = typeof(TTo);
         object? boxed = value;
-        var fromType = boxed?.GetType() ?? typeof(TFrom);
+        var fromType = typeof(TFrom);
 
         object? converted;
 

--- a/src/ReactiveUI.Binding.Shared/Fallback/RuntimeBindingFallback.cs
+++ b/src/ReactiveUI.Binding.Shared/Fallback/RuntimeBindingFallback.cs
@@ -303,6 +303,58 @@ public static class RuntimeBindingFallback
             bindingExpression);
     }
 
+    /// <summary>Writes every value a sequence produces into a property, converting it on the way.</summary>
+    /// <typeparam name="TValue">The type the sequence produces.</typeparam>
+    /// <typeparam name="TTarget">The type declaring the written property.</typeparam>
+    /// <typeparam name="TTargetValue">The type of the written property.</typeparam>
+    /// <param name="source">The sequence driving the writes.</param>
+    /// <param name="target">The object declaring the written property.</param>
+    /// <param name="targetProperty">The property to write.</param>
+    /// <param name="conversionHint">An optional hint handed to the converter.</param>
+    /// <param name="converterOverride">A converter that takes precedence over the registered ones.</param>
+    /// <param name="scheduler">The scheduler the writes are delivered on, or null for the main thread.</param>
+    /// <param name="bindingExpression">The bound expression, named when a write faults.</param>
+    /// <returns>A disposable that, when disposed, stops writing.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="targetProperty"/> is null.</exception>
+    /// <remarks>
+    /// A value the converter refuses is written as the target type's default, which is what the generated path
+    /// does with the same converter, so a call site behaves the same whether or not it was claimed.
+    /// A null target holds no property to write, so the values are dropped rather than faulting the sequence.
+    /// </remarks>
+    [RequiresUnreferencedCode("Runtime binding fallback resolves the property chain by reflection.")]
+    public static IDisposable BindTo<TValue, TTarget, TTargetValue>(
+        IObservable<TValue> source,
+        TTarget? target,
+        Expression<Func<TTarget, TTargetValue>> targetProperty,
+        object? conversionHint,
+        IBindingTypeConverter? converterOverride,
+        ISequencer? scheduler,
+        string bindingExpression)
+        where TTarget : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(source);
+        ArgumentExceptionHelper.ThrowIfNull(targetProperty);
+
+        if (target is null)
+        {
+            return EmptyDisposable.Instance;
+        }
+
+        var converted = new MapSignal<TValue, TTargetValue>(
+            source,
+            value =>
+            {
+                _ = RuntimeBindingConverter.TryConvert<TValue, TTargetValue>(
+                    value,
+                    conversionHint,
+                    converterOverride,
+                    out var result);
+                return result;
+            });
+
+        return Write(Schedule(converted, scheduler), target, targetProperty, bindingExpression);
+    }
+
     /// <summary>Wraps a two-way pair of writes as the binding value the view-first APIs hand back.</summary>
     /// <typeparam name="TViewModel">The type declaring the view-model property.</typeparam>
     /// <typeparam name="TView">The type declaring the view property.</typeparam>

--- a/src/ReactiveUI.Binding.Shared/Fallback/RuntimeCommandBindingFallback.cs
+++ b/src/ReactiveUI.Binding.Shared/Fallback/RuntimeCommandBindingFallback.cs
@@ -1,0 +1,122 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Windows.Input;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive.Fallback;
+#else
+namespace ReactiveUI.Binding.Fallback;
+#endif
+
+/// <summary>Binds a command to a control through the runtime expression engine.</summary>
+/// <remarks>
+/// Reached where the generator could not serve the call site - a view or view model it cannot name, or a selector
+/// that is not an inline lambda. Which control mechanism carries the execution is the generated path's decision
+/// too: both ask <c>CommandBinderService</c> for the binder with the highest affinity for the control, and
+/// only how the command and the control are found differs.
+/// </remarks>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class RuntimeCommandBindingFallback
+{
+    /// <summary>Keeps the command an observed property holds bound to the control another one holds.</summary>
+    /// <typeparam name="TView">The type declaring the control property.</typeparam>
+    /// <typeparam name="TViewModel">The type declaring the command property.</typeparam>
+    /// <typeparam name="TProp">The type of the command property.</typeparam>
+    /// <typeparam name="TControl">The type of the control the command is bound to.</typeparam>
+    /// <param name="view">The object declaring the control property.</param>
+    /// <param name="viewModel">The object declaring the command property.</param>
+    /// <param name="commandProperty">The property holding the command to bind.</param>
+    /// <param name="controlProperty">The property holding the control to bind it to.</param>
+    /// <param name="commandParameter">The values offered as the command parameter.</param>
+    /// <param name="toEvent">The control event that executes the command, or null for the control's default.</param>
+    /// <param name="bindingExpression">The bound expression, named when the observation faults.</param>
+    /// <returns>A disposable that, when disposed, unbinds the command and stops observing.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="commandProperty"/> or <paramref name="controlProperty"/> is null.</exception>
+    /// <remarks>
+    /// Both sides are followed, so replacing either the command or the control rebinds and drops the binding it
+    /// held before. A null view model holds no command property to observe, so nothing is bound rather than the
+    /// call faulting - which is the ordinary state before a view model is assigned.
+    /// </remarks>
+    [RequiresUnreferencedCode("Runtime command binding resolves the property chain by reflection.")]
+    public static IDisposable BindCommand<
+        TView,
+        TViewModel,
+        TProp,
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicProperties
+            | DynamicallyAccessedMemberTypes.PublicEvents
+            | DynamicallyAccessedMemberTypes.NonPublicEvents)]
+        TControl>(
+        TView view,
+        TViewModel? viewModel,
+        Expression<Func<TViewModel, TProp?>> commandProperty,
+        Expression<Func<TView, TControl>> controlProperty,
+        IObservable<object?> commandParameter,
+        string? toEvent,
+        string bindingExpression)
+        where TView : class
+        where TViewModel : class
+        where TProp : ICommand
+        where TControl : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(commandProperty);
+        ArgumentExceptionHelper.ThrowIfNull(controlProperty);
+
+        if (viewModel is null)
+        {
+            return EmptyDisposable.Instance;
+        }
+
+        var binding = new MutableDisposable();
+        var commands = RuntimeObservationFallback.WhenAnyValue(viewModel, commandProperty);
+        var controls = RuntimeObservationFallback.WhenAnyValue(view, controlProperty);
+
+        var observation = BindingErrors.Subscribe(
+            LinqExtensions.CombineLatest(commands, controls, static (command, control) => (command, control)),
+            pair => binding.Disposable = Bind(pair.command, pair.control, commandParameter, toEvent),
+            bindingExpression);
+
+        return new MultipleDisposable(observation, binding);
+    }
+
+    /// <summary>Hands one command and one control to the binder with the highest affinity for that control.</summary>
+    /// <typeparam name="TProp">The type of the command.</typeparam>
+    /// <typeparam name="TControl">The type of the control.</typeparam>
+    /// <param name="command">The command to execute, or null while the property holds none.</param>
+    /// <param name="control">The control that executes it, or null while the property holds none.</param>
+    /// <param name="commandParameter">The values offered as the command parameter.</param>
+    /// <param name="toEvent">The control event that executes the command, or null for the control's default.</param>
+    /// <returns>The binding, or an empty disposable when there is nothing to bind.</returns>
+    [RequiresUnreferencedCode("Runtime command binding resolves the control's event by reflection.")]
+    private static IDisposable Bind<
+        TProp,
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicProperties
+            | DynamicallyAccessedMemberTypes.PublicEvents
+            | DynamicallyAccessedMemberTypes.NonPublicEvents)]
+        TControl>(
+        TProp? command,
+        TControl? control,
+        IObservable<object?> commandParameter,
+        string? toEvent)
+        where TProp : ICommand
+        where TControl : class
+    {
+        if (command is null || control is null)
+        {
+            return EmptyDisposable.Instance;
+        }
+
+        var binder = CommandBinding.CommandBinderService.GetBinder<TControl>(toEvent is not null);
+
+        var bound = toEvent is null
+            ? binder?.BindCommandToObject(command, control, commandParameter)
+            : binder?.BindCommandToObject<TControl, EventArgs>(command, control, commandParameter, toEvent);
+
+        return bound ?? EmptyDisposable.Instance;
+    }
+}

--- a/src/ReactiveUI.Binding.Shared/Fallback/RuntimeInteractionFallback.cs
+++ b/src/ReactiveUI.Binding.Shared/Fallback/RuntimeInteractionFallback.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive.Fallback;
+#else
+namespace ReactiveUI.Binding.Fallback;
+#endif
+
+/// <summary>Registers an interaction handler against a property the runtime expression engine resolves.</summary>
+/// <remarks>
+/// Reached where the generator could not serve the call site - a view model it cannot name, or a selector that is
+/// not an inline lambda. How the handler runs is the generated path's: both hand it to the interaction itself,
+/// and only how the interaction is found differs.
+/// </remarks>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class RuntimeInteractionFallback
+{
+    /// <summary>Keeps a handler registered against whichever interaction the observed property holds.</summary>
+    /// <typeparam name="TViewModel">The type declaring the interaction property.</typeparam>
+    /// <typeparam name="TInput">The type the interaction takes.</typeparam>
+    /// <typeparam name="TOutput">The type the interaction produces.</typeparam>
+    /// <param name="viewModel">The object declaring the interaction property.</param>
+    /// <param name="interactionProperty">The property holding the interaction to handle.</param>
+    /// <param name="register">Registers the caller's handler against one interaction.</param>
+    /// <param name="bindingExpression">The bound expression, named when the observation faults.</param>
+    /// <returns>A disposable that, when disposed, unregisters the handler and stops observing.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="interactionProperty"/> or <paramref name="register"/> is null.</exception>
+    /// <remarks>
+    /// The registration follows the property: replacing the interaction unregisters the handler from the one it
+    /// held before, so a view model that swaps an interaction does not leave a handler on the old one. A null view
+    /// model holds no property to observe, so nothing is registered rather than the call faulting.
+    /// </remarks>
+    [RequiresUnreferencedCode("Runtime interaction fallback resolves the property chain by reflection.")]
+    public static IDisposable BindInteraction<TViewModel, TInput, TOutput>(
+        TViewModel? viewModel,
+        Expression<Func<TViewModel, IInteraction<TInput, TOutput>>> interactionProperty,
+        Func<IInteraction<TInput, TOutput>, IDisposable> register,
+        string bindingExpression)
+        where TViewModel : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(interactionProperty);
+        ArgumentExceptionHelper.ThrowIfNull(register);
+
+        if (viewModel is null)
+        {
+            return EmptyDisposable.Instance;
+        }
+
+        var registration = new MutableDisposable();
+        var observation = BindingErrors.Subscribe(
+            RuntimeObservationFallback.WhenAnyValue(viewModel, interactionProperty),
+            interaction => registration.Disposable = interaction is null
+                ? EmptyDisposable.Instance
+                : register(interaction),
+            bindingExpression);
+
+        return new MultipleDisposable(observation, registration);
+    }
+}

--- a/src/ReactiveUI.Binding.Shared/Interfaces/IViewLocator.cs
+++ b/src/ReactiveUI.Binding.Shared/Interfaces/IViewLocator.cs
@@ -30,5 +30,6 @@ public interface IViewLocator : IEnableLogger
     /// <param name="viewModel">The view model instance to resolve a view for.</param>
     /// <param name="contract">An optional contract string for named registrations.</param>
     /// <returns>The resolved view, or <see langword="null"/> if no view is found.</returns>
+    [RequiresDynamicCode("Resolving a view from an object closes IViewFor<> over its runtime type. Use the generic overload, or register the view, to stay ahead-of-time safe.")]
     IViewFor? ResolveView(object? viewModel, string? contract);
 }

--- a/src/ReactiveUI.Binding.Shared/Interfaces/ViewLocatorMixins.cs
+++ b/src/ReactiveUI.Binding.Shared/Interfaces/ViewLocatorMixins.cs
@@ -32,6 +32,7 @@ public static class ViewLocatorMixins
         /// <summary>Resolves a view for the specified view model instance using the default contract.</summary>
         /// <param name="viewModel">The view model instance to resolve a view for.</param>
         /// <returns>The resolved view, or <see langword="null"/> if no view is found.</returns>
+        [RequiresDynamicCode("Resolving a view from an object closes IViewFor<> over its runtime type. Use the generic overload, or register the view, to stay ahead-of-time safe.")]
         public IViewFor? ResolveView(object? viewModel)
         {
             ArgumentExceptionHelper.ThrowIfNull(locator);

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveSchedulerExtensions.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveSchedulerExtensions.Unsafe.cs
@@ -1,0 +1,449 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+
+/// <summary>The opt-in half of the scheduler overloads, which resolves a binding by reflection.</summary>
+/// <remarks>
+/// The unsuffixed members resolve at compile time and throw when no generated dispatch claimed the call site;
+/// these walk the chain by reflection instead, and are annotated so a consumer publishing trimmed or
+/// ahead-of-time sees the requirement at their own call site. They are declared as classic static extension
+/// methods rather than extension-block members, because nothing has to lose extension lookup to a generated
+/// overload here.
+/// </remarks>
+public static partial class ReactiveSchedulerExtensions
+{
+    /// <summary>Creates a one-way binding from a source property to a target property with a specified scheduler.</summary>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TTarget">The type of the target object.</typeparam>
+    /// <typeparam name="TProperty">The type of the property being bound.</typeparam>
+    /// <param name="source">The source the binding is rooted on.</param>
+    /// <param name="target">The target object whose property will be updated.</param>
+    /// <param name="sourceProperty">An expression that selects the source property to observe.</param>
+    /// <param name="targetProperty">An expression that selects the target property to update.</param>
+    /// <param name="scheduler">The scheduler to use for the binding.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode("Runtime binding fallback resolves the property chain by reflection.")]
+    public static IDisposable BindOneWayUnsafe<TSource, TTarget, TProperty>(
+        this TSource source,
+        TTarget target,
+        Expression<Func<TSource, TProperty>> sourceProperty,
+        Expression<Func<TTarget, TProperty>> targetProperty,
+        ISequencer? scheduler)
+        where TSource : class
+        where TTarget : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(sourceProperty.Body);
+
+        return RuntimeBindingFallback.BindOneWay(
+            source,
+            target,
+            sourceProperty,
+            targetProperty,
+            scheduler,
+            bindingExpression);
+    }
+
+    /// <summary>
+    /// Creates a one-way binding from a source property to a target property with a conversion function and a specified scheduler.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TSourceProp">The type of the source property.</typeparam>
+    /// <typeparam name="TTarget">The type of the target object.</typeparam>
+    /// <typeparam name="TTargetProp">The type of the target property.</typeparam>
+    /// <param name="source">The source the binding is rooted on.</param>
+    /// <param name="target">The target object whose property will be updated.</param>
+    /// <param name="sourceProperty">An expression that selects the source property to observe.</param>
+    /// <param name="targetProperty">An expression that selects the target property to update.</param>
+    /// <param name="conversionFunc">A function that converts the source property value to the target property type.</param>
+    /// <param name="scheduler">The scheduler to use for the binding.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode("Runtime binding fallback resolves the property chain by reflection.")]
+    public static IDisposable BindOneWayUnsafe<TSource, TSourceProp, TTarget, TTargetProp>(
+        this TSource source,
+        TTarget target,
+        Expression<Func<TSource, TSourceProp>> sourceProperty,
+        Expression<Func<TTarget, TTargetProp>> targetProperty,
+        Func<TSourceProp, TTargetProp> conversionFunc,
+        ISequencer? scheduler)
+        where TSource : class
+        where TTarget : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(sourceProperty.Body);
+
+        return RuntimeBindingFallback.BindOneWay(
+            source,
+            target,
+            sourceProperty,
+            targetProperty,
+            conversionFunc,
+            scheduler,
+            bindingExpression);
+    }
+
+    /// <summary>Creates a one-way binding from a source property to a target property using an explicit <see cref="IBindingTypeConverter"/>.</summary>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TSourceProp">The type of the source property.</typeparam>
+    /// <typeparam name="TTarget">The type of the target object.</typeparam>
+    /// <typeparam name="TTargetProp">The type of the target property.</typeparam>
+    /// <param name="source">The source the binding is rooted on.</param>
+    /// <param name="target">The target object whose property will be updated.</param>
+    /// <param name="sourceProperty">An expression that selects the source property to observe.</param>
+    /// <param name="targetProperty">An expression that selects the target property to update.</param>
+    /// <param name="converter">The binding type converter to use for converting between source and target types.</param>
+    /// <param name="scheduler">The scheduler to use for the binding.</param>
+    /// <param name="conversionHint">An optional hint passed to the converter (e.g., format string).</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode("Runtime binding fallback resolves the property chain by reflection.")]
+    public static IDisposable BindOneWayUnsafe<TSource, TSourceProp, TTarget, TTargetProp>(
+        this TSource source,
+        TTarget target,
+        Expression<Func<TSource, TSourceProp>> sourceProperty,
+        Expression<Func<TTarget, TTargetProp>> targetProperty,
+        IBindingTypeConverter converter,
+        ISequencer? scheduler,
+        object? conversionHint)
+        where TSource : class
+        where TTarget : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(sourceProperty.Body);
+
+        return RuntimeBindingFallback.BindOneWay(
+            source,
+            target,
+            sourceProperty,
+            targetProperty,
+                value =>
+                {
+                    _ = RuntimeBindingConverter.TryConvert<TSourceProp, TTargetProp>(
+                        value,
+                        conversionHint,
+                        converter,
+                        out var converted);
+                    return converted;
+                },
+            scheduler,
+            bindingExpression);
+    }
+
+    /// <summary>Creates a two-way binding between a source property and a target property with a specified scheduler.</summary>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TTarget">The type of the target object.</typeparam>
+    /// <typeparam name="TProperty">The type of the property being bound.</typeparam>
+    /// <param name="source">The source the binding is rooted on.</param>
+    /// <param name="target">The target object whose property will be updated.</param>
+    /// <param name="sourceProperty">An expression that selects the source property to observe.</param>
+    /// <param name="targetProperty">An expression that selects the target property to update.</param>
+    /// <param name="scheduler">The scheduler to use for the binding.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode("Runtime binding fallback resolves the property chain by reflection.")]
+    public static IDisposable BindTwoWayUnsafe<TSource, TTarget, TProperty>(
+        this TSource source,
+        TTarget target,
+        Expression<Func<TSource, TProperty>> sourceProperty,
+        Expression<Func<TTarget, TProperty>> targetProperty,
+        ISequencer? scheduler)
+        where TSource : class
+        where TTarget : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(sourceProperty.Body);
+
+        return RuntimeBindingFallback.BindTwoWay(
+            source,
+            target,
+            sourceProperty,
+            targetProperty,
+            scheduler,
+            bindingExpression);
+    }
+
+    /// <summary>
+    /// Creates a two-way binding between a source property and a target property with conversion functions and a specified scheduler.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TSourceProp">The type of the source property.</typeparam>
+    /// <typeparam name="TTarget">The type of the target object.</typeparam>
+    /// <typeparam name="TTargetProp">The type of the target property.</typeparam>
+    /// <param name="source">The source the binding is rooted on.</param>
+    /// <param name="target">The target object whose property will be updated.</param>
+    /// <param name="sourceProperty">An expression that selects the source property to observe.</param>
+    /// <param name="targetProperty">An expression that selects the target property to update.</param>
+    /// <param name="sourceToTargetConv">A function that converts the source property value to the target property type.</param>
+    /// <param name="targetToSourceConv">A function that converts the target property value back to the source property type.</param>
+    /// <param name="scheduler">The scheduler to use for the binding.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode("Runtime binding fallback resolves the property chain by reflection.")]
+    public static IDisposable BindTwoWayUnsafe<TSource, TSourceProp, TTarget, TTargetProp>(
+        this TSource source,
+        TTarget target,
+        Expression<Func<TSource, TSourceProp>> sourceProperty,
+        Expression<Func<TTarget, TTargetProp>> targetProperty,
+        Func<TSourceProp, TTargetProp> sourceToTargetConv,
+        Func<TTargetProp, TSourceProp> targetToSourceConv,
+        ISequencer? scheduler)
+        where TSource : class
+        where TTarget : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(sourceProperty.Body);
+
+        return RuntimeBindingFallback.BindTwoWay(
+            source,
+            target,
+            sourceProperty,
+            targetProperty,
+            TwoWayConverters.Create(sourceToTargetConv, targetToSourceConv),
+            scheduler,
+            bindingExpression);
+    }
+
+    /// <summary>Creates a two-way binding between a source property and a target property using explicit <see cref="IBindingTypeConverter"/> instances.</summary>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TSourceProp">The type of the source property.</typeparam>
+    /// <typeparam name="TTarget">The type of the target object.</typeparam>
+    /// <typeparam name="TTargetProp">The type of the target property.</typeparam>
+    /// <param name="source">The source the binding is rooted on.</param>
+    /// <param name="target">The target object whose property will be updated.</param>
+    /// <param name="sourceProperty">An expression that selects the source property to observe.</param>
+    /// <param name="targetProperty">An expression that selects the target property to update.</param>
+    /// <param name="sourceToTargetConverter">The converter for source-to-target conversion.</param>
+    /// <param name="targetToSourceConverter">The converter for target-to-source conversion.</param>
+    /// <param name="scheduler">The scheduler to use for the binding.</param>
+    /// <param name="conversionHint">An optional hint passed to the converters (e.g., format string).</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode("Runtime binding fallback resolves the property chain by reflection.")]
+    public static IDisposable BindTwoWayUnsafe<TSource, TSourceProp, TTarget, TTargetProp>(
+        this TSource source,
+        TTarget target,
+        Expression<Func<TSource, TSourceProp>> sourceProperty,
+        Expression<Func<TTarget, TTargetProp>> targetProperty,
+        IBindingTypeConverter sourceToTargetConverter,
+        IBindingTypeConverter targetToSourceConverter,
+        ISequencer? scheduler,
+        object? conversionHint)
+        where TSource : class
+        where TTarget : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(sourceProperty.Body);
+
+        return RuntimeBindingFallback.BindTwoWay(
+            source,
+            target,
+            sourceProperty,
+            targetProperty,
+            TwoWayConverters.Create<TSourceProp, TTargetProp>(
+                value =>
+                {
+                    _ = RuntimeBindingConverter.TryConvert<TSourceProp, TTargetProp>(
+                        value,
+                        conversionHint,
+                        sourceToTargetConverter,
+                        out var converted);
+                    return converted;
+                },
+                value =>
+                {
+                    _ = RuntimeBindingConverter.TryConvert<TTargetProp, TSourceProp>(
+                        value,
+                        conversionHint,
+                        targetToSourceConverter,
+                        out var converted);
+                    return converted;
+                }),
+            scheduler,
+            bindingExpression);
+    }
+
+    /// <summary>Creates a one-way binding from a view model property to a view property with a specified selector and scheduler.</summary>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+    /// <typeparam name="TProp">The type of the view model property.</typeparam>
+    /// <typeparam name="TOut">The type of the view property.</typeparam>
+    /// <param name="view">The view the binding is rooted on.</param>
+    /// <param name="viewModel">The view model to observe.</param>
+    /// <param name="viewModelProperty">An expression that selects the view model property to observe.</param>
+    /// <param name="viewProperty">An expression that selects the view property to update.</param>
+    /// <param name="selector">A function that converts the view model property value to the view property type.</param>
+    /// <param name="scheduler">The scheduler to use for the binding.</param>
+    /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode("Runtime binding fallback resolves the property chain by reflection.")]
+    public static IReactiveBinding<TView, TOut> OneWayBindUnsafe<TView, TViewModel, TProp, TOut>(
+        this TView view,
+        TViewModel viewModel,
+        Expression<Func<TViewModel, TProp>> viewModelProperty,
+        Expression<Func<TView, TOut>> viewProperty,
+        Func<TProp, TOut> selector,
+        ISequencer? scheduler)
+        where TView : class, IViewFor
+        where TViewModel : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(viewModelProperty.Body);
+
+        return RuntimeBindingFallback.OneWayBind(
+            view,
+            viewModel,
+            viewModelProperty,
+            viewProperty,
+            selector,
+            scheduler,
+            bindingExpression);
+    }
+
+    /// <summary>Creates a one-way binding from a view model property to a view property using an explicit <see cref="IBindingTypeConverter"/>.</summary>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+    /// <typeparam name="TVMProp">The type of the view model property.</typeparam>
+    /// <typeparam name="TVProp">The type of the view property.</typeparam>
+    /// <param name="view">The view the binding is rooted on.</param>
+    /// <param name="viewModel">The view model to observe.</param>
+    /// <param name="viewModelProperty">An expression that selects the view model property to observe.</param>
+    /// <param name="viewProperty">An expression that selects the view property to update.</param>
+    /// <param name="converter">The binding type converter to use for converting between source and target types.</param>
+    /// <param name="scheduler">The scheduler to use for the binding.</param>
+    /// <param name="conversionHint">An optional hint passed to the converter (e.g., format string).</param>
+    /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode("Runtime binding fallback resolves the property chain by reflection.")]
+    public static IReactiveBinding<TView, TVProp> OneWayBindUnsafe<TView, TViewModel, TVMProp, TVProp>(
+        this TView view,
+        TViewModel viewModel,
+        Expression<Func<TViewModel, TVMProp>> viewModelProperty,
+        Expression<Func<TView, TVProp>> viewProperty,
+        IBindingTypeConverter converter,
+        ISequencer? scheduler,
+        object? conversionHint)
+        where TView : class, IViewFor
+        where TViewModel : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(viewModelProperty.Body);
+
+        return RuntimeBindingFallback.OneWayBind(
+            view,
+            viewModel,
+            viewModelProperty,
+            viewProperty,
+                value =>
+                {
+                    _ = RuntimeBindingConverter.TryConvert<TVMProp, TVProp>(
+                        value,
+                        conversionHint,
+                        converter,
+                        out var converted);
+                    return converted;
+                },
+            scheduler,
+            bindingExpression);
+    }
+
+    /// <summary>
+    /// Creates a two-way binding between a view model property and a view property with conversion functions and a specified scheduler.
+    /// </summary>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+    /// <typeparam name="TVMProp">The type of the view model property.</typeparam>
+    /// <typeparam name="TVProp">The type of the view property.</typeparam>
+    /// <param name="view">The view the binding is rooted on.</param>
+    /// <param name="viewModel">The view model to observe.</param>
+    /// <param name="viewModelProperty">An expression that selects the view model property to observe.</param>
+    /// <param name="viewProperty">An expression that selects the view property to update.</param>
+    /// <param name="viewModelToViewConverter">A function that converts the view model property value to the view property type.</param>
+    /// <param name="viewToViewModelConverter">A function that converts the view property value back to the view model property type.</param>
+    /// <param name="scheduler">The scheduler to use for the binding.</param>
+    /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode("Runtime binding fallback resolves the property chain by reflection.")]
+    public static IReactiveBinding<TView, BindingChange> BindUnsafe<TView, TViewModel, TVMProp, TVProp>(
+        this TView view,
+        TViewModel viewModel,
+        Expression<Func<TViewModel, TVMProp>> viewModelProperty,
+        Expression<Func<TView, TVProp>> viewProperty,
+        Func<TVMProp, TVProp> viewModelToViewConverter,
+        Func<TVProp, TVMProp> viewToViewModelConverter,
+        ISequencer? scheduler)
+        where TView : class, IViewFor
+        where TViewModel : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(viewModelProperty.Body);
+
+        return RuntimeBindingFallback.Bind(
+            view,
+            viewModel,
+            viewModelProperty,
+            viewProperty,
+            TwoWayConverters.Create(viewModelToViewConverter, viewToViewModelConverter),
+            scheduler,
+            bindingExpression);
+    }
+
+    /// <summary>Creates a two-way binding between a view model property and a view property using explicit <see cref="IBindingTypeConverter"/> instances.</summary>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+    /// <typeparam name="TVMProp">The type of the view model property.</typeparam>
+    /// <typeparam name="TVProp">The type of the view property.</typeparam>
+    /// <param name="view">The view the binding is rooted on.</param>
+    /// <param name="viewModel">The view model to observe.</param>
+    /// <param name="viewModelProperty">An expression that selects the view model property to observe.</param>
+    /// <param name="viewProperty">An expression that selects the view property to update.</param>
+    /// <param name="viewModelToViewConverter">The converter for view model-to-view conversion.</param>
+    /// <param name="viewToViewModelConverter">The converter for view-to-view model conversion.</param>
+    /// <param name="scheduler">The scheduler to use for the binding.</param>
+    /// <param name="conversionHint">An optional hint passed to the converters (e.g., format string).</param>
+    /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode("Runtime binding fallback resolves the property chain by reflection.")]
+    public static IReactiveBinding<TView, BindingChange> BindUnsafe<TView, TViewModel, TVMProp, TVProp>(
+        this TView view,
+        TViewModel viewModel,
+        Expression<Func<TViewModel, TVMProp>> viewModelProperty,
+        Expression<Func<TView, TVProp>> viewProperty,
+        IBindingTypeConverter viewModelToViewConverter,
+        IBindingTypeConverter viewToViewModelConverter,
+        ISequencer? scheduler,
+        object? conversionHint)
+        where TView : class, IViewFor
+        where TViewModel : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(viewModelProperty.Body);
+
+        return RuntimeBindingFallback.Bind(
+            view,
+            viewModel,
+            viewModelProperty,
+            viewProperty,
+            TwoWayConverters.Create<TVMProp, TVProp>(
+                value =>
+                {
+                    _ = RuntimeBindingConverter.TryConvert<TVMProp, TVProp>(
+                        value,
+                        conversionHint,
+                        viewModelToViewConverter,
+                        out var converted);
+                    return converted;
+                },
+                value =>
+                {
+                    _ = RuntimeBindingConverter.TryConvert<TVProp, TVMProp>(
+                        value,
+                        conversionHint,
+                        viewToViewModelConverter,
+                        out var converted);
+                    return converted;
+                }),
+            scheduler,
+            bindingExpression);
+    }
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveSchedulerExtensions.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveSchedulerExtensions.cs
@@ -13,8 +13,7 @@ namespace ReactiveUI.Binding;
 /// The scheduler type follows the package: ReactiveUI.Binding takes an ISequencer,
 /// ReactiveUI.Binding.Reactive takes a System.Reactive IScheduler.
 /// </summary>
-[ExcludeFromCodeCoverage]
-public static class ReactiveSchedulerExtensions
+public static partial class ReactiveSchedulerExtensions
 {
     /// <summary>
     /// The message displayed when no generated binding is found during certain binding operations.
@@ -23,7 +22,7 @@ public static class ReactiveSchedulerExtensions
     /// avoid this error, ensure that the binding expression is an inline lambda.
     /// </summary>
     private const string NoGeneratedBindingMessage =
-        "No generated binding found. Ensure the expression is an inline lambda for compile-time optimization.";
+        "No generated binding dispatch matched this call site. Use the matching Unsafe overload to resolve the expression at run time.";
 
     /// <summary>Provides BindOneWay extension members for <paramref name="source"/>.</summary>
     /// <typeparam name="TSource">The type of the source object.</typeparam>
@@ -170,8 +169,10 @@ public static class ReactiveSchedulerExtensions
             ISequencer? scheduler = null,
             [CallerFilePath] string callerFilePath = "",
             [CallerLineNumber] int callerLineNumber = 0)
-            where TTarget : class =>
+            where TTarget : class
+        {
             throw new InvalidOperationException(NoGeneratedBindingMessage);
+        }
 
 #if NET8_0_OR_GREATER
         /// <summary>Creates a two-way binding between a source property and a target property with a specified scheduler.</summary>
@@ -318,8 +319,10 @@ public static class ReactiveSchedulerExtensions
             ISequencer? scheduler = null,
             [CallerFilePath] string callerFilePath = "",
             [CallerLineNumber] int callerLineNumber = 0)
-            where TTarget : class =>
+            where TTarget : class
+        {
             throw new InvalidOperationException(NoGeneratedBindingMessage);
+        }
 
     }
 
@@ -413,8 +416,10 @@ public static class ReactiveSchedulerExtensions
             ISequencer? scheduler = null,
             [CallerFilePath] string callerFilePath = "",
             [CallerLineNumber] int callerLineNumber = 0)
-            where TViewModel : class =>
+            where TViewModel : class
+        {
             throw new InvalidOperationException(NoGeneratedBindingMessage);
+        }
 
 #if NET8_0_OR_GREATER
         /// <summary>
@@ -510,7 +515,9 @@ public static class ReactiveSchedulerExtensions
             ISequencer? scheduler = null,
             [CallerFilePath] string callerFilePath = "",
             [CallerLineNumber] int callerLineNumber = 0)
-            where TViewModel : class =>
+            where TViewModel : class
+        {
             throw new InvalidOperationException(NoGeneratedBindingMessage);
+        }
     }
 }

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.BindCommand.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.BindCommand.Unsafe.cs
@@ -1,0 +1,149 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+
+/// <summary>Resolves a BindCommand expression by reflection, for a call site the generator could not read.</summary>
+/// <remarks>
+/// The opt-in half of <c>BindCommand</c>. The unsuffixed overloads resolve at compile time and throw when no generated
+/// dispatch claimed the call site; these walk the chain by reflection instead, and are annotated so a consumer
+/// publishing trimmed or ahead-of-time sees the requirement at their own call site.
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>Binds a command from a view model to a control on a view.</summary>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+    /// <typeparam name="TProp">The type of the command property.</typeparam>
+    /// <typeparam name="TControl">The type of the control.</typeparam>
+    /// <param name="view">The view to bind to.</param>
+    /// <param name="viewModel">The view model containing the command.</param>
+    /// <param name="propertyName">An expression that selects the command property on the view model.</param>
+    /// <param name="controlName">An expression that selects the control on the view.</param>
+    /// <param name="toEvent">The event name to bind to. If null, a default event is selected.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST2309", Justification = "the CallerInfo and toEvent defaults must stay optional; overloads would shadow the generated overloads")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IDisposable BindCommandUnsafe<TView, TViewModel, TProp, TControl>(
+        this TView view,
+        TViewModel? viewModel,
+        Expression<Func<TViewModel, TProp?>> propertyName,
+        Expression<Func<TView, TControl>> controlName,
+        string? toEvent)
+        where TView : class, IViewFor
+        where TViewModel : class
+        where TProp : ICommand
+        where TControl : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(propertyName.Body);
+
+        return RuntimeCommandBindingFallback.BindCommand(
+            view,
+            viewModel,
+            propertyName,
+            controlName,
+            Signal.Return<object?>(null),
+            toEvent,
+            bindingExpression);
+    }
+
+    /// <summary>Binds a command from a view model to a control on a view with an observable parameter.</summary>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+    /// <typeparam name="TProp">The type of the command property.</typeparam>
+    /// <typeparam name="TControl">The type of the control.</typeparam>
+    /// <typeparam name="TParam">The type of the command parameter.</typeparam>
+    /// <param name="view">The view to bind to.</param>
+    /// <param name="viewModel">The view model containing the command.</param>
+    /// <param name="propertyName">An expression that selects the command property on the view model.</param>
+    /// <param name="controlName">An expression that selects the control on the view.</param>
+    /// <param name="withParameter">An observable that provides the command parameter.</param>
+    /// <param name="toEvent">The event name to bind to. If null, a default event is selected.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST2309", Justification = "the CallerInfo and toEvent defaults must stay optional; overloads would shadow the generated overloads")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IDisposable BindCommandUnsafe<TView, TViewModel, TProp, TControl, TParam>(
+        this TView view,
+        TViewModel? viewModel,
+        Expression<Func<TViewModel, TProp?>> propertyName,
+        Expression<Func<TView, TControl>> controlName,
+        IObservable<TParam?> withParameter,
+        string? toEvent)
+        where TView : class, IViewFor
+        where TViewModel : class
+        where TProp : ICommand
+        where TControl : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(propertyName.Body);
+
+        return RuntimeCommandBindingFallback.BindCommand(
+            view,
+            viewModel,
+            propertyName,
+            controlName,
+            LinqExtensions.Map(withParameter, static value => (object?)value),
+            toEvent,
+            bindingExpression);
+    }
+
+    /// <summary>Binds a command from a view model to a control on a view with a parameter expression.</summary>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+    /// <typeparam name="TProp">The type of the command property.</typeparam>
+    /// <typeparam name="TControl">The type of the control.</typeparam>
+    /// <typeparam name="TParam">The type of the command parameter.</typeparam>
+    /// <param name="view">The view to bind to.</param>
+    /// <param name="viewModel">The view model containing the command.</param>
+    /// <param name="propertyName">An expression that selects the command property on the view model.</param>
+    /// <param name="controlName">An expression that selects the control on the view.</param>
+    /// <param name="withParameter">An expression that selects the command parameter property on the view model.</param>
+    /// <param name="toEvent">The event name to bind to. If null, a default event is selected.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST2309", Justification = "the CallerInfo and toEvent defaults must stay optional; overloads would shadow the generated overloads")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IDisposable BindCommandUnsafe<TView, TViewModel, TProp, TControl, TParam>(
+        this TView view,
+        TViewModel? viewModel,
+        Expression<Func<TViewModel, TProp?>> propertyName,
+        Expression<Func<TView, TControl>> controlName,
+        Expression<Func<TViewModel, TParam?>> withParameter,
+        string? toEvent)
+        where TView : class, IViewFor
+        where TViewModel : class
+        where TProp : ICommand
+        where TControl : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(propertyName.Body);
+
+        // The parameter property lives on the same view model, so it is only observable once there is one.
+        var parameters = viewModel is null
+            ? Signal.Never<object?>()
+            : LinqExtensions.Map(
+                RuntimeObservationFallback.WhenAnyValue(viewModel, withParameter),
+                static value => (object?)value);
+
+        return RuntimeCommandBindingFallback.BindCommand(
+            view,
+            viewModel,
+            propertyName,
+            controlName,
+            parameters,
+            toEvent,
+            bindingExpression);
+    }
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.BindCommand.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.BindCommand.cs
@@ -14,6 +14,10 @@ namespace ReactiveUI.Binding;
 /// <summary>Extension methods for binding commands from a view model to controls on a view.</summary>
 public static partial class ReactiveUIBindingExtensions
 {
+    /// <summary>Reported when no generated dispatch claimed a BindCommand call site.</summary>
+    private const string NoBindCommandDispatchMessage =
+        "No generated BindCommand dispatch matched this call site. Use BindCommandUnsafe to resolve the expression at run time.";
+
 #if NET8_0_OR_GREATER
     /// <summary>Binds a command from a view model to a control on a view.</summary>
     /// <typeparam name="TView">The type of the view.</typeparam>
@@ -30,7 +34,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindCommand dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindCommand dispatch matched this call site. Use BindCommandUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST2309", Justification = "the CallerInfo and toEvent defaults must stay optional; overloads would shadow the generated overloads")]
     public static IDisposable BindCommand<TView, TViewModel, TProp, TControl>(
@@ -61,7 +65,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindCommand dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindCommand dispatch matched this call site. Use BindCommandUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST2309", Justification = "the CallerInfo defaults must stay optional; overloads would shadow the generated overloads")]
     [SuppressMessage("Design", "SST2309", Justification = "the CallerInfo and toEvent defaults must stay optional; overloads would shadow the generated overloads")]
     public static IDisposable BindCommand<TView, TViewModel, TProp, TControl>(
@@ -78,7 +82,7 @@ public static partial class ReactiveUIBindingExtensions
         where TControl : class
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindCommandDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -99,7 +103,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindCommand dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindCommand dispatch matched this call site. Use BindCommandUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST2309", Justification = "the CallerInfo and toEvent defaults must stay optional; overloads would shadow the generated overloads")]
     public static IDisposable BindCommand<TView, TViewModel, TProp, TControl, TParam>(
@@ -133,7 +137,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindCommand dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindCommand dispatch matched this call site. Use BindCommandUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST2309", Justification = "the CallerInfo defaults must stay optional; overloads would shadow the generated overloads")]
     [SuppressMessage("Design", "SST2309", Justification = "the CallerInfo and toEvent defaults must stay optional; overloads would shadow the generated overloads")]
@@ -152,7 +156,7 @@ public static partial class ReactiveUIBindingExtensions
         where TControl : class
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindCommandDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -174,7 +178,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindCommand dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindCommand dispatch matched this call site. Use BindCommandUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST2309", Justification = "the CallerInfo and toEvent defaults must stay optional; overloads would shadow the generated overloads")]
     public static IDisposable BindCommand<TView, TViewModel, TProp, TControl, TParam>(
@@ -209,7 +213,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindCommand dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindCommand dispatch matched this call site. Use BindCommandUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST2309", Justification = "the CallerInfo defaults must stay optional; overloads would shadow the generated overloads")]
     [SuppressMessage("Design", "SST2309", Justification = "the CallerInfo and toEvent defaults must stay optional; overloads would shadow the generated overloads")]
@@ -228,6 +232,6 @@ public static partial class ReactiveUIBindingExtensions
         where TControl : class
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindCommandDispatchMessage);
     }
 }

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.BindInteraction.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.BindInteraction.Unsafe.cs
@@ -1,0 +1,80 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+
+/// <summary>Resolves a BindInteraction expression by reflection, for a call site the generator could not read.</summary>
+/// <remarks>
+/// The opt-in half of <c>BindInteraction</c>. The unsuffixed overloads resolve at compile time and throw when no generated
+/// dispatch claimed the call site; these walk the chain by reflection instead, and are annotated so a consumer
+/// publishing trimmed or ahead-of-time sees the requirement at their own call site.
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>Binds a task-based handler to an interaction exposed by the view model.</summary>
+    /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TInput">The type of the interaction's input.</typeparam>
+    /// <typeparam name="TOutput">The type of the interaction's output.</typeparam>
+    /// <param name="view">The view that provides the handler.</param>
+    /// <param name="viewModel">The view model that exposes the interaction.</param>
+    /// <param name="propertyName">An expression that selects the interaction property on the view model.</param>
+    /// <param name="handler">A task-based handler for the interaction.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IDisposable BindInteractionUnsafe<TViewModel, TView, TInput, TOutput>(
+        this TView view,
+        TViewModel? viewModel,
+        Expression<Func<TViewModel, IInteraction<TInput, TOutput>>> propertyName,
+        Func<IInteractionContext<TInput, TOutput>, Task> handler)
+        where TViewModel : class
+        where TView : class, IViewFor
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(propertyName.Body);
+
+        return RuntimeInteractionFallback.BindInteraction(
+            viewModel,
+            propertyName,
+            interaction => interaction.RegisterHandler(handler),
+            bindingExpression);
+    }
+
+    /// <summary>Binds an observable-based handler to an interaction exposed by the view model.</summary>
+    /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TInput">The type of the interaction's input.</typeparam>
+    /// <typeparam name="TOutput">The type of the interaction's output.</typeparam>
+    /// <typeparam name="TDontCare">The signal type of the observable handler.</typeparam>
+    /// <param name="view">The view that provides the handler.</param>
+    /// <param name="viewModel">The view model that exposes the interaction.</param>
+    /// <param name="propertyName">An expression that selects the interaction property on the view model.</param>
+    /// <param name="handler">An observable-based handler for the interaction.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IDisposable BindInteractionUnsafe<TViewModel, TView, TInput, TOutput, TDontCare>(
+        this TView view,
+        TViewModel? viewModel,
+        Expression<Func<TViewModel, IInteraction<TInput, TOutput>>> propertyName,
+        Func<IInteractionContext<TInput, TOutput>, IObservable<TDontCare>> handler)
+        where TViewModel : class
+        where TView : class, IViewFor
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(propertyName.Body);
+
+        return RuntimeInteractionFallback.BindInteraction(
+            viewModel,
+            propertyName,
+            interaction => interaction.RegisterHandler(handler),
+            bindingExpression);
+    }
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.BindInteraction.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.BindInteraction.cs
@@ -11,6 +11,10 @@ namespace ReactiveUI.Binding;
 /// <summary>Extension methods for binding interactions between a view and a view model.</summary>
 public static partial class ReactiveUIBindingExtensions
 {
+    /// <summary>Reported when no generated dispatch claimed a BindInteraction call site.</summary>
+    private const string NoBindInteractionDispatchMessage =
+        "No generated BindInteraction dispatch matched this call site. Use BindInteractionUnsafe to resolve the expression at run time.";
+
 #if NET8_0_OR_GREATER
     /// <summary>Binds a task-based handler to an interaction exposed by the view model.</summary>
     /// <typeparam name="TViewModel">The type of the view model.</typeparam>
@@ -25,7 +29,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindInteraction dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindInteraction dispatch matched this call site. Use BindInteractionUnsafe to resolve the expression at run time.</exception>
     public static IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(
         this TView view,
         TViewModel? viewModel,
@@ -50,7 +54,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindInteraction dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindInteraction dispatch matched this call site. Use BindInteractionUnsafe to resolve the expression at run time.</exception>
     public static IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(
         this TView view,
         TViewModel? viewModel,
@@ -62,7 +66,7 @@ public static partial class ReactiveUIBindingExtensions
         where TView : class, IViewFor
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindInteractionDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -80,7 +84,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindInteraction dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindInteraction dispatch matched this call site. Use BindInteractionUnsafe to resolve the expression at run time.</exception>
     public static IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(
         this TView view,
         TViewModel? viewModel,
@@ -106,7 +110,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindInteraction dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindInteraction dispatch matched this call site. Use BindInteractionUnsafe to resolve the expression at run time.</exception>
     public static IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(
         this TView view,
         TViewModel? viewModel,
@@ -118,6 +122,6 @@ public static partial class ReactiveUIBindingExtensions
         where TView : class, IViewFor
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindInteractionDispatchMessage);
     }
 }

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.BindTo.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.BindTo.Unsafe.cs
@@ -1,0 +1,151 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+
+/// <summary>Resolves a BindTo expression by reflection, for a call site the generator could not read.</summary>
+/// <remarks>
+/// The opt-in half of <c>BindTo</c>. The unsuffixed overloads resolve at compile time and throw when no generated
+/// dispatch claimed the call site; these walk the chain by reflection instead, and are annotated so a consumer
+/// publishing trimmed or ahead-of-time sees the requirement at their own call site.
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>Applies an observable stream to a target property. Conceptually similar to <c>source.Subscribe(x =&gt; target.property = x)</c>.</summary>
+    /// <typeparam name="TValue">The type of the value produced by the source observable.</typeparam>
+    /// <typeparam name="TTarget">The type of the target object.</typeparam>
+    /// <typeparam name="TTargetValue">The type of the property on the target object.</typeparam>
+    /// <param name="source">The observable stream to bind to a target property.</param>
+    /// <param name="target">The target object whose property will be set.</param>
+    /// <param name="property">An expression that selects the target property to set.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IDisposable BindToUnsafe<TValue, TTarget, TTargetValue>(
+        this IObservable<TValue> source,
+        TTarget? target,
+        Expression<Func<TTarget, TTargetValue?>> property)
+        where TTarget : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(property.Body);
+
+        return RuntimeBindingFallback.BindTo(
+            source,
+            target,
+            property,
+            null,
+            null,
+            null,
+            bindingExpression);
+    }
+
+    /// <summary>
+    /// Applies an observable stream to a target property, using the supplied conversion hint when a
+    /// converter is required to coerce the source value to the target property type.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value produced by the source observable.</typeparam>
+    /// <typeparam name="TTarget">The type of the target object.</typeparam>
+    /// <typeparam name="TTargetValue">The type of the property on the target object.</typeparam>
+    /// <param name="source">The observable stream to bind to a target property.</param>
+    /// <param name="target">The target object whose property will be set.</param>
+    /// <param name="property">An expression that selects the target property to set.</param>
+    /// <param name="conversionHint">An object that provides a hint to the converter. The semantics are defined by the converter.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IDisposable BindToUnsafe<TValue, TTarget, TTargetValue>(
+        this IObservable<TValue> source,
+        TTarget? target,
+        Expression<Func<TTarget, TTargetValue?>> property,
+        object? conversionHint)
+        where TTarget : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(property.Body);
+
+        return RuntimeBindingFallback.BindTo(
+            source,
+            target,
+            property,
+            conversionHint,
+            null,
+            null,
+            bindingExpression);
+    }
+
+    /// <summary>
+    /// Applies an observable stream to a target property, using the supplied converter to coerce the
+    /// source value to the target property type.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value produced by the source observable.</typeparam>
+    /// <typeparam name="TTarget">The type of the target object.</typeparam>
+    /// <typeparam name="TTargetValue">The type of the property on the target object.</typeparam>
+    /// <param name="source">The observable stream to bind to a target property.</param>
+    /// <param name="target">The target object whose property will be set.</param>
+    /// <param name="property">An expression that selects the target property to set.</param>
+    /// <param name="converterOverride">An explicit converter to use when converting the source value to the target property type.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IDisposable BindToUnsafe<TValue, TTarget, TTargetValue>(
+        this IObservable<TValue> source,
+        TTarget? target,
+        Expression<Func<TTarget, TTargetValue?>> property,
+        IBindingTypeConverter? converterOverride)
+        where TTarget : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(property.Body);
+
+        return RuntimeBindingFallback.BindTo(
+            source,
+            target,
+            property,
+            null,
+            converterOverride,
+            null,
+            bindingExpression);
+    }
+
+    /// <summary>
+    /// Applies an observable stream to a target property, using the supplied converter and conversion
+    /// hint to coerce the source value to the target property type.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value produced by the source observable.</typeparam>
+    /// <typeparam name="TTarget">The type of the target object.</typeparam>
+    /// <typeparam name="TTargetValue">The type of the property on the target object.</typeparam>
+    /// <param name="source">The observable stream to bind to a target property.</param>
+    /// <param name="target">The target object whose property will be set.</param>
+    /// <param name="property">An expression that selects the target property to set.</param>
+    /// <param name="conversionHint">An object that provides a hint to the converter. The semantics are defined by the converter.</param>
+    /// <param name="converterOverride">An explicit converter to use when converting the source value to the target property type.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IDisposable BindToUnsafe<TValue, TTarget, TTargetValue>(
+        this IObservable<TValue> source,
+        TTarget? target,
+        Expression<Func<TTarget, TTargetValue?>> property,
+        object? conversionHint,
+        IBindingTypeConverter? converterOverride)
+        where TTarget : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(property.Body);
+
+        return RuntimeBindingFallback.BindTo(
+            source,
+            target,
+            property,
+            conversionHint,
+            converterOverride,
+            null,
+            bindingExpression);
+    }
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.BindTo.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.BindTo.cs
@@ -15,6 +15,10 @@ namespace ReactiveUI.Binding;
 /// </summary>
 public static partial class ReactiveUIBindingExtensions
 {
+    /// <summary>Reported when no generated dispatch claimed a BindTo call site.</summary>
+    private const string NoBindToDispatchMessage =
+        "No generated BindTo dispatch matched this call site. Use BindToUnsafe to resolve the expression at run time.";
+
 #if NET8_0_OR_GREATER
     /// <summary>Applies an observable stream to a target property. Conceptually similar to <c>source.Subscribe(x =&gt; target.property = x)</c>.</summary>
     /// <typeparam name="TValue">The type of the value produced by the source observable.</typeparam>
@@ -27,7 +31,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site. Use BindToUnsafe to resolve the expression at run time.</exception>
     public static IDisposable BindTo<TValue, TTarget, TTargetValue>(
         this IObservable<TValue> source,
         TTarget? target,
@@ -47,7 +51,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site. Use BindToUnsafe to resolve the expression at run time.</exception>
     public static IDisposable BindTo<TValue, TTarget, TTargetValue>(
         this IObservable<TValue> source,
         TTarget? target,
@@ -57,7 +61,7 @@ public static partial class ReactiveUIBindingExtensions
         where TTarget : class
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindToDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -76,7 +80,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site. Use BindToUnsafe to resolve the expression at run time.</exception>
     public static IDisposable BindTo<TValue, TTarget, TTargetValue>(
         this IObservable<TValue> source,
         TTarget? target,
@@ -101,7 +105,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site. Use BindToUnsafe to resolve the expression at run time.</exception>
     public static IDisposable BindTo<TValue, TTarget, TTargetValue>(
         this IObservable<TValue> source,
         TTarget? target,
@@ -112,7 +116,7 @@ public static partial class ReactiveUIBindingExtensions
         where TTarget : class
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindToDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -131,7 +135,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site. Use BindToUnsafe to resolve the expression at run time.</exception>
     public static IDisposable BindTo<TValue, TTarget, TTargetValue>(
         this IObservable<TValue> source,
         TTarget? target,
@@ -156,7 +160,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site. Use BindToUnsafe to resolve the expression at run time.</exception>
     public static IDisposable BindTo<TValue, TTarget, TTargetValue>(
         this IObservable<TValue> source,
         TTarget? target,
@@ -167,7 +171,7 @@ public static partial class ReactiveUIBindingExtensions
         where TTarget : class
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindToDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -187,7 +191,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site. Use BindToUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IDisposable BindTo<TValue, TTarget, TTargetValue>(
         this IObservable<TValue> source,
@@ -215,7 +219,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindTo dispatch matched this call site. Use BindToUnsafe to resolve the expression at run time.</exception>
     public static IDisposable BindTo<TValue, TTarget, TTargetValue>(
         this IObservable<TValue> source,
         TTarget? target,
@@ -227,6 +231,6 @@ public static partial class ReactiveUIBindingExtensions
         where TTarget : class
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindToDispatchMessage);
     }
 }

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.Binding.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.Binding.Unsafe.cs
@@ -1,0 +1,307 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+
+/// <summary>Resolves a BindOneWay expression by reflection, for a call site the generator could not read.</summary>
+/// <remarks>
+/// The opt-in half of <c>BindOneWay</c>. The unsuffixed overloads resolve at compile time and throw when no generated
+/// dispatch claimed the call site; these walk the chain by reflection instead, and are annotated so a consumer
+/// publishing trimmed or ahead-of-time sees the requirement at their own call site.
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>Creates a one-way binding from a source property to a target property.</summary>
+    /// <typeparam name="TSource">The type of the source object.</typeparam>
+    /// <typeparam name="TTarget">The type of the target object.</typeparam>
+    /// <typeparam name="TProperty">The type of the property being bound.</typeparam>
+    /// <param name="source">The source object to observe for property changes.</param>
+    /// <param name="target">The target object whose property will be updated.</param>
+    /// <param name="sourceProperty">An expression that selects the source property to observe.</param>
+    /// <param name="targetProperty">An expression that selects the target property to update.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IDisposable BindOneWayUnsafe<TSource, TTarget, TProperty>(
+        this TSource source,
+        TTarget target,
+        Expression<Func<TSource, TProperty>> sourceProperty,
+        Expression<Func<TTarget, TProperty>> targetProperty)
+        where TSource : class
+        where TTarget : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(sourceProperty.Body);
+
+        return RuntimeBindingFallback.BindOneWay(
+            source,
+            target,
+            sourceProperty,
+            targetProperty,
+            null,
+            bindingExpression);
+    }
+
+    /// <summary>Creates a one-way binding from a source property to a target property with a conversion function.</summary>
+    /// <typeparam name="TSource">The type of the source object.</typeparam>
+    /// <typeparam name="TSourceProp">The type of the source property.</typeparam>
+    /// <typeparam name="TTarget">The type of the target object.</typeparam>
+    /// <typeparam name="TTargetProp">The type of the target property.</typeparam>
+    /// <param name="source">The source object to observe for property changes.</param>
+    /// <param name="target">The target object whose property will be updated.</param>
+    /// <param name="sourceProperty">An expression that selects the source property to observe.</param>
+    /// <param name="targetProperty">An expression that selects the target property to update.</param>
+    /// <param name="conversionFunc">A function that converts the source property value to the target property type.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IDisposable BindOneWayUnsafe<TSource, TSourceProp, TTarget, TTargetProp>(
+        this TSource source,
+        TTarget target,
+        Expression<Func<TSource, TSourceProp>> sourceProperty,
+        Expression<Func<TTarget, TTargetProp>> targetProperty,
+        Func<TSourceProp, TTargetProp> conversionFunc)
+        where TSource : class
+        where TTarget : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(sourceProperty.Body);
+
+        return RuntimeBindingFallback.BindOneWay(
+            source,
+            target,
+            sourceProperty,
+            targetProperty,
+            conversionFunc,
+            null,
+            bindingExpression);
+    }
+
+    /// <summary>Creates a two-way binding between a source property and a target property.</summary>
+    /// <typeparam name="TSource">The type of the source object.</typeparam>
+    /// <typeparam name="TTarget">The type of the target object.</typeparam>
+    /// <typeparam name="TProperty">The type of the property being bound.</typeparam>
+    /// <param name="source">The source object to observe for property changes.</param>
+    /// <param name="target">The target object whose property will be updated.</param>
+    /// <param name="sourceProperty">An expression that selects the source property to observe.</param>
+    /// <param name="targetProperty">An expression that selects the target property to update.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IDisposable BindTwoWayUnsafe<TSource, TTarget, TProperty>(
+        this TSource source,
+        TTarget target,
+        Expression<Func<TSource, TProperty>> sourceProperty,
+        Expression<Func<TTarget, TProperty>> targetProperty)
+        where TSource : class
+        where TTarget : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(sourceProperty.Body);
+
+        return RuntimeBindingFallback.BindTwoWay(
+            source,
+            target,
+            sourceProperty,
+            targetProperty,
+            null,
+            bindingExpression);
+    }
+
+    /// <summary>Creates a two-way binding between a source property and a target property with conversion functions.</summary>
+    /// <typeparam name="TSource">The type of the source object.</typeparam>
+    /// <typeparam name="TSourceProp">The type of the source property.</typeparam>
+    /// <typeparam name="TTarget">The type of the target object.</typeparam>
+    /// <typeparam name="TTargetProp">The type of the target property.</typeparam>
+    /// <param name="source">The source object to observe for property changes.</param>
+    /// <param name="target">The target object whose property will be updated.</param>
+    /// <param name="sourceProperty">An expression that selects the source property to observe.</param>
+    /// <param name="targetProperty">An expression that selects the target property to update.</param>
+    /// <param name="sourceToTargetConv">A function that converts the source property value to the target property type.</param>
+    /// <param name="targetToSourceConv">A function that converts the target property value back to the source property type.</param>
+    /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IDisposable BindTwoWayUnsafe<TSource, TSourceProp, TTarget, TTargetProp>(
+        this TSource source,
+        TTarget target,
+        Expression<Func<TSource, TSourceProp>> sourceProperty,
+        Expression<Func<TTarget, TTargetProp>> targetProperty,
+        Func<TSourceProp, TTargetProp> sourceToTargetConv,
+        Func<TTargetProp, TSourceProp> targetToSourceConv)
+        where TSource : class
+        where TTarget : class
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(sourceProperty.Body);
+
+        return RuntimeBindingFallback.BindTwoWay(
+            source,
+            target,
+            sourceProperty,
+            targetProperty,
+            TwoWayConverters.Create(sourceToTargetConv, targetToSourceConv),
+            null,
+            bindingExpression);
+    }
+
+    /// <summary>Creates a one-way binding from a view model property to a view property.</summary>
+    /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TVMProp">The type of the view model property.</typeparam>
+    /// <typeparam name="TVProp">The type of the view property.</typeparam>
+    /// <param name="view">The view to bind to.</param>
+    /// <param name="viewModel">The view model to observe.</param>
+    /// <param name="viewModelProperty">An expression that selects the view model property to observe.</param>
+    /// <param name="viewProperty">An expression that selects the view property to update.</param>
+    /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IReactiveBinding<TView, TVProp> OneWayBindUnsafe<TViewModel, TView, TVMProp, TVProp>(
+        this TView view,
+        TViewModel viewModel,
+        Expression<Func<TViewModel, TVMProp>> viewModelProperty,
+        Expression<Func<TView, TVProp>> viewProperty)
+        where TViewModel : class
+        where TView : class, IViewFor
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(viewModelProperty.Body);
+
+        return RuntimeBindingFallback.OneWayBind(
+            view,
+            viewModel,
+            viewModelProperty,
+            viewProperty,
+                static value =>
+                {
+                    _ = RuntimeBindingConverter.TryConvert<TVMProp, TVProp>(value, null, null, out var converted);
+                    return converted;
+                },
+            null,
+            bindingExpression);
+    }
+
+    /// <summary>Creates a one-way binding from a view model property to a view property with a specified selector.</summary>
+    /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TProp">The type of the view model property.</typeparam>
+    /// <typeparam name="TOut">The type of the view property.</typeparam>
+    /// <param name="view">The view to bind to.</param>
+    /// <param name="viewModel">The view model to observe.</param>
+    /// <param name="viewModelProperty">An expression that selects the view model property to observe.</param>
+    /// <param name="viewProperty">An expression that selects the view property to update.</param>
+    /// <param name="selector">A function that converts the view model property value to the view property type.</param>
+    /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IReactiveBinding<TView, TOut> OneWayBindUnsafe<TViewModel, TView, TProp, TOut>(
+        this TView view,
+        TViewModel viewModel,
+        Expression<Func<TViewModel, TProp>> viewModelProperty,
+        Expression<Func<TView, TOut>> viewProperty,
+        Func<TProp, TOut> selector)
+        where TViewModel : class
+        where TView : class, IViewFor
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(viewModelProperty.Body);
+
+        return RuntimeBindingFallback.OneWayBind(
+            view,
+            viewModel,
+            viewModelProperty,
+            viewProperty,
+            selector,
+            null,
+            bindingExpression);
+    }
+
+    /// <summary>Creates a two-way binding between a view model property and a view property.</summary>
+    /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TVMProp">The type of the view model property.</typeparam>
+    /// <typeparam name="TVProp">The type of the view property.</typeparam>
+    /// <param name="view">The view to bind to.</param>
+    /// <param name="viewModel">The view model to observe.</param>
+    /// <param name="viewModelProperty">An expression that selects the view model property to observe.</param>
+    /// <param name="viewProperty">An expression that selects the view property to update.</param>
+    /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IReactiveBinding<TView, BindingChange> BindUnsafe<TViewModel, TView, TVMProp, TVProp>(
+        this TView view,
+        TViewModel viewModel,
+        Expression<Func<TViewModel, TVMProp>> viewModelProperty,
+        Expression<Func<TView, TVProp>> viewProperty)
+        where TViewModel : class
+        where TView : class, IViewFor
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(viewModelProperty.Body);
+
+        return RuntimeBindingFallback.Bind(
+            view,
+            viewModel,
+            viewModelProperty,
+            viewProperty,
+            TwoWayConverters.Create<TVMProp, TVProp>(
+                static value =>
+                {
+                    _ = RuntimeBindingConverter.TryConvert<TVMProp, TVProp>(value, null, null, out var converted);
+                    return converted;
+                },
+                static value =>
+                {
+                    _ = RuntimeBindingConverter.TryConvert<TVProp, TVMProp>(value, null, null, out var converted);
+                    return converted;
+                }),
+            null,
+            bindingExpression);
+    }
+
+    /// <summary>Creates a two-way binding between a view model property and a view property with conversion functions.</summary>
+    /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TVMProp">The type of the view model property.</typeparam>
+    /// <typeparam name="TVProp">The type of the view property.</typeparam>
+    /// <param name="view">The view to bind to.</param>
+    /// <param name="viewModel">The view model to observe.</param>
+    /// <param name="viewModelProperty">An expression that selects the view model property to observe.</param>
+    /// <param name="viewProperty">An expression that selects the view property to update.</param>
+    /// <param name="viewModelToViewConverter">A function that converts the view model property value to the view property type.</param>
+    /// <param name="viewToViewModelConverter">A function that converts the view property value back to the view model property type.</param>
+    /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IReactiveBinding<TView, BindingChange> BindUnsafe<TViewModel, TView, TVMProp, TVProp>(
+        this TView view,
+        TViewModel viewModel,
+        Expression<Func<TViewModel, TVMProp>> viewModelProperty,
+        Expression<Func<TView, TVProp>> viewProperty,
+        Func<TVMProp, TVProp> viewModelToViewConverter,
+        Func<TVProp, TVMProp> viewToViewModelConverter)
+        where TViewModel : class
+        where TView : class, IViewFor
+    {
+        var bindingExpression = Reflection.ExpressionToPropertyNames(viewModelProperty.Body);
+
+        return RuntimeBindingFallback.Bind(
+            view,
+            viewModel,
+            viewModelProperty,
+            viewProperty,
+            TwoWayConverters.Create(viewModelToViewConverter, viewToViewModelConverter),
+            null,
+            bindingExpression);
+    }
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.Binding.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.Binding.cs
@@ -11,6 +11,22 @@ namespace ReactiveUI.Binding;
 /// <summary>Extension methods for property binding (BindOneWay, BindTwoWay, OneWayBind, Bind).</summary>
 public static partial class ReactiveUIBindingExtensions
 {
+    /// <summary>Reported when no generated dispatch claimed a Bind call site.</summary>
+    private const string NoBindDispatchMessage =
+        "No generated Bind dispatch matched this call site. Use BindUnsafe to resolve the expression at run time.";
+
+    /// <summary>Reported when no generated dispatch claimed a BindOneWay call site.</summary>
+    private const string NoBindOneWayDispatchMessage =
+        "No generated BindOneWay dispatch matched this call site. Use BindOneWayUnsafe to resolve the expression at run time.";
+
+    /// <summary>Reported when no generated dispatch claimed a BindTwoWay call site.</summary>
+    private const string NoBindTwoWayDispatchMessage =
+        "No generated BindTwoWay dispatch matched this call site. Use BindTwoWayUnsafe to resolve the expression at run time.";
+
+    /// <summary>Reported when no generated dispatch claimed a OneWayBind call site.</summary>
+    private const string NoOneWayBindDispatchMessage =
+        "No generated OneWayBind dispatch matched this call site. Use OneWayBindUnsafe to resolve the expression at run time.";
+
 #if NET8_0_OR_GREATER
     /// <summary>Creates a one-way binding from a source property to a target property.</summary>
     /// <typeparam name="TSource">The type of the source object.</typeparam>
@@ -25,7 +41,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindOneWay dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindOneWay dispatch matched this call site. Use BindOneWayUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IDisposable BindOneWay<TSource, TTarget, TProperty>(
         this TSource source,
@@ -52,7 +68,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindOneWay dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindOneWay dispatch matched this call site. Use BindOneWayUnsafe to resolve the expression at run time.</exception>
     public static IDisposable BindOneWay<TSource, TTarget, TProperty>(
         this TSource source,
         TTarget target,
@@ -64,7 +80,7 @@ public static partial class ReactiveUIBindingExtensions
         where TTarget : class
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindOneWayDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -83,7 +99,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindOneWay dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindOneWay dispatch matched this call site. Use BindOneWayUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IDisposable BindOneWay<TSource, TSourceProp, TTarget, TTargetProp>(
         this TSource source,
@@ -113,7 +129,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindOneWay dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindOneWay dispatch matched this call site. Use BindOneWayUnsafe to resolve the expression at run time.</exception>
     public static IDisposable BindOneWay<TSource, TSourceProp, TTarget, TTargetProp>(
         this TSource source,
         TTarget target,
@@ -126,7 +142,7 @@ public static partial class ReactiveUIBindingExtensions
         where TTarget : class
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindOneWayDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -143,7 +159,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindTwoWay dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindTwoWay dispatch matched this call site. Use BindTwoWayUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IDisposable BindTwoWay<TSource, TTarget, TProperty>(
         this TSource source,
@@ -170,7 +186,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindTwoWay dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindTwoWay dispatch matched this call site. Use BindTwoWayUnsafe to resolve the expression at run time.</exception>
     public static IDisposable BindTwoWay<TSource, TTarget, TProperty>(
         this TSource source,
         TTarget target,
@@ -182,7 +198,7 @@ public static partial class ReactiveUIBindingExtensions
         where TTarget : class
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindTwoWayDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -202,7 +218,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindTwoWay dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindTwoWay dispatch matched this call site. Use BindTwoWayUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IDisposable BindTwoWay<TSource, TSourceProp, TTarget, TTargetProp>(
         this TSource source,
@@ -234,7 +250,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, disconnects the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated BindTwoWay dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated BindTwoWay dispatch matched this call site. Use BindTwoWayUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IDisposable BindTwoWay<TSource, TSourceProp, TTarget, TTargetProp>(
         this TSource source,
@@ -249,7 +265,7 @@ public static partial class ReactiveUIBindingExtensions
         where TTarget : class
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindTwoWayDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -267,7 +283,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated IReactiveBinding dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated OneWayBind dispatch matched this call site. Use OneWayBindUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IReactiveBinding<TView, TVProp> OneWayBind<TViewModel, TView, TVMProp, TVProp>(
         this TView view,
@@ -295,7 +311,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated IReactiveBinding dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated OneWayBind dispatch matched this call site. Use OneWayBindUnsafe to resolve the expression at run time.</exception>
     public static IReactiveBinding<TView, TVProp> OneWayBind<TViewModel, TView, TVMProp, TVProp>(
         this TView view,
         TViewModel viewModel,
@@ -307,7 +323,7 @@ public static partial class ReactiveUIBindingExtensions
         where TView : class, IViewFor
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoOneWayBindDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -326,7 +342,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated IReactiveBinding dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated OneWayBind dispatch matched this call site. Use OneWayBindUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IReactiveBinding<TView, TOut> OneWayBind<TViewModel, TView, TProp, TOut>(
         this TView view,
@@ -356,7 +372,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated IReactiveBinding dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated OneWayBind dispatch matched this call site. Use OneWayBindUnsafe to resolve the expression at run time.</exception>
     public static IReactiveBinding<TView, TOut> OneWayBind<TViewModel, TView, TProp, TOut>(
         this TView view,
         TViewModel viewModel,
@@ -369,7 +385,7 @@ public static partial class ReactiveUIBindingExtensions
         where TView : class, IViewFor
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoOneWayBindDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -387,7 +403,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated IReactiveBinding dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated Bind dispatch matched this call site. Use BindUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IReactiveBinding<TView, BindingChange> Bind<TViewModel, TView, TVMProp, TVProp>(
         this TView view,
@@ -415,7 +431,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated IReactiveBinding dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated Bind dispatch matched this call site. Use BindUnsafe to resolve the expression at run time.</exception>
     public static IReactiveBinding<TView, BindingChange> Bind<TViewModel, TView, TVMProp, TVProp>(
         this TView view,
         TViewModel viewModel,
@@ -427,7 +443,7 @@ public static partial class ReactiveUIBindingExtensions
         where TView : class, IViewFor
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -447,7 +463,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated IReactiveBinding dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated Bind dispatch matched this call site. Use BindUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IReactiveBinding<TView, BindingChange> Bind<TViewModel, TView, TVMProp, TVProp>(
         this TView view,
@@ -479,7 +495,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A reactive binding that can be disposed to disconnect the binding.</returns>
-    /// <exception cref="InvalidOperationException">No generated IReactiveBinding dispatch matched this call site.</exception>
+    /// <exception cref="InvalidOperationException">No generated Bind dispatch matched this call site. Use BindUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IReactiveBinding<TView, BindingChange> Bind<TViewModel, TView, TVMProp, TVProp>(
         this TView view,
@@ -494,6 +510,6 @@ public static partial class ReactiveUIBindingExtensions
         where TView : class, IViewFor
 #endif
     {
-        throw new InvalidOperationException(NoGeneratedBindingMessage);
+        throw new InvalidOperationException(NoBindDispatchMessage);
     }
 }

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.InvokeCommand.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.InvokeCommand.Unsafe.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+
+/// <summary>Resolves an InvokeCommand expression by reflection, for a call site the generator could not read.</summary>
+/// <remarks>
+/// The opt-in half of <c>InvokeCommand</c>. The unsuffixed overload resolves at compile time and throws when no
+/// generated dispatch claimed the call site; this one walks the chain by reflection instead, and is annotated so a
+/// consumer publishing trimmed or ahead-of-time sees the requirement at their own call site.
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>Executes the command a property holds with each value the sequence produces.</summary>
+    /// <typeparam name="T">The type of the value offered as the command parameter.</typeparam>
+    /// <typeparam name="TTarget">The type declaring the command property.</typeparam>
+    /// <param name="source">The sequence driving the executions.</param>
+    /// <param name="target">The object declaring the command property.</param>
+    /// <param name="commandProperty">An expression that selects the command property to execute.</param>
+    /// <returns>A disposable that, when disposed, stops executing the command and stops observing the property.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="commandProperty"/> is null.</exception>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode("Runtime command fallback resolves the property chain by reflection.")]
+    public static IDisposable InvokeCommandUnsafe<T, TTarget>(
+        this IObservable<T> source,
+        TTarget? target,
+        Expression<Func<TTarget, ICommand?>> commandProperty)
+        where TTarget : class
+        => RuntimeCommandFallback.InvokeCommand(source, target, commandProperty);
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.InvokeCommand.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.InvokeCommand.cs
@@ -18,6 +18,10 @@ namespace ReactiveUI.Binding;
 /// </remarks>
 public static partial class ReactiveUIBindingExtensions
 {
+    /// <summary>Reported when no generated dispatch claimed an InvokeCommand call site.</summary>
+    private const string NoInvokeCommandDispatchMessage =
+        "No generated InvokeCommand dispatch matched this call site. Use InvokeCommandUnsafe to resolve the expression at run time.";
+
     /// <summary>Executes a command with each value the sequence produces.</summary>
     /// <typeparam name="T">The type of the value offered as the command parameter.</typeparam>
     /// <param name="source">The sequence driving the executions.</param>
@@ -43,8 +47,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, stops executing the command and stops observing the property.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="commandProperty"/> is null.</exception>
-    [RequiresUnreferencedCode("Runtime command fallback resolves the property chain by reflection.")]
+    /// <exception cref="InvalidOperationException">No generated InvokeCommand dispatch matched this call site. Use InvokeCommandUnsafe to resolve the expression at run time.</exception>
     public static IDisposable InvokeCommand<T, TTarget>(
         this IObservable<T> source,
         TTarget? target,
@@ -63,8 +66,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>A disposable that, when disposed, stops executing the command and stops observing the property.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="commandProperty"/> is null.</exception>
-    [RequiresUnreferencedCode("Runtime command fallback resolves the property chain by reflection.")]
+    /// <exception cref="InvalidOperationException">No generated InvokeCommand dispatch matched this call site. Use InvokeCommandUnsafe to resolve the expression at run time.</exception>
     public static IDisposable InvokeCommand<T, TTarget>(
         this IObservable<T> source,
         TTarget? target,
@@ -73,5 +75,5 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TTarget : class
 #endif
-        => RuntimeCommandFallback.InvokeCommand(source, target, commandProperty);
+        => throw new InvalidOperationException(NoInvokeCommandDispatchMessage);
 }

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAny.WideArity.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAny.WideArity.Unsafe.cs
@@ -1,0 +1,985 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+
+/// <summary>Resolves a WhenAny expression by reflection, for a call site the generator could not read.</summary>
+/// <remarks>
+/// The opt-in half of <c>WhenAny</c>. The unsuffixed overloads resolve at compile time and throw when no generated
+/// dispatch claimed the call site; these walk the chain by reflection instead, and are annotated so a consumer
+/// publishing trimmed or ahead-of-time sees the requirement at their own call site.
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>Observes 1 property on the specified sender and applies a selector to the observed changes.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The type of property 1 value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects property 1 to observe.</param>
+    /// <param name="selector">A function that combines the observed changes into a result.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyUnsafe<TSender, TRet, T1>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Func<IObservedChange<TSender, T1>, TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+
+        return sender.SubscribeToExpressionChain<TSender, T1>(
+                property1.Body,
+                skipInitial: false)
+            .Select(selector);
+    }
+
+    /// <summary>Observes 2 properties on the specified sender and applies a selector to the observed changes.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The type of property 1 value.</typeparam>
+    /// <typeparam name="T2">The type of property 2 value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects property 1 to observe.</param>
+    /// <param name="property2">An expression that selects property 2 to observe.</param>
+    /// <param name="selector">A function that combines the observed changes into a result.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyUnsafe<TSender, TRet, T1, T2>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Func<IObservedChange<TSender, T1>, IObservedChange<TSender, T2>, TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
+            property1.Body,
+            skipInitial: false);
+        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
+            property2.Body,
+            skipInitial: false);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            (c1, c2) => selector(c1, c2));
+    }
+
+    /// <summary>Observes 3 properties on the specified sender and applies a selector to the observed changes.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The type of property 1 value.</typeparam>
+    /// <typeparam name="T2">The type of property 2 value.</typeparam>
+    /// <typeparam name="T3">The type of property 3 value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects property 1 to observe.</param>
+    /// <param name="property2">An expression that selects property 2 to observe.</param>
+    /// <param name="property3">An expression that selects property 3 to observe.</param>
+    /// <param name="selector">A function that combines the observed changes into a result.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyUnsafe<TSender, TRet, T1, T2, T3>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Func<IObservedChange<TSender, T1>, IObservedChange<TSender, T2>, IObservedChange<TSender, T3>, TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
+            property1.Body,
+            skipInitial: false);
+        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
+            property2.Body,
+            skipInitial: false);
+        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
+            property3.Body,
+            skipInitial: false);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            (c1, c2, c3) => selector(c1, c2, c3));
+    }
+
+    /// <summary>Observes 4 properties on the specified sender and applies a selector to the observed changes.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The type of property 1 value.</typeparam>
+    /// <typeparam name="T2">The type of property 2 value.</typeparam>
+    /// <typeparam name="T3">The type of property 3 value.</typeparam>
+    /// <typeparam name="T4">The type of property 4 value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects property 1 to observe.</param>
+    /// <param name="property2">An expression that selects property 2 to observe.</param>
+    /// <param name="property3">An expression that selects property 3 to observe.</param>
+    /// <param name="property4">An expression that selects property 4 to observe.</param>
+    /// <param name="selector">A function that combines the observed changes into a result.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyUnsafe<TSender, TRet, T1, T2, T3, T4>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Func<
+            IObservedChange<TSender, T1>,
+            IObservedChange<TSender, T2>,
+            IObservedChange<TSender, T3>,
+            IObservedChange<TSender, T4>,
+            TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
+            property1.Body,
+            skipInitial: false);
+        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
+            property2.Body,
+            skipInitial: false);
+        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
+            property3.Body,
+            skipInitial: false);
+        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
+            property4.Body,
+            skipInitial: false);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            (c1, c2, c3, c4) => selector(c1, c2, c3, c4));
+    }
+
+    /// <summary>Observes 5 properties on the specified sender and applies a selector to the observed changes.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The type of property 1 value.</typeparam>
+    /// <typeparam name="T2">The type of property 2 value.</typeparam>
+    /// <typeparam name="T3">The type of property 3 value.</typeparam>
+    /// <typeparam name="T4">The type of property 4 value.</typeparam>
+    /// <typeparam name="T5">The type of property 5 value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects property 1 to observe.</param>
+    /// <param name="property2">An expression that selects property 2 to observe.</param>
+    /// <param name="property3">An expression that selects property 3 to observe.</param>
+    /// <param name="property4">An expression that selects property 4 to observe.</param>
+    /// <param name="property5">An expression that selects property 5 to observe.</param>
+    /// <param name="selector">A function that combines the observed changes into a result.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyUnsafe<TSender, TRet, T1, T2, T3, T4, T5>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Func<
+            IObservedChange<TSender, T1>,
+            IObservedChange<TSender, T2>,
+            IObservedChange<TSender, T3>,
+            IObservedChange<TSender, T4>,
+            IObservedChange<TSender, T5>,
+            TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
+            property1.Body,
+            skipInitial: false);
+        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
+            property2.Body,
+            skipInitial: false);
+        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
+            property3.Body,
+            skipInitial: false);
+        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
+            property4.Body,
+            skipInitial: false);
+        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
+            property5.Body,
+            skipInitial: false);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            (c1, c2, c3, c4, c5) => selector(c1, c2, c3, c4, c5));
+    }
+
+    /// <summary>Observes 6 properties on the specified sender and applies a selector to the observed changes.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The type of property 1 value.</typeparam>
+    /// <typeparam name="T2">The type of property 2 value.</typeparam>
+    /// <typeparam name="T3">The type of property 3 value.</typeparam>
+    /// <typeparam name="T4">The type of property 4 value.</typeparam>
+    /// <typeparam name="T5">The type of property 5 value.</typeparam>
+    /// <typeparam name="T6">The type of property 6 value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects property 1 to observe.</param>
+    /// <param name="property2">An expression that selects property 2 to observe.</param>
+    /// <param name="property3">An expression that selects property 3 to observe.</param>
+    /// <param name="property4">An expression that selects property 4 to observe.</param>
+    /// <param name="property5">An expression that selects property 5 to observe.</param>
+    /// <param name="property6">An expression that selects property 6 to observe.</param>
+    /// <param name="selector">A function that combines the observed changes into a result.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyUnsafe<TSender, TRet, T1, T2, T3, T4, T5, T6>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Func<
+            IObservedChange<TSender, T1>,
+            IObservedChange<TSender, T2>,
+            IObservedChange<TSender, T3>,
+            IObservedChange<TSender, T4>,
+            IObservedChange<TSender, T5>,
+            IObservedChange<TSender, T6>,
+            TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
+            property1.Body,
+            skipInitial: false);
+        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
+            property2.Body,
+            skipInitial: false);
+        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
+            property3.Body,
+            skipInitial: false);
+        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
+            property4.Body,
+            skipInitial: false);
+        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
+            property5.Body,
+            skipInitial: false);
+        var o6 = sender.SubscribeToExpressionChain<TSender, T6>(
+            property6.Body,
+            skipInitial: false);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            (c1, c2, c3, c4, c5, c6) => selector(c1, c2, c3, c4, c5, c6));
+    }
+
+    /// <summary>Observes 7 properties on the specified sender and applies a selector to the observed changes.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The type of property 1 value.</typeparam>
+    /// <typeparam name="T2">The type of property 2 value.</typeparam>
+    /// <typeparam name="T3">The type of property 3 value.</typeparam>
+    /// <typeparam name="T4">The type of property 4 value.</typeparam>
+    /// <typeparam name="T5">The type of property 5 value.</typeparam>
+    /// <typeparam name="T6">The type of property 6 value.</typeparam>
+    /// <typeparam name="T7">The type of property 7 value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects property 1 to observe.</param>
+    /// <param name="property2">An expression that selects property 2 to observe.</param>
+    /// <param name="property3">An expression that selects property 3 to observe.</param>
+    /// <param name="property4">An expression that selects property 4 to observe.</param>
+    /// <param name="property5">An expression that selects property 5 to observe.</param>
+    /// <param name="property6">An expression that selects property 6 to observe.</param>
+    /// <param name="property7">An expression that selects property 7 to observe.</param>
+    /// <param name="selector">A function that combines the observed changes into a result.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyUnsafe<TSender, TRet, T1, T2, T3, T4, T5, T6, T7>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Func<
+            IObservedChange<TSender, T1>,
+            IObservedChange<TSender, T2>,
+            IObservedChange<TSender, T3>,
+            IObservedChange<TSender, T4>,
+            IObservedChange<TSender, T5>,
+            IObservedChange<TSender, T6>,
+            IObservedChange<TSender, T7>,
+            TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
+            property1.Body,
+            skipInitial: false);
+        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
+            property2.Body,
+            skipInitial: false);
+        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
+            property3.Body,
+            skipInitial: false);
+        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
+            property4.Body,
+            skipInitial: false);
+        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
+            property5.Body,
+            skipInitial: false);
+        var o6 = sender.SubscribeToExpressionChain<TSender, T6>(
+            property6.Body,
+            skipInitial: false);
+        var o7 = sender.SubscribeToExpressionChain<TSender, T7>(
+            property7.Body,
+            skipInitial: false);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            (c1, c2, c3, c4, c5, c6, c7) => selector(c1, c2, c3, c4, c5, c6, c7));
+    }
+
+    /// <summary>Observes 8 properties on the specified sender and applies a selector to the observed changes.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The type of property 1 value.</typeparam>
+    /// <typeparam name="T2">The type of property 2 value.</typeparam>
+    /// <typeparam name="T3">The type of property 3 value.</typeparam>
+    /// <typeparam name="T4">The type of property 4 value.</typeparam>
+    /// <typeparam name="T5">The type of property 5 value.</typeparam>
+    /// <typeparam name="T6">The type of property 6 value.</typeparam>
+    /// <typeparam name="T7">The type of property 7 value.</typeparam>
+    /// <typeparam name="T8">The type of property 8 value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects property 1 to observe.</param>
+    /// <param name="property2">An expression that selects property 2 to observe.</param>
+    /// <param name="property3">An expression that selects property 3 to observe.</param>
+    /// <param name="property4">An expression that selects property 4 to observe.</param>
+    /// <param name="property5">An expression that selects property 5 to observe.</param>
+    /// <param name="property6">An expression that selects property 6 to observe.</param>
+    /// <param name="property7">An expression that selects property 7 to observe.</param>
+    /// <param name="property8">An expression that selects property 8 to observe.</param>
+    /// <param name="selector">A function that combines the observed changes into a result.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyUnsafe<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Func<
+            IObservedChange<TSender, T1>,
+            IObservedChange<TSender, T2>,
+            IObservedChange<TSender, T3>,
+            IObservedChange<TSender, T4>,
+            IObservedChange<TSender, T5>,
+            IObservedChange<TSender, T6>,
+            IObservedChange<TSender, T7>,
+            IObservedChange<TSender, T8>,
+            TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
+            property1.Body,
+            skipInitial: false);
+        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
+            property2.Body,
+            skipInitial: false);
+        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
+            property3.Body,
+            skipInitial: false);
+        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
+            property4.Body,
+            skipInitial: false);
+        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
+            property5.Body,
+            skipInitial: false);
+        var o6 = sender.SubscribeToExpressionChain<TSender, T6>(
+            property6.Body,
+            skipInitial: false);
+        var o7 = sender.SubscribeToExpressionChain<TSender, T7>(
+            property7.Body,
+            skipInitial: false);
+        var o8 = sender.SubscribeToExpressionChain<TSender, T8>(
+            property8.Body,
+            skipInitial: false);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            o8,
+            (c1, c2, c3, c4, c5, c6, c7, c8) => selector(c1, c2, c3, c4, c5, c6, c7, c8));
+    }
+
+    /// <summary>Observes 9 properties on the specified sender and applies a selector to the observed changes.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The type of property 1 value.</typeparam>
+    /// <typeparam name="T2">The type of property 2 value.</typeparam>
+    /// <typeparam name="T3">The type of property 3 value.</typeparam>
+    /// <typeparam name="T4">The type of property 4 value.</typeparam>
+    /// <typeparam name="T5">The type of property 5 value.</typeparam>
+    /// <typeparam name="T6">The type of property 6 value.</typeparam>
+    /// <typeparam name="T7">The type of property 7 value.</typeparam>
+    /// <typeparam name="T8">The type of property 8 value.</typeparam>
+    /// <typeparam name="T9">The type of property 9 value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects property 1 to observe.</param>
+    /// <param name="property2">An expression that selects property 2 to observe.</param>
+    /// <param name="property3">An expression that selects property 3 to observe.</param>
+    /// <param name="property4">An expression that selects property 4 to observe.</param>
+    /// <param name="property5">An expression that selects property 5 to observe.</param>
+    /// <param name="property6">An expression that selects property 6 to observe.</param>
+    /// <param name="property7">An expression that selects property 7 to observe.</param>
+    /// <param name="property8">An expression that selects property 8 to observe.</param>
+    /// <param name="property9">An expression that selects property 9 to observe.</param>
+    /// <param name="selector">A function that combines the observed changes into a result.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyUnsafe<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Func<
+            IObservedChange<TSender, T1>,
+            IObservedChange<TSender, T2>,
+            IObservedChange<TSender, T3>,
+            IObservedChange<TSender, T4>,
+            IObservedChange<TSender, T5>,
+            IObservedChange<TSender, T6>,
+            IObservedChange<TSender, T7>,
+            IObservedChange<TSender, T8>,
+            IObservedChange<TSender, T9>,
+            TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
+            property1.Body,
+            skipInitial: false);
+        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
+            property2.Body,
+            skipInitial: false);
+        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
+            property3.Body,
+            skipInitial: false);
+        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
+            property4.Body,
+            skipInitial: false);
+        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
+            property5.Body,
+            skipInitial: false);
+        var o6 = sender.SubscribeToExpressionChain<TSender, T6>(
+            property6.Body,
+            skipInitial: false);
+        var o7 = sender.SubscribeToExpressionChain<TSender, T7>(
+            property7.Body,
+            skipInitial: false);
+        var o8 = sender.SubscribeToExpressionChain<TSender, T8>(
+            property8.Body,
+            skipInitial: false);
+        var o9 = sender.SubscribeToExpressionChain<TSender, T9>(
+            property9.Body,
+            skipInitial: false);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            o8,
+            o9,
+            (c1, c2, c3, c4, c5, c6, c7, c8, c9) => selector(c1, c2, c3, c4, c5, c6, c7, c8, c9));
+    }
+
+    /// <summary>Observes 10 properties on the specified sender and applies a selector to the observed changes.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The type of property 1 value.</typeparam>
+    /// <typeparam name="T2">The type of property 2 value.</typeparam>
+    /// <typeparam name="T3">The type of property 3 value.</typeparam>
+    /// <typeparam name="T4">The type of property 4 value.</typeparam>
+    /// <typeparam name="T5">The type of property 5 value.</typeparam>
+    /// <typeparam name="T6">The type of property 6 value.</typeparam>
+    /// <typeparam name="T7">The type of property 7 value.</typeparam>
+    /// <typeparam name="T8">The type of property 8 value.</typeparam>
+    /// <typeparam name="T9">The type of property 9 value.</typeparam>
+    /// <typeparam name="T10">The type of property 10 value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects property 1 to observe.</param>
+    /// <param name="property2">An expression that selects property 2 to observe.</param>
+    /// <param name="property3">An expression that selects property 3 to observe.</param>
+    /// <param name="property4">An expression that selects property 4 to observe.</param>
+    /// <param name="property5">An expression that selects property 5 to observe.</param>
+    /// <param name="property6">An expression that selects property 6 to observe.</param>
+    /// <param name="property7">An expression that selects property 7 to observe.</param>
+    /// <param name="property8">An expression that selects property 8 to observe.</param>
+    /// <param name="property9">An expression that selects property 9 to observe.</param>
+    /// <param name="property10">An expression that selects property 10 to observe.</param>
+    /// <param name="selector">A function that combines the observed changes into a result.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyUnsafe<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Func<
+            IObservedChange<TSender, T1>,
+            IObservedChange<TSender, T2>,
+            IObservedChange<TSender, T3>,
+            IObservedChange<TSender, T4>,
+            IObservedChange<TSender, T5>,
+            IObservedChange<TSender, T6>,
+            IObservedChange<TSender, T7>,
+            IObservedChange<TSender, T8>,
+            IObservedChange<TSender, T9>,
+            IObservedChange<TSender, T10>,
+            TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
+            property1.Body,
+            skipInitial: false);
+        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
+            property2.Body,
+            skipInitial: false);
+        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
+            property3.Body,
+            skipInitial: false);
+        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
+            property4.Body,
+            skipInitial: false);
+        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
+            property5.Body,
+            skipInitial: false);
+        var o6 = sender.SubscribeToExpressionChain<TSender, T6>(
+            property6.Body,
+            skipInitial: false);
+        var o7 = sender.SubscribeToExpressionChain<TSender, T7>(
+            property7.Body,
+            skipInitial: false);
+        var o8 = sender.SubscribeToExpressionChain<TSender, T8>(
+            property8.Body,
+            skipInitial: false);
+        var o9 = sender.SubscribeToExpressionChain<TSender, T9>(
+            property9.Body,
+            skipInitial: false);
+        var o10 = sender.SubscribeToExpressionChain<TSender, T10>(
+            property10.Body,
+            skipInitial: false);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            o8,
+            o9,
+            o10,
+            (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) => selector(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10));
+    }
+
+    /// <summary>Observes 11 properties on the specified sender and applies a selector to the observed changes.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The type of property 1 value.</typeparam>
+    /// <typeparam name="T2">The type of property 2 value.</typeparam>
+    /// <typeparam name="T3">The type of property 3 value.</typeparam>
+    /// <typeparam name="T4">The type of property 4 value.</typeparam>
+    /// <typeparam name="T5">The type of property 5 value.</typeparam>
+    /// <typeparam name="T6">The type of property 6 value.</typeparam>
+    /// <typeparam name="T7">The type of property 7 value.</typeparam>
+    /// <typeparam name="T8">The type of property 8 value.</typeparam>
+    /// <typeparam name="T9">The type of property 9 value.</typeparam>
+    /// <typeparam name="T10">The type of property 10 value.</typeparam>
+    /// <typeparam name="T11">The type of property 11 value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects property 1 to observe.</param>
+    /// <param name="property2">An expression that selects property 2 to observe.</param>
+    /// <param name="property3">An expression that selects property 3 to observe.</param>
+    /// <param name="property4">An expression that selects property 4 to observe.</param>
+    /// <param name="property5">An expression that selects property 5 to observe.</param>
+    /// <param name="property6">An expression that selects property 6 to observe.</param>
+    /// <param name="property7">An expression that selects property 7 to observe.</param>
+    /// <param name="property8">An expression that selects property 8 to observe.</param>
+    /// <param name="property9">An expression that selects property 9 to observe.</param>
+    /// <param name="property10">An expression that selects property 10 to observe.</param>
+    /// <param name="property11">An expression that selects property 11 to observe.</param>
+    /// <param name="selector">A function that combines the observed changes into a result.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyUnsafe<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Expression<Func<TSender, T11>> property11,
+        Func<
+            IObservedChange<TSender, T1>,
+            IObservedChange<TSender, T2>,
+            IObservedChange<TSender, T3>,
+            IObservedChange<TSender, T4>,
+            IObservedChange<TSender, T5>,
+            IObservedChange<TSender, T6>,
+            IObservedChange<TSender, T7>,
+            IObservedChange<TSender, T8>,
+            IObservedChange<TSender, T9>,
+            IObservedChange<TSender, T10>,
+            IObservedChange<TSender, T11>,
+            TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
+            property1.Body,
+            skipInitial: false);
+        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
+            property2.Body,
+            skipInitial: false);
+        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
+            property3.Body,
+            skipInitial: false);
+        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
+            property4.Body,
+            skipInitial: false);
+        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
+            property5.Body,
+            skipInitial: false);
+        var o6 = sender.SubscribeToExpressionChain<TSender, T6>(
+            property6.Body,
+            skipInitial: false);
+        var o7 = sender.SubscribeToExpressionChain<TSender, T7>(
+            property7.Body,
+            skipInitial: false);
+        var o8 = sender.SubscribeToExpressionChain<TSender, T8>(
+            property8.Body,
+            skipInitial: false);
+        var o9 = sender.SubscribeToExpressionChain<TSender, T9>(
+            property9.Body,
+            skipInitial: false);
+        var o10 = sender.SubscribeToExpressionChain<TSender, T10>(
+            property10.Body,
+            skipInitial: false);
+        var o11 = sender.SubscribeToExpressionChain<TSender, T11>(
+            property11.Body,
+            skipInitial: false);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            o8,
+            o9,
+            o10,
+            o11,
+            (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11) => selector(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11));
+    }
+
+    /// <summary>Observes 12 properties on the specified sender and applies a selector to the observed changes.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The type of property 1 value.</typeparam>
+    /// <typeparam name="T2">The type of property 2 value.</typeparam>
+    /// <typeparam name="T3">The type of property 3 value.</typeparam>
+    /// <typeparam name="T4">The type of property 4 value.</typeparam>
+    /// <typeparam name="T5">The type of property 5 value.</typeparam>
+    /// <typeparam name="T6">The type of property 6 value.</typeparam>
+    /// <typeparam name="T7">The type of property 7 value.</typeparam>
+    /// <typeparam name="T8">The type of property 8 value.</typeparam>
+    /// <typeparam name="T9">The type of property 9 value.</typeparam>
+    /// <typeparam name="T10">The type of property 10 value.</typeparam>
+    /// <typeparam name="T11">The type of property 11 value.</typeparam>
+    /// <typeparam name="T12">The type of property 12 value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects property 1 to observe.</param>
+    /// <param name="property2">An expression that selects property 2 to observe.</param>
+    /// <param name="property3">An expression that selects property 3 to observe.</param>
+    /// <param name="property4">An expression that selects property 4 to observe.</param>
+    /// <param name="property5">An expression that selects property 5 to observe.</param>
+    /// <param name="property6">An expression that selects property 6 to observe.</param>
+    /// <param name="property7">An expression that selects property 7 to observe.</param>
+    /// <param name="property8">An expression that selects property 8 to observe.</param>
+    /// <param name="property9">An expression that selects property 9 to observe.</param>
+    /// <param name="property10">An expression that selects property 10 to observe.</param>
+    /// <param name="property11">An expression that selects property 11 to observe.</param>
+    /// <param name="property12">An expression that selects property 12 to observe.</param>
+    /// <param name="selector">A function that combines the observed changes into a result.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyUnsafe<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Expression<Func<TSender, T11>> property11,
+        Expression<Func<TSender, T12>> property12,
+        Func<
+            IObservedChange<TSender, T1>,
+            IObservedChange<TSender, T2>,
+            IObservedChange<TSender, T3>,
+            IObservedChange<TSender, T4>,
+            IObservedChange<TSender, T5>,
+            IObservedChange<TSender, T6>,
+            IObservedChange<TSender, T7>,
+            IObservedChange<TSender, T8>,
+            IObservedChange<TSender, T9>,
+            IObservedChange<TSender, T10>,
+            IObservedChange<TSender, T11>,
+            IObservedChange<TSender, T12>,
+            TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
+            property1.Body,
+            skipInitial: false);
+        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
+            property2.Body,
+            skipInitial: false);
+        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
+            property3.Body,
+            skipInitial: false);
+        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
+            property4.Body,
+            skipInitial: false);
+        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
+            property5.Body,
+            skipInitial: false);
+        var o6 = sender.SubscribeToExpressionChain<TSender, T6>(
+            property6.Body,
+            skipInitial: false);
+        var o7 = sender.SubscribeToExpressionChain<TSender, T7>(
+            property7.Body,
+            skipInitial: false);
+        var o8 = sender.SubscribeToExpressionChain<TSender, T8>(
+            property8.Body,
+            skipInitial: false);
+        var o9 = sender.SubscribeToExpressionChain<TSender, T9>(
+            property9.Body,
+            skipInitial: false);
+        var o10 = sender.SubscribeToExpressionChain<TSender, T10>(
+            property10.Body,
+            skipInitial: false);
+        var o11 = sender.SubscribeToExpressionChain<TSender, T11>(
+            property11.Body,
+            skipInitial: false);
+        var o12 = sender.SubscribeToExpressionChain<TSender, T12>(
+            property12.Body,
+            skipInitial: false);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            o8,
+            o9,
+            o10,
+            o11,
+            o12,
+            (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12) =>
+                selector(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12));
+    }
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAny.WideArity.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAny.WideArity.cs
@@ -13,6 +13,9 @@ namespace ReactiveUI.Binding;
 /// <summary>Extension methods for observing property changes with IObservedChange context (WhenAny).</summary>
 public static partial class ReactiveUIBindingExtensions
 {
+    /// <summary>Reported when no generated dispatch claimed a WhenAny call site.</summary>
+    private const string NoWhenAnyDispatchMessage =
+        "No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.";
 #if NET8_0_OR_GREATER
     /// <summary>Observes 1 property on the specified sender and applies a selector to the observed changes.</summary>
     /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
@@ -25,7 +28,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAny<TSender, TRet, T1>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -46,7 +49,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAny<TSender, TRet, T1>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -56,13 +59,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-
-        return sender.SubscribeToExpressionChain<TSender, T1>(
-                property1.Body,
-                skipInitial: false)
-            .Select(selector);
+        throw new InvalidOperationException(NoWhenAnyDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -80,8 +77,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -107,7 +104,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -118,21 +115,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
-            property1.Body,
-            skipInitial: false);
-        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
-            property2.Body,
-            skipInitial: false);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            (c1, c2) => selector(c1, c2));
+        throw new InvalidOperationException(NoWhenAnyDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -153,9 +136,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -186,7 +169,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -198,26 +181,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
-            property1.Body,
-            skipInitial: false);
-        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
-            property2.Body,
-            skipInitial: false);
-        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
-            property3.Body,
-            skipInitial: false);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            (c1, c2, c3) => selector(c1, c2, c3));
+        throw new InvalidOperationException(NoWhenAnyDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -241,9 +205,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -284,8 +248,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -298,31 +262,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
-            property1.Body,
-            skipInitial: false);
-        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
-            property2.Body,
-            skipInitial: false);
-        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
-            property3.Body,
-            skipInitial: false);
-        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
-            property4.Body,
-            skipInitial: false);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            (c1, c2, c3, c4) => selector(c1, c2, c3, c4));
+        throw new InvalidOperationException(NoWhenAnyDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -349,9 +289,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -398,8 +338,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -413,36 +353,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
-            property1.Body,
-            skipInitial: false);
-        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
-            property2.Body,
-            skipInitial: false);
-        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
-            property3.Body,
-            skipInitial: false);
-        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
-            property4.Body,
-            skipInitial: false);
-        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
-            property5.Body,
-            skipInitial: false);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            (c1, c2, c3, c4, c5) => selector(c1, c2, c3, c4, c5));
+        throw new InvalidOperationException(NoWhenAnyDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -472,9 +383,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5, T6>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -527,8 +438,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5, T6>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -550,41 +461,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
-            property1.Body,
-            skipInitial: false);
-        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
-            property2.Body,
-            skipInitial: false);
-        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
-            property3.Body,
-            skipInitial: false);
-        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
-            property4.Body,
-            skipInitial: false);
-        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
-            property5.Body,
-            skipInitial: false);
-        var o6 = sender.SubscribeToExpressionChain<TSender, T6>(
-            property6.Body,
-            skipInitial: false);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            o6,
-            (c1, c2, c3, c4, c5, c6) => selector(c1, c2, c3, c4, c5, c6));
+        throw new InvalidOperationException(NoWhenAnyDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -617,9 +494,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5, T6, T7>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -678,9 +555,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5, T6, T7>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -704,46 +581,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
-            property1.Body,
-            skipInitial: false);
-        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
-            property2.Body,
-            skipInitial: false);
-        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
-            property3.Body,
-            skipInitial: false);
-        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
-            property4.Body,
-            skipInitial: false);
-        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
-            property5.Body,
-            skipInitial: false);
-        var o6 = sender.SubscribeToExpressionChain<TSender, T6>(
-            property6.Body,
-            skipInitial: false);
-        var o7 = sender.SubscribeToExpressionChain<TSender, T7>(
-            property7.Body,
-            skipInitial: false);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            o6,
-            o7,
-            (c1, c2, c3, c4, c5, c6, c7) => selector(c1, c2, c3, c4, c5, c6, c7));
+        throw new InvalidOperationException(NoWhenAnyDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -779,9 +617,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -846,9 +684,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -874,51 +712,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
-            property1.Body,
-            skipInitial: false);
-        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
-            property2.Body,
-            skipInitial: false);
-        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
-            property3.Body,
-            skipInitial: false);
-        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
-            property4.Body,
-            skipInitial: false);
-        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
-            property5.Body,
-            skipInitial: false);
-        var o6 = sender.SubscribeToExpressionChain<TSender, T6>(
-            property6.Body,
-            skipInitial: false);
-        var o7 = sender.SubscribeToExpressionChain<TSender, T7>(
-            property7.Body,
-            skipInitial: false);
-        var o8 = sender.SubscribeToExpressionChain<TSender, T8>(
-            property8.Body,
-            skipInitial: false);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            o6,
-            o7,
-            o8,
-            (c1, c2, c3, c4, c5, c6, c7, c8) => selector(c1, c2, c3, c4, c5, c6, c7, c8));
+        throw new InvalidOperationException(NoWhenAnyDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -957,9 +751,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -1030,9 +824,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -1060,56 +854,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
-            property1.Body,
-            skipInitial: false);
-        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
-            property2.Body,
-            skipInitial: false);
-        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
-            property3.Body,
-            skipInitial: false);
-        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
-            property4.Body,
-            skipInitial: false);
-        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
-            property5.Body,
-            skipInitial: false);
-        var o6 = sender.SubscribeToExpressionChain<TSender, T6>(
-            property6.Body,
-            skipInitial: false);
-        var o7 = sender.SubscribeToExpressionChain<TSender, T7>(
-            property7.Body,
-            skipInitial: false);
-        var o8 = sender.SubscribeToExpressionChain<TSender, T8>(
-            property8.Body,
-            skipInitial: false);
-        var o9 = sender.SubscribeToExpressionChain<TSender, T9>(
-            property9.Body,
-            skipInitial: false);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            o6,
-            o7,
-            o8,
-            o9,
-            (c1, c2, c3, c4, c5, c6, c7, c8, c9) => selector(c1, c2, c3, c4, c5, c6, c7, c8, c9));
+        throw new InvalidOperationException(NoWhenAnyDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1151,9 +896,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -1230,9 +975,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -1262,61 +1007,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
-            property1.Body,
-            skipInitial: false);
-        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
-            property2.Body,
-            skipInitial: false);
-        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
-            property3.Body,
-            skipInitial: false);
-        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
-            property4.Body,
-            skipInitial: false);
-        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
-            property5.Body,
-            skipInitial: false);
-        var o6 = sender.SubscribeToExpressionChain<TSender, T6>(
-            property6.Body,
-            skipInitial: false);
-        var o7 = sender.SubscribeToExpressionChain<TSender, T7>(
-            property7.Body,
-            skipInitial: false);
-        var o8 = sender.SubscribeToExpressionChain<TSender, T8>(
-            property8.Body,
-            skipInitial: false);
-        var o9 = sender.SubscribeToExpressionChain<TSender, T9>(
-            property9.Body,
-            skipInitial: false);
-        var o10 = sender.SubscribeToExpressionChain<TSender, T10>(
-            property10.Body,
-            skipInitial: false);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            o6,
-            o7,
-            o8,
-            o9,
-            o10,
-            (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) => selector(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10));
+        throw new InvalidOperationException(NoWhenAnyDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1361,9 +1052,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -1446,9 +1137,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -1480,66 +1171,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
-            property1.Body,
-            skipInitial: false);
-        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
-            property2.Body,
-            skipInitial: false);
-        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
-            property3.Body,
-            skipInitial: false);
-        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
-            property4.Body,
-            skipInitial: false);
-        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
-            property5.Body,
-            skipInitial: false);
-        var o6 = sender.SubscribeToExpressionChain<TSender, T6>(
-            property6.Body,
-            skipInitial: false);
-        var o7 = sender.SubscribeToExpressionChain<TSender, T7>(
-            property7.Body,
-            skipInitial: false);
-        var o8 = sender.SubscribeToExpressionChain<TSender, T8>(
-            property8.Body,
-            skipInitial: false);
-        var o9 = sender.SubscribeToExpressionChain<TSender, T9>(
-            property9.Body,
-            skipInitial: false);
-        var o10 = sender.SubscribeToExpressionChain<TSender, T10>(
-            property10.Body,
-            skipInitial: false);
-        var o11 = sender.SubscribeToExpressionChain<TSender, T11>(
-            property11.Body,
-            skipInitial: false);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            o6,
-            o7,
-            o8,
-            o9,
-            o10,
-            o11,
-            (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11) => selector(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11));
+        throw new InvalidOperationException(NoWhenAnyDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1587,9 +1219,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -1678,9 +1310,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAny dispatch matched this call site. Use WhenAnyUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAny<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -1714,71 +1346,6 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = sender.SubscribeToExpressionChain<TSender, T1>(
-            property1.Body,
-            skipInitial: false);
-        var o2 = sender.SubscribeToExpressionChain<TSender, T2>(
-            property2.Body,
-            skipInitial: false);
-        var o3 = sender.SubscribeToExpressionChain<TSender, T3>(
-            property3.Body,
-            skipInitial: false);
-        var o4 = sender.SubscribeToExpressionChain<TSender, T4>(
-            property4.Body,
-            skipInitial: false);
-        var o5 = sender.SubscribeToExpressionChain<TSender, T5>(
-            property5.Body,
-            skipInitial: false);
-        var o6 = sender.SubscribeToExpressionChain<TSender, T6>(
-            property6.Body,
-            skipInitial: false);
-        var o7 = sender.SubscribeToExpressionChain<TSender, T7>(
-            property7.Body,
-            skipInitial: false);
-        var o8 = sender.SubscribeToExpressionChain<TSender, T8>(
-            property8.Body,
-            skipInitial: false);
-        var o9 = sender.SubscribeToExpressionChain<TSender, T9>(
-            property9.Body,
-            skipInitial: false);
-        var o10 = sender.SubscribeToExpressionChain<TSender, T10>(
-            property10.Body,
-            skipInitial: false);
-        var o11 = sender.SubscribeToExpressionChain<TSender, T11>(
-            property11.Body,
-            skipInitial: false);
-        var o12 = sender.SubscribeToExpressionChain<TSender, T12>(
-            property12.Body,
-            skipInitial: false);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            o6,
-            o7,
-            o8,
-            o9,
-            o10,
-            o11,
-            o12,
-            (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12) =>
-                selector(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12));
+        throw new InvalidOperationException(NoWhenAnyDispatchMessage);
     }
 }

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyObservable.Extended.WideArity.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyObservable.Extended.WideArity.Unsafe.cs
@@ -1,0 +1,710 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+
+/// <summary>Resolves a WhenAnyObservable expression by reflection, for a call site the generator could not read.</summary>
+/// <remarks>
+/// The opt-in half of <c>WhenAnyObservable</c>. The unsuffixed overloads resolve at compile time and throw when no generated
+/// dispatch claimed the call site; these walk the chain by reflection instead, and are annotated so a consumer
+/// publishing trimmed or ahead-of-time sees the requirement at their own call site.
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>
+    /// Observes 3 observable properties with different types on the specified sender and applies a selector to the combined latest values.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The element type of observable property 1.</typeparam>
+    /// <typeparam name="T2">The element type of observable property 2.</typeparam>
+    /// <typeparam name="T3">The element type of observable property 3.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="selector">A function that combines the latest values from all observables.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet, T1, T2, T3>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<T1>?>> obs1,
+        Expression<Func<TSender, IObservable<T2>?>> obs2,
+        Expression<Func<TSender, IObservable<T3>?>> obs3,
+        Func<T1?, T2?, T3?, TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
+        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
+        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            (v1, v2, v3) => selector(v1, v2, v3));
+    }
+
+    /// <summary>
+    /// Observes 4 observable properties with different types on the specified sender and applies a selector to the combined latest values.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The element type of observable property 1.</typeparam>
+    /// <typeparam name="T2">The element type of observable property 2.</typeparam>
+    /// <typeparam name="T3">The element type of observable property 3.</typeparam>
+    /// <typeparam name="T4">The element type of observable property 4.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="selector">A function that combines the latest values from all observables.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet, T1, T2, T3, T4>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<T1>?>> obs1,
+        Expression<Func<TSender, IObservable<T2>?>> obs2,
+        Expression<Func<TSender, IObservable<T3>?>> obs3,
+        Expression<Func<TSender, IObservable<T4>?>> obs4,
+        Func<T1?, T2?, T3?, T4?, TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
+        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
+        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
+        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            (v1, v2, v3, v4) => selector(v1, v2, v3, v4));
+    }
+
+    /// <summary>
+    /// Observes 5 observable properties with different types on the specified sender and applies a selector to the combined latest values.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The element type of observable property 1.</typeparam>
+    /// <typeparam name="T2">The element type of observable property 2.</typeparam>
+    /// <typeparam name="T3">The element type of observable property 3.</typeparam>
+    /// <typeparam name="T4">The element type of observable property 4.</typeparam>
+    /// <typeparam name="T5">The element type of observable property 5.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="selector">A function that combines the latest values from all observables.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet, T1, T2, T3, T4, T5>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<T1>?>> obs1,
+        Expression<Func<TSender, IObservable<T2>?>> obs2,
+        Expression<Func<TSender, IObservable<T3>?>> obs3,
+        Expression<Func<TSender, IObservable<T4>?>> obs4,
+        Expression<Func<TSender, IObservable<T5>?>> obs5,
+        Func<T1?, T2?, T3?, T4?, T5?, TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
+        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
+        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
+        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
+        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            (v1, v2, v3, v4, v5) => selector(v1, v2, v3, v4, v5));
+    }
+
+    /// <summary>
+    /// Observes 6 observable properties with different types on the specified sender and applies a selector to the combined latest values.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The element type of observable property 1.</typeparam>
+    /// <typeparam name="T2">The element type of observable property 2.</typeparam>
+    /// <typeparam name="T3">The element type of observable property 3.</typeparam>
+    /// <typeparam name="T4">The element type of observable property 4.</typeparam>
+    /// <typeparam name="T5">The element type of observable property 5.</typeparam>
+    /// <typeparam name="T6">The element type of observable property 6.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="obs6">An expression that selects observable property 6 to observe.</param>
+    /// <param name="selector">A function that combines the latest values from all observables.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet, T1, T2, T3, T4, T5, T6>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<T1>?>> obs1,
+        Expression<Func<TSender, IObservable<T2>?>> obs2,
+        Expression<Func<TSender, IObservable<T3>?>> obs3,
+        Expression<Func<TSender, IObservable<T4>?>> obs4,
+        Expression<Func<TSender, IObservable<T5>?>> obs5,
+        Expression<Func<TSender, IObservable<T6>?>> obs6,
+        Func<T1?, T2?, T3?, T4?, T5?, T6?, TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(obs6);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
+        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
+        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
+        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
+        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
+        var o6 = ObservableChainHelpers.SwitchLatest(sender, obs6);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            (v1, v2, v3, v4, v5, v6) => selector(v1, v2, v3, v4, v5, v6));
+    }
+
+    /// <summary>
+    /// Observes 7 observable properties with different types on the specified sender and applies a selector to the combined latest values.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The element type of observable property 1.</typeparam>
+    /// <typeparam name="T2">The element type of observable property 2.</typeparam>
+    /// <typeparam name="T3">The element type of observable property 3.</typeparam>
+    /// <typeparam name="T4">The element type of observable property 4.</typeparam>
+    /// <typeparam name="T5">The element type of observable property 5.</typeparam>
+    /// <typeparam name="T6">The element type of observable property 6.</typeparam>
+    /// <typeparam name="T7">The element type of observable property 7.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="obs6">An expression that selects observable property 6 to observe.</param>
+    /// <param name="obs7">An expression that selects observable property 7 to observe.</param>
+    /// <param name="selector">A function that combines the latest values from all observables.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet, T1, T2, T3, T4, T5, T6, T7>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<T1>?>> obs1,
+        Expression<Func<TSender, IObservable<T2>?>> obs2,
+        Expression<Func<TSender, IObservable<T3>?>> obs3,
+        Expression<Func<TSender, IObservable<T4>?>> obs4,
+        Expression<Func<TSender, IObservable<T5>?>> obs5,
+        Expression<Func<TSender, IObservable<T6>?>> obs6,
+        Expression<Func<TSender, IObservable<T7>?>> obs7,
+        Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(obs6);
+        ArgumentExceptionHelper.ThrowIfNull(obs7);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
+        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
+        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
+        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
+        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
+        var o6 = ObservableChainHelpers.SwitchLatest(sender, obs6);
+        var o7 = ObservableChainHelpers.SwitchLatest(sender, obs7);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            (v1, v2, v3, v4, v5, v6, v7) => selector(v1, v2, v3, v4, v5, v6, v7));
+    }
+
+    /// <summary>
+    /// Observes 8 observable properties with different types on the specified sender and applies a selector to the combined latest values.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The element type of observable property 1.</typeparam>
+    /// <typeparam name="T2">The element type of observable property 2.</typeparam>
+    /// <typeparam name="T3">The element type of observable property 3.</typeparam>
+    /// <typeparam name="T4">The element type of observable property 4.</typeparam>
+    /// <typeparam name="T5">The element type of observable property 5.</typeparam>
+    /// <typeparam name="T6">The element type of observable property 6.</typeparam>
+    /// <typeparam name="T7">The element type of observable property 7.</typeparam>
+    /// <typeparam name="T8">The element type of observable property 8.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="obs6">An expression that selects observable property 6 to observe.</param>
+    /// <param name="obs7">An expression that selects observable property 7 to observe.</param>
+    /// <param name="obs8">An expression that selects observable property 8 to observe.</param>
+    /// <param name="selector">A function that combines the latest values from all observables.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<T1>?>> obs1,
+        Expression<Func<TSender, IObservable<T2>?>> obs2,
+        Expression<Func<TSender, IObservable<T3>?>> obs3,
+        Expression<Func<TSender, IObservable<T4>?>> obs4,
+        Expression<Func<TSender, IObservable<T5>?>> obs5,
+        Expression<Func<TSender, IObservable<T6>?>> obs6,
+        Expression<Func<TSender, IObservable<T7>?>> obs7,
+        Expression<Func<TSender, IObservable<T8>?>> obs8,
+        Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(obs6);
+        ArgumentExceptionHelper.ThrowIfNull(obs7);
+        ArgumentExceptionHelper.ThrowIfNull(obs8);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
+        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
+        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
+        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
+        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
+        var o6 = ObservableChainHelpers.SwitchLatest(sender, obs6);
+        var o7 = ObservableChainHelpers.SwitchLatest(sender, obs7);
+        var o8 = ObservableChainHelpers.SwitchLatest(sender, obs8);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            o8,
+            (v1, v2, v3, v4, v5, v6, v7, v8) => selector(v1, v2, v3, v4, v5, v6, v7, v8));
+    }
+
+    /// <summary>
+    /// Observes 9 observable properties with different types on the specified sender and applies a selector to the combined latest values.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The element type of observable property 1.</typeparam>
+    /// <typeparam name="T2">The element type of observable property 2.</typeparam>
+    /// <typeparam name="T3">The element type of observable property 3.</typeparam>
+    /// <typeparam name="T4">The element type of observable property 4.</typeparam>
+    /// <typeparam name="T5">The element type of observable property 5.</typeparam>
+    /// <typeparam name="T6">The element type of observable property 6.</typeparam>
+    /// <typeparam name="T7">The element type of observable property 7.</typeparam>
+    /// <typeparam name="T8">The element type of observable property 8.</typeparam>
+    /// <typeparam name="T9">The element type of observable property 9.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="obs6">An expression that selects observable property 6 to observe.</param>
+    /// <param name="obs7">An expression that selects observable property 7 to observe.</param>
+    /// <param name="obs8">An expression that selects observable property 8 to observe.</param>
+    /// <param name="obs9">An expression that selects observable property 9 to observe.</param>
+    /// <param name="selector">A function that combines the latest values from all observables.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<T1>?>> obs1,
+        Expression<Func<TSender, IObservable<T2>?>> obs2,
+        Expression<Func<TSender, IObservable<T3>?>> obs3,
+        Expression<Func<TSender, IObservable<T4>?>> obs4,
+        Expression<Func<TSender, IObservable<T5>?>> obs5,
+        Expression<Func<TSender, IObservable<T6>?>> obs6,
+        Expression<Func<TSender, IObservable<T7>?>> obs7,
+        Expression<Func<TSender, IObservable<T8>?>> obs8,
+        Expression<Func<TSender, IObservable<T9>?>> obs9,
+        Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(obs6);
+        ArgumentExceptionHelper.ThrowIfNull(obs7);
+        ArgumentExceptionHelper.ThrowIfNull(obs8);
+        ArgumentExceptionHelper.ThrowIfNull(obs9);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
+        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
+        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
+        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
+        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
+        var o6 = ObservableChainHelpers.SwitchLatest(sender, obs6);
+        var o7 = ObservableChainHelpers.SwitchLatest(sender, obs7);
+        var o8 = ObservableChainHelpers.SwitchLatest(sender, obs8);
+        var o9 = ObservableChainHelpers.SwitchLatest(sender, obs9);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            o8,
+            o9,
+            (v1, v2, v3, v4, v5, v6, v7, v8, v9) => selector(v1, v2, v3, v4, v5, v6, v7, v8, v9));
+    }
+
+    /// <summary>
+    /// Observes 10 observable properties with different types on the specified sender and applies a selector to the combined latest values.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The element type of observable property 1.</typeparam>
+    /// <typeparam name="T2">The element type of observable property 2.</typeparam>
+    /// <typeparam name="T3">The element type of observable property 3.</typeparam>
+    /// <typeparam name="T4">The element type of observable property 4.</typeparam>
+    /// <typeparam name="T5">The element type of observable property 5.</typeparam>
+    /// <typeparam name="T6">The element type of observable property 6.</typeparam>
+    /// <typeparam name="T7">The element type of observable property 7.</typeparam>
+    /// <typeparam name="T8">The element type of observable property 8.</typeparam>
+    /// <typeparam name="T9">The element type of observable property 9.</typeparam>
+    /// <typeparam name="T10">The element type of observable property 10.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="obs6">An expression that selects observable property 6 to observe.</param>
+    /// <param name="obs7">An expression that selects observable property 7 to observe.</param>
+    /// <param name="obs8">An expression that selects observable property 8 to observe.</param>
+    /// <param name="obs9">An expression that selects observable property 9 to observe.</param>
+    /// <param name="obs10">An expression that selects observable property 10 to observe.</param>
+    /// <param name="selector">A function that combines the latest values from all observables.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<T1>?>> obs1,
+        Expression<Func<TSender, IObservable<T2>?>> obs2,
+        Expression<Func<TSender, IObservable<T3>?>> obs3,
+        Expression<Func<TSender, IObservable<T4>?>> obs4,
+        Expression<Func<TSender, IObservable<T5>?>> obs5,
+        Expression<Func<TSender, IObservable<T6>?>> obs6,
+        Expression<Func<TSender, IObservable<T7>?>> obs7,
+        Expression<Func<TSender, IObservable<T8>?>> obs8,
+        Expression<Func<TSender, IObservable<T9>?>> obs9,
+        Expression<Func<TSender, IObservable<T10>?>> obs10,
+        Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(obs6);
+        ArgumentExceptionHelper.ThrowIfNull(obs7);
+        ArgumentExceptionHelper.ThrowIfNull(obs8);
+        ArgumentExceptionHelper.ThrowIfNull(obs9);
+        ArgumentExceptionHelper.ThrowIfNull(obs10);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
+        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
+        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
+        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
+        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
+        var o6 = ObservableChainHelpers.SwitchLatest(sender, obs6);
+        var o7 = ObservableChainHelpers.SwitchLatest(sender, obs7);
+        var o8 = ObservableChainHelpers.SwitchLatest(sender, obs8);
+        var o9 = ObservableChainHelpers.SwitchLatest(sender, obs9);
+        var o10 = ObservableChainHelpers.SwitchLatest(sender, obs10);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            o8,
+            o9,
+            o10,
+            selector);
+    }
+
+    /// <summary>
+    /// Observes 11 observable properties with different types on the specified sender and applies a selector to the combined latest values.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The element type of observable property 1.</typeparam>
+    /// <typeparam name="T2">The element type of observable property 2.</typeparam>
+    /// <typeparam name="T3">The element type of observable property 3.</typeparam>
+    /// <typeparam name="T4">The element type of observable property 4.</typeparam>
+    /// <typeparam name="T5">The element type of observable property 5.</typeparam>
+    /// <typeparam name="T6">The element type of observable property 6.</typeparam>
+    /// <typeparam name="T7">The element type of observable property 7.</typeparam>
+    /// <typeparam name="T8">The element type of observable property 8.</typeparam>
+    /// <typeparam name="T9">The element type of observable property 9.</typeparam>
+    /// <typeparam name="T10">The element type of observable property 10.</typeparam>
+    /// <typeparam name="T11">The element type of observable property 11.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="obs6">An expression that selects observable property 6 to observe.</param>
+    /// <param name="obs7">An expression that selects observable property 7 to observe.</param>
+    /// <param name="obs8">An expression that selects observable property 8 to observe.</param>
+    /// <param name="obs9">An expression that selects observable property 9 to observe.</param>
+    /// <param name="obs10">An expression that selects observable property 10 to observe.</param>
+    /// <param name="obs11">An expression that selects observable property 11 to observe.</param>
+    /// <param name="selector">A function that combines the latest values from all observables.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<T1>?>> obs1,
+        Expression<Func<TSender, IObservable<T2>?>> obs2,
+        Expression<Func<TSender, IObservable<T3>?>> obs3,
+        Expression<Func<TSender, IObservable<T4>?>> obs4,
+        Expression<Func<TSender, IObservable<T5>?>> obs5,
+        Expression<Func<TSender, IObservable<T6>?>> obs6,
+        Expression<Func<TSender, IObservable<T7>?>> obs7,
+        Expression<Func<TSender, IObservable<T8>?>> obs8,
+        Expression<Func<TSender, IObservable<T9>?>> obs9,
+        Expression<Func<TSender, IObservable<T10>?>> obs10,
+        Expression<Func<TSender, IObservable<T11>?>> obs11,
+        Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(obs6);
+        ArgumentExceptionHelper.ThrowIfNull(obs7);
+        ArgumentExceptionHelper.ThrowIfNull(obs8);
+        ArgumentExceptionHelper.ThrowIfNull(obs9);
+        ArgumentExceptionHelper.ThrowIfNull(obs10);
+        ArgumentExceptionHelper.ThrowIfNull(obs11);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
+        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
+        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
+        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
+        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
+        var o6 = ObservableChainHelpers.SwitchLatest(sender, obs6);
+        var o7 = ObservableChainHelpers.SwitchLatest(sender, obs7);
+        var o8 = ObservableChainHelpers.SwitchLatest(sender, obs8);
+        var o9 = ObservableChainHelpers.SwitchLatest(sender, obs9);
+        var o10 = ObservableChainHelpers.SwitchLatest(sender, obs10);
+        var o11 = ObservableChainHelpers.SwitchLatest(sender, obs11);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            o8,
+            o9,
+            o10,
+            o11,
+            selector);
+    }
+
+    /// <summary>
+    /// Observes 12 observable properties with different types on the specified sender and applies a selector to the combined latest values.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The element type of observable property 1.</typeparam>
+    /// <typeparam name="T2">The element type of observable property 2.</typeparam>
+    /// <typeparam name="T3">The element type of observable property 3.</typeparam>
+    /// <typeparam name="T4">The element type of observable property 4.</typeparam>
+    /// <typeparam name="T5">The element type of observable property 5.</typeparam>
+    /// <typeparam name="T6">The element type of observable property 6.</typeparam>
+    /// <typeparam name="T7">The element type of observable property 7.</typeparam>
+    /// <typeparam name="T8">The element type of observable property 8.</typeparam>
+    /// <typeparam name="T9">The element type of observable property 9.</typeparam>
+    /// <typeparam name="T10">The element type of observable property 10.</typeparam>
+    /// <typeparam name="T11">The element type of observable property 11.</typeparam>
+    /// <typeparam name="T12">The element type of observable property 12.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="obs6">An expression that selects observable property 6 to observe.</param>
+    /// <param name="obs7">An expression that selects observable property 7 to observe.</param>
+    /// <param name="obs8">An expression that selects observable property 8 to observe.</param>
+    /// <param name="obs9">An expression that selects observable property 9 to observe.</param>
+    /// <param name="obs10">An expression that selects observable property 10 to observe.</param>
+    /// <param name="obs11">An expression that selects observable property 11 to observe.</param>
+    /// <param name="obs12">An expression that selects observable property 12 to observe.</param>
+    /// <param name="selector">A function that combines the latest values from all observables.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<T1>?>> obs1,
+        Expression<Func<TSender, IObservable<T2>?>> obs2,
+        Expression<Func<TSender, IObservable<T3>?>> obs3,
+        Expression<Func<TSender, IObservable<T4>?>> obs4,
+        Expression<Func<TSender, IObservable<T5>?>> obs5,
+        Expression<Func<TSender, IObservable<T6>?>> obs6,
+        Expression<Func<TSender, IObservable<T7>?>> obs7,
+        Expression<Func<TSender, IObservable<T8>?>> obs8,
+        Expression<Func<TSender, IObservable<T9>?>> obs9,
+        Expression<Func<TSender, IObservable<T10>?>> obs10,
+        Expression<Func<TSender, IObservable<T11>?>> obs11,
+        Expression<Func<TSender, IObservable<T12>?>> obs12,
+        Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(obs6);
+        ArgumentExceptionHelper.ThrowIfNull(obs7);
+        ArgumentExceptionHelper.ThrowIfNull(obs8);
+        ArgumentExceptionHelper.ThrowIfNull(obs9);
+        ArgumentExceptionHelper.ThrowIfNull(obs10);
+        ArgumentExceptionHelper.ThrowIfNull(obs11);
+        ArgumentExceptionHelper.ThrowIfNull(obs12);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
+        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
+        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
+        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
+        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
+        var o6 = ObservableChainHelpers.SwitchLatest(sender, obs6);
+        var o7 = ObservableChainHelpers.SwitchLatest(sender, obs7);
+        var o8 = ObservableChainHelpers.SwitchLatest(sender, obs8);
+        var o9 = ObservableChainHelpers.SwitchLatest(sender, obs9);
+        var o10 = ObservableChainHelpers.SwitchLatest(sender, obs10);
+        var o11 = ObservableChainHelpers.SwitchLatest(sender, obs11);
+        var o12 = ObservableChainHelpers.SwitchLatest(sender, obs12);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            o8,
+            o9,
+            o10,
+            o11,
+            o12,
+            selector);
+    }
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyObservable.Extended.WideArity.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyObservable.Extended.WideArity.cs
@@ -36,8 +36,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -67,7 +67,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -79,20 +79,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
-        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
-        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            (v1, v2, v3) => selector(v1, v2, v3));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -118,9 +105,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -154,8 +141,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -168,23 +155,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
-        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
-        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
-        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            (v1, v2, v3, v4) => selector(v1, v2, v3, v4));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -213,9 +184,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -253,8 +224,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -268,26 +239,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
-        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
-        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
-        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
-        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            (v1, v2, v3, v4, v5) => selector(v1, v2, v3, v4, v5));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -319,9 +271,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5, T6>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -363,8 +315,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5, T6>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -379,29 +331,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(obs6);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
-        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
-        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
-        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
-        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
-        var o6 = ObservableChainHelpers.SwitchLatest(sender, obs6);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            o6,
-            (v1, v2, v3, v4, v5, v6) => selector(v1, v2, v3, v4, v5, v6));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -436,9 +366,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5, T6, T7>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -484,8 +414,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5, T6, T7>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -501,32 +431,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(obs6);
-        ArgumentExceptionHelper.ThrowIfNull(obs7);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
-        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
-        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
-        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
-        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
-        var o6 = ObservableChainHelpers.SwitchLatest(sender, obs6);
-        var o7 = ObservableChainHelpers.SwitchLatest(sender, obs7);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            o6,
-            o7,
-            (v1, v2, v3, v4, v5, v6, v7) => selector(v1, v2, v3, v4, v5, v6, v7));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -564,9 +469,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -616,8 +521,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -634,35 +539,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(obs6);
-        ArgumentExceptionHelper.ThrowIfNull(obs7);
-        ArgumentExceptionHelper.ThrowIfNull(obs8);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
-        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
-        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
-        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
-        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
-        var o6 = ObservableChainHelpers.SwitchLatest(sender, obs6);
-        var o7 = ObservableChainHelpers.SwitchLatest(sender, obs7);
-        var o8 = ObservableChainHelpers.SwitchLatest(sender, obs8);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            o6,
-            o7,
-            o8,
-            (v1, v2, v3, v4, v5, v6, v7, v8) => selector(v1, v2, v3, v4, v5, v6, v7, v8));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -703,9 +580,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -759,8 +636,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -778,38 +655,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(obs6);
-        ArgumentExceptionHelper.ThrowIfNull(obs7);
-        ArgumentExceptionHelper.ThrowIfNull(obs8);
-        ArgumentExceptionHelper.ThrowIfNull(obs9);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
-        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
-        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
-        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
-        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
-        var o6 = ObservableChainHelpers.SwitchLatest(sender, obs6);
-        var o7 = ObservableChainHelpers.SwitchLatest(sender, obs7);
-        var o8 = ObservableChainHelpers.SwitchLatest(sender, obs8);
-        var o9 = ObservableChainHelpers.SwitchLatest(sender, obs9);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            o6,
-            o7,
-            o8,
-            o9,
-            (v1, v2, v3, v4, v5, v6, v7, v8, v9) => selector(v1, v2, v3, v4, v5, v6, v7, v8, v9));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -853,9 +699,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -913,8 +759,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -933,41 +779,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(obs6);
-        ArgumentExceptionHelper.ThrowIfNull(obs7);
-        ArgumentExceptionHelper.ThrowIfNull(obs8);
-        ArgumentExceptionHelper.ThrowIfNull(obs9);
-        ArgumentExceptionHelper.ThrowIfNull(obs10);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
-        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
-        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
-        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
-        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
-        var o6 = ObservableChainHelpers.SwitchLatest(sender, obs6);
-        var o7 = ObservableChainHelpers.SwitchLatest(sender, obs7);
-        var o8 = ObservableChainHelpers.SwitchLatest(sender, obs8);
-        var o9 = ObservableChainHelpers.SwitchLatest(sender, obs9);
-        var o10 = ObservableChainHelpers.SwitchLatest(sender, obs10);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            o6,
-            o7,
-            o8,
-            o9,
-            o10,
-            selector);
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1014,9 +826,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -1078,8 +890,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -1099,44 +911,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(obs6);
-        ArgumentExceptionHelper.ThrowIfNull(obs7);
-        ArgumentExceptionHelper.ThrowIfNull(obs8);
-        ArgumentExceptionHelper.ThrowIfNull(obs9);
-        ArgumentExceptionHelper.ThrowIfNull(obs10);
-        ArgumentExceptionHelper.ThrowIfNull(obs11);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
-        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
-        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
-        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
-        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
-        var o6 = ObservableChainHelpers.SwitchLatest(sender, obs6);
-        var o7 = ObservableChainHelpers.SwitchLatest(sender, obs7);
-        var o8 = ObservableChainHelpers.SwitchLatest(sender, obs8);
-        var o9 = ObservableChainHelpers.SwitchLatest(sender, obs9);
-        var o10 = ObservableChainHelpers.SwitchLatest(sender, obs10);
-        var o11 = ObservableChainHelpers.SwitchLatest(sender, obs11);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            o6,
-            o7,
-            o8,
-            o9,
-            o10,
-            o11,
-            selector);
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1186,9 +961,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -1254,9 +1029,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -1277,46 +1052,6 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(obs6);
-        ArgumentExceptionHelper.ThrowIfNull(obs7);
-        ArgumentExceptionHelper.ThrowIfNull(obs8);
-        ArgumentExceptionHelper.ThrowIfNull(obs9);
-        ArgumentExceptionHelper.ThrowIfNull(obs10);
-        ArgumentExceptionHelper.ThrowIfNull(obs11);
-        ArgumentExceptionHelper.ThrowIfNull(obs12);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
-        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
-        var o3 = ObservableChainHelpers.SwitchLatest(sender, obs3);
-        var o4 = ObservableChainHelpers.SwitchLatest(sender, obs4);
-        var o5 = ObservableChainHelpers.SwitchLatest(sender, obs5);
-        var o6 = ObservableChainHelpers.SwitchLatest(sender, obs6);
-        var o7 = ObservableChainHelpers.SwitchLatest(sender, obs7);
-        var o8 = ObservableChainHelpers.SwitchLatest(sender, obs8);
-        var o9 = ObservableChainHelpers.SwitchLatest(sender, obs9);
-        var o10 = ObservableChainHelpers.SwitchLatest(sender, obs10);
-        var o11 = ObservableChainHelpers.SwitchLatest(sender, obs11);
-        var o12 = ObservableChainHelpers.SwitchLatest(sender, obs12);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            o3,
-            o4,
-            o5,
-            o6,
-            o7,
-            o8,
-            o9,
-            o10,
-            o11,
-            o12,
-            selector);
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 }

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyObservable.WideArity.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyObservable.WideArity.Unsafe.cs
@@ -1,0 +1,576 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+
+/// <summary>Resolves a WhenAnyObservable expression by reflection, for a call site the generator could not read.</summary>
+/// <remarks>
+/// The opt-in half of <c>WhenAnyObservable</c>. The unsuffixed overloads resolve at compile time and throw when no generated
+/// dispatch claimed the call site; these walk the chain by reflection instead, and are annotated so a consumer
+/// publishing trimmed or ahead-of-time sees the requirement at their own call site.
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>Observes 1 observable property on the specified sender and switches to the latest observable.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The element type of the observed observables.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <returns>An observable sequence that emits values from the latest observed observable.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<TRet>?>> obs1)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+
+        return ObservableChainHelpers.SwitchLatest(sender, obs1);
+    }
+
+    /// <summary>Observes 2 observable properties on the specified sender and merges the switched observables.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The element type of the observed observables.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<TRet>?>> obs1,
+        Expression<Func<TSender, IObservable<TRet>?>> obs2)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+
+        return Signal.Merge(
+            sender.WhenAnyObservableUnsafe(obs1),
+            sender.WhenAnyObservableUnsafe(obs2));
+    }
+
+    /// <summary>Observes 3 observable properties on the specified sender and merges the switched observables.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The element type of the observed observables.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<TRet>?>> obs1,
+        Expression<Func<TSender, IObservable<TRet>?>> obs2,
+        Expression<Func<TSender, IObservable<TRet>?>> obs3)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+
+        return Signal.Merge(
+            sender.WhenAnyObservableUnsafe(obs1),
+            sender.WhenAnyObservableUnsafe(obs2),
+            sender.WhenAnyObservableUnsafe(obs3));
+    }
+
+    /// <summary>Observes 4 observable properties on the specified sender and merges the switched observables.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The element type of the observed observables.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<TRet>?>> obs1,
+        Expression<Func<TSender, IObservable<TRet>?>> obs2,
+        Expression<Func<TSender, IObservable<TRet>?>> obs3,
+        Expression<Func<TSender, IObservable<TRet>?>> obs4)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+
+        return Signal.Merge(
+            sender.WhenAnyObservableUnsafe(obs1),
+            sender.WhenAnyObservableUnsafe(obs2),
+            sender.WhenAnyObservableUnsafe(obs3),
+            sender.WhenAnyObservableUnsafe(obs4));
+    }
+
+    /// <summary>Observes 5 observable properties on the specified sender and merges the switched observables.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The element type of the observed observables.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<TRet>?>> obs1,
+        Expression<Func<TSender, IObservable<TRet>?>> obs2,
+        Expression<Func<TSender, IObservable<TRet>?>> obs3,
+        Expression<Func<TSender, IObservable<TRet>?>> obs4,
+        Expression<Func<TSender, IObservable<TRet>?>> obs5)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+
+        return Signal.Merge(
+            sender.WhenAnyObservableUnsafe(obs1),
+            sender.WhenAnyObservableUnsafe(obs2),
+            sender.WhenAnyObservableUnsafe(obs3),
+            sender.WhenAnyObservableUnsafe(obs4),
+            sender.WhenAnyObservableUnsafe(obs5));
+    }
+
+    /// <summary>Observes 6 observable properties on the specified sender and merges the switched observables.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The element type of the observed observables.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="obs6">An expression that selects observable property 6 to observe.</param>
+    /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<TRet>?>> obs1,
+        Expression<Func<TSender, IObservable<TRet>?>> obs2,
+        Expression<Func<TSender, IObservable<TRet>?>> obs3,
+        Expression<Func<TSender, IObservable<TRet>?>> obs4,
+        Expression<Func<TSender, IObservable<TRet>?>> obs5,
+        Expression<Func<TSender, IObservable<TRet>?>> obs6)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(obs6);
+
+        return Signal.Merge(
+            sender.WhenAnyObservableUnsafe(obs1),
+            sender.WhenAnyObservableUnsafe(obs2),
+            sender.WhenAnyObservableUnsafe(obs3),
+            sender.WhenAnyObservableUnsafe(obs4),
+            sender.WhenAnyObservableUnsafe(obs5),
+            sender.WhenAnyObservableUnsafe(obs6));
+    }
+
+    /// <summary>Observes 7 observable properties on the specified sender and merges the switched observables.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The element type of the observed observables.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="obs6">An expression that selects observable property 6 to observe.</param>
+    /// <param name="obs7">An expression that selects observable property 7 to observe.</param>
+    /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<TRet>?>> obs1,
+        Expression<Func<TSender, IObservable<TRet>?>> obs2,
+        Expression<Func<TSender, IObservable<TRet>?>> obs3,
+        Expression<Func<TSender, IObservable<TRet>?>> obs4,
+        Expression<Func<TSender, IObservable<TRet>?>> obs5,
+        Expression<Func<TSender, IObservable<TRet>?>> obs6,
+        Expression<Func<TSender, IObservable<TRet>?>> obs7)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(obs6);
+        ArgumentExceptionHelper.ThrowIfNull(obs7);
+
+        return Signal.Merge(
+            sender.WhenAnyObservableUnsafe(obs1),
+            sender.WhenAnyObservableUnsafe(obs2),
+            sender.WhenAnyObservableUnsafe(obs3),
+            sender.WhenAnyObservableUnsafe(obs4),
+            sender.WhenAnyObservableUnsafe(obs5),
+            sender.WhenAnyObservableUnsafe(obs6),
+            sender.WhenAnyObservableUnsafe(obs7));
+    }
+
+    /// <summary>Observes 8 observable properties on the specified sender and merges the switched observables.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The element type of the observed observables.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="obs6">An expression that selects observable property 6 to observe.</param>
+    /// <param name="obs7">An expression that selects observable property 7 to observe.</param>
+    /// <param name="obs8">An expression that selects observable property 8 to observe.</param>
+    /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<TRet>?>> obs1,
+        Expression<Func<TSender, IObservable<TRet>?>> obs2,
+        Expression<Func<TSender, IObservable<TRet>?>> obs3,
+        Expression<Func<TSender, IObservable<TRet>?>> obs4,
+        Expression<Func<TSender, IObservable<TRet>?>> obs5,
+        Expression<Func<TSender, IObservable<TRet>?>> obs6,
+        Expression<Func<TSender, IObservable<TRet>?>> obs7,
+        Expression<Func<TSender, IObservable<TRet>?>> obs8)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(obs6);
+        ArgumentExceptionHelper.ThrowIfNull(obs7);
+        ArgumentExceptionHelper.ThrowIfNull(obs8);
+
+        return Signal.Merge(
+            sender.WhenAnyObservableUnsafe(obs1),
+            sender.WhenAnyObservableUnsafe(obs2),
+            sender.WhenAnyObservableUnsafe(obs3),
+            sender.WhenAnyObservableUnsafe(obs4),
+            sender.WhenAnyObservableUnsafe(obs5),
+            sender.WhenAnyObservableUnsafe(obs6),
+            sender.WhenAnyObservableUnsafe(obs7),
+            sender.WhenAnyObservableUnsafe(obs8));
+    }
+
+    /// <summary>Observes 9 observable properties on the specified sender and merges the switched observables.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The element type of the observed observables.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="obs6">An expression that selects observable property 6 to observe.</param>
+    /// <param name="obs7">An expression that selects observable property 7 to observe.</param>
+    /// <param name="obs8">An expression that selects observable property 8 to observe.</param>
+    /// <param name="obs9">An expression that selects observable property 9 to observe.</param>
+    /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<TRet>?>> obs1,
+        Expression<Func<TSender, IObservable<TRet>?>> obs2,
+        Expression<Func<TSender, IObservable<TRet>?>> obs3,
+        Expression<Func<TSender, IObservable<TRet>?>> obs4,
+        Expression<Func<TSender, IObservable<TRet>?>> obs5,
+        Expression<Func<TSender, IObservable<TRet>?>> obs6,
+        Expression<Func<TSender, IObservable<TRet>?>> obs7,
+        Expression<Func<TSender, IObservable<TRet>?>> obs8,
+        Expression<Func<TSender, IObservable<TRet>?>> obs9)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(obs6);
+        ArgumentExceptionHelper.ThrowIfNull(obs7);
+        ArgumentExceptionHelper.ThrowIfNull(obs8);
+        ArgumentExceptionHelper.ThrowIfNull(obs9);
+
+        return Signal.Merge(
+            sender.WhenAnyObservableUnsafe(obs1),
+            sender.WhenAnyObservableUnsafe(obs2),
+            sender.WhenAnyObservableUnsafe(obs3),
+            sender.WhenAnyObservableUnsafe(obs4),
+            sender.WhenAnyObservableUnsafe(obs5),
+            sender.WhenAnyObservableUnsafe(obs6),
+            sender.WhenAnyObservableUnsafe(obs7),
+            sender.WhenAnyObservableUnsafe(obs8),
+            sender.WhenAnyObservableUnsafe(obs9));
+    }
+
+    /// <summary>Observes 10 observable properties on the specified sender and merges the switched observables.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The element type of the observed observables.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="obs6">An expression that selects observable property 6 to observe.</param>
+    /// <param name="obs7">An expression that selects observable property 7 to observe.</param>
+    /// <param name="obs8">An expression that selects observable property 8 to observe.</param>
+    /// <param name="obs9">An expression that selects observable property 9 to observe.</param>
+    /// <param name="obs10">An expression that selects observable property 10 to observe.</param>
+    /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<TRet>?>> obs1,
+        Expression<Func<TSender, IObservable<TRet>?>> obs2,
+        Expression<Func<TSender, IObservable<TRet>?>> obs3,
+        Expression<Func<TSender, IObservable<TRet>?>> obs4,
+        Expression<Func<TSender, IObservable<TRet>?>> obs5,
+        Expression<Func<TSender, IObservable<TRet>?>> obs6,
+        Expression<Func<TSender, IObservable<TRet>?>> obs7,
+        Expression<Func<TSender, IObservable<TRet>?>> obs8,
+        Expression<Func<TSender, IObservable<TRet>?>> obs9,
+        Expression<Func<TSender, IObservable<TRet>?>> obs10)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(obs6);
+        ArgumentExceptionHelper.ThrowIfNull(obs7);
+        ArgumentExceptionHelper.ThrowIfNull(obs8);
+        ArgumentExceptionHelper.ThrowIfNull(obs9);
+        ArgumentExceptionHelper.ThrowIfNull(obs10);
+
+        return Signal.Merge(
+            sender.WhenAnyObservableUnsafe(obs1),
+            sender.WhenAnyObservableUnsafe(obs2),
+            sender.WhenAnyObservableUnsafe(obs3),
+            sender.WhenAnyObservableUnsafe(obs4),
+            sender.WhenAnyObservableUnsafe(obs5),
+            sender.WhenAnyObservableUnsafe(obs6),
+            sender.WhenAnyObservableUnsafe(obs7),
+            sender.WhenAnyObservableUnsafe(obs8),
+            sender.WhenAnyObservableUnsafe(obs9),
+            sender.WhenAnyObservableUnsafe(obs10));
+    }
+
+    /// <summary>Observes 11 observable properties on the specified sender and merges the switched observables.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The element type of the observed observables.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="obs6">An expression that selects observable property 6 to observe.</param>
+    /// <param name="obs7">An expression that selects observable property 7 to observe.</param>
+    /// <param name="obs8">An expression that selects observable property 8 to observe.</param>
+    /// <param name="obs9">An expression that selects observable property 9 to observe.</param>
+    /// <param name="obs10">An expression that selects observable property 10 to observe.</param>
+    /// <param name="obs11">An expression that selects observable property 11 to observe.</param>
+    /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<TRet>?>> obs1,
+        Expression<Func<TSender, IObservable<TRet>?>> obs2,
+        Expression<Func<TSender, IObservable<TRet>?>> obs3,
+        Expression<Func<TSender, IObservable<TRet>?>> obs4,
+        Expression<Func<TSender, IObservable<TRet>?>> obs5,
+        Expression<Func<TSender, IObservable<TRet>?>> obs6,
+        Expression<Func<TSender, IObservable<TRet>?>> obs7,
+        Expression<Func<TSender, IObservable<TRet>?>> obs8,
+        Expression<Func<TSender, IObservable<TRet>?>> obs9,
+        Expression<Func<TSender, IObservable<TRet>?>> obs10,
+        Expression<Func<TSender, IObservable<TRet>?>> obs11)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(obs6);
+        ArgumentExceptionHelper.ThrowIfNull(obs7);
+        ArgumentExceptionHelper.ThrowIfNull(obs8);
+        ArgumentExceptionHelper.ThrowIfNull(obs9);
+        ArgumentExceptionHelper.ThrowIfNull(obs10);
+        ArgumentExceptionHelper.ThrowIfNull(obs11);
+
+        return Signal.Merge(
+            sender.WhenAnyObservableUnsafe(obs1),
+            sender.WhenAnyObservableUnsafe(obs2),
+            sender.WhenAnyObservableUnsafe(obs3),
+            sender.WhenAnyObservableUnsafe(obs4),
+            sender.WhenAnyObservableUnsafe(obs5),
+            sender.WhenAnyObservableUnsafe(obs6),
+            sender.WhenAnyObservableUnsafe(obs7),
+            sender.WhenAnyObservableUnsafe(obs8),
+            sender.WhenAnyObservableUnsafe(obs9),
+            sender.WhenAnyObservableUnsafe(obs10),
+            sender.WhenAnyObservableUnsafe(obs11));
+    }
+
+    /// <summary>Observes 12 observable properties on the specified sender and merges the switched observables.</summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The element type of the observed observables.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="obs3">An expression that selects observable property 3 to observe.</param>
+    /// <param name="obs4">An expression that selects observable property 4 to observe.</param>
+    /// <param name="obs5">An expression that selects observable property 5 to observe.</param>
+    /// <param name="obs6">An expression that selects observable property 6 to observe.</param>
+    /// <param name="obs7">An expression that selects observable property 7 to observe.</param>
+    /// <param name="obs8">An expression that selects observable property 8 to observe.</param>
+    /// <param name="obs9">An expression that selects observable property 9 to observe.</param>
+    /// <param name="obs10">An expression that selects observable property 10 to observe.</param>
+    /// <param name="obs11">An expression that selects observable property 11 to observe.</param>
+    /// <param name="obs12">An expression that selects observable property 12 to observe.</param>
+    /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<TRet>?>> obs1,
+        Expression<Func<TSender, IObservable<TRet>?>> obs2,
+        Expression<Func<TSender, IObservable<TRet>?>> obs3,
+        Expression<Func<TSender, IObservable<TRet>?>> obs4,
+        Expression<Func<TSender, IObservable<TRet>?>> obs5,
+        Expression<Func<TSender, IObservable<TRet>?>> obs6,
+        Expression<Func<TSender, IObservable<TRet>?>> obs7,
+        Expression<Func<TSender, IObservable<TRet>?>> obs8,
+        Expression<Func<TSender, IObservable<TRet>?>> obs9,
+        Expression<Func<TSender, IObservable<TRet>?>> obs10,
+        Expression<Func<TSender, IObservable<TRet>?>> obs11,
+        Expression<Func<TSender, IObservable<TRet>?>> obs12)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(obs3);
+        ArgumentExceptionHelper.ThrowIfNull(obs4);
+        ArgumentExceptionHelper.ThrowIfNull(obs5);
+        ArgumentExceptionHelper.ThrowIfNull(obs6);
+        ArgumentExceptionHelper.ThrowIfNull(obs7);
+        ArgumentExceptionHelper.ThrowIfNull(obs8);
+        ArgumentExceptionHelper.ThrowIfNull(obs9);
+        ArgumentExceptionHelper.ThrowIfNull(obs10);
+        ArgumentExceptionHelper.ThrowIfNull(obs11);
+        ArgumentExceptionHelper.ThrowIfNull(obs12);
+
+        return Signal.Merge(
+            sender.WhenAnyObservableUnsafe(obs1),
+            sender.WhenAnyObservableUnsafe(obs2),
+            sender.WhenAnyObservableUnsafe(obs3),
+            sender.WhenAnyObservableUnsafe(obs4),
+            sender.WhenAnyObservableUnsafe(obs5),
+            sender.WhenAnyObservableUnsafe(obs6),
+            sender.WhenAnyObservableUnsafe(obs7),
+            sender.WhenAnyObservableUnsafe(obs8),
+            sender.WhenAnyObservableUnsafe(obs9),
+            sender.WhenAnyObservableUnsafe(obs10),
+            sender.WhenAnyObservableUnsafe(obs11),
+            sender.WhenAnyObservableUnsafe(obs12));
+    }
+
+    /// <summary>
+    /// Observes 2 observable properties with different types on the specified sender and applies a selector to the combined latest values.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector.</typeparam>
+    /// <typeparam name="T1">The element type of observable property 1.</typeparam>
+    /// <typeparam name="T2">The element type of observable property 2.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="obs1">An expression that selects observable property 1 to observe.</param>
+    /// <param name="obs2">An expression that selects observable property 2 to observe.</param>
+    /// <param name="selector">A function that combines the latest values from all observables.</param>
+    /// <returns>An observable sequence of selector results.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    public static IObservable<TRet> WhenAnyObservableUnsafe<TSender, TRet, T1, T2>(
+        this TSender sender,
+        Expression<Func<TSender, IObservable<T1>?>> obs1,
+        Expression<Func<TSender, IObservable<T2>?>> obs2,
+        Func<T1?, T2?, TRet> selector)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(obs1);
+        ArgumentExceptionHelper.ThrowIfNull(obs2);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
+        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
+        return CombineLatestObservable.Create(
+            o1,
+            o2,
+            (v1, v2) => selector(v1, v2));
+    }
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyObservable.WideArity.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyObservable.WideArity.cs
@@ -16,6 +16,9 @@ namespace ReactiveUI.Binding;
 /// </summary>
 public static partial class ReactiveUIBindingExtensions
 {
+    /// <summary>Reported when no generated dispatch claimed a WhenAnyObservable call site.</summary>
+    private const string NoWhenAnyObservableDispatchMessage =
+        "No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.";
 #if NET8_0_OR_GREATER
     /// <summary>Observes 1 observable property on the specified sender and switches to the latest observable.</summary>
     /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
@@ -26,7 +29,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the latest observed observable.</returns>
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -43,7 +46,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the latest observed observable.</returns>
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -52,10 +55,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-
-        return ObservableChainHelpers.SwitchLatest(sender, obs1);
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -70,7 +70,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -90,7 +90,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -100,13 +100,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-
-        return Signal.Merge(
-            sender.WhenAnyObservable(obs1),
-            sender.WhenAnyObservable(obs2));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -123,8 +117,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -147,7 +141,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -158,15 +152,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-
-        return Signal.Merge(
-            sender.WhenAnyObservable(obs1),
-            sender.WhenAnyObservable(obs2),
-            sender.WhenAnyObservable(obs3));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -185,8 +171,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -212,7 +198,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -224,17 +210,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-
-        return Signal.Merge(
-            sender.WhenAnyObservable(obs1),
-            sender.WhenAnyObservable(obs2),
-            sender.WhenAnyObservable(obs3),
-            sender.WhenAnyObservable(obs4));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -255,8 +231,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -285,8 +261,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -299,19 +275,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-
-        return Signal.Merge(
-            sender.WhenAnyObservable(obs1),
-            sender.WhenAnyObservable(obs2),
-            sender.WhenAnyObservable(obs3),
-            sender.WhenAnyObservable(obs4),
-            sender.WhenAnyObservable(obs5));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -334,9 +298,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -368,8 +332,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -383,21 +347,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(obs6);
-
-        return Signal.Merge(
-            sender.WhenAnyObservable(obs1),
-            sender.WhenAnyObservable(obs2),
-            sender.WhenAnyObservable(obs3),
-            sender.WhenAnyObservable(obs4),
-            sender.WhenAnyObservable(obs5),
-            sender.WhenAnyObservable(obs6));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -422,9 +372,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -459,8 +409,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -475,23 +425,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(obs6);
-        ArgumentExceptionHelper.ThrowIfNull(obs7);
-
-        return Signal.Merge(
-            sender.WhenAnyObservable(obs1),
-            sender.WhenAnyObservable(obs2),
-            sender.WhenAnyObservable(obs3),
-            sender.WhenAnyObservable(obs4),
-            sender.WhenAnyObservable(obs5),
-            sender.WhenAnyObservable(obs6),
-            sender.WhenAnyObservable(obs7));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -518,9 +452,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -558,8 +492,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -575,25 +509,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(obs6);
-        ArgumentExceptionHelper.ThrowIfNull(obs7);
-        ArgumentExceptionHelper.ThrowIfNull(obs8);
-
-        return Signal.Merge(
-            sender.WhenAnyObservable(obs1),
-            sender.WhenAnyObservable(obs2),
-            sender.WhenAnyObservable(obs3),
-            sender.WhenAnyObservable(obs4),
-            sender.WhenAnyObservable(obs5),
-            sender.WhenAnyObservable(obs6),
-            sender.WhenAnyObservable(obs7),
-            sender.WhenAnyObservable(obs8));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -622,9 +538,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -665,8 +581,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -683,27 +599,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(obs6);
-        ArgumentExceptionHelper.ThrowIfNull(obs7);
-        ArgumentExceptionHelper.ThrowIfNull(obs8);
-        ArgumentExceptionHelper.ThrowIfNull(obs9);
-
-        return Signal.Merge(
-            sender.WhenAnyObservable(obs1),
-            sender.WhenAnyObservable(obs2),
-            sender.WhenAnyObservable(obs3),
-            sender.WhenAnyObservable(obs4),
-            sender.WhenAnyObservable(obs5),
-            sender.WhenAnyObservable(obs6),
-            sender.WhenAnyObservable(obs7),
-            sender.WhenAnyObservable(obs8),
-            sender.WhenAnyObservable(obs9));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -734,9 +630,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -780,8 +676,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -799,29 +695,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(obs6);
-        ArgumentExceptionHelper.ThrowIfNull(obs7);
-        ArgumentExceptionHelper.ThrowIfNull(obs8);
-        ArgumentExceptionHelper.ThrowIfNull(obs9);
-        ArgumentExceptionHelper.ThrowIfNull(obs10);
-
-        return Signal.Merge(
-            sender.WhenAnyObservable(obs1),
-            sender.WhenAnyObservable(obs2),
-            sender.WhenAnyObservable(obs3),
-            sender.WhenAnyObservable(obs4),
-            sender.WhenAnyObservable(obs5),
-            sender.WhenAnyObservable(obs6),
-            sender.WhenAnyObservable(obs7),
-            sender.WhenAnyObservable(obs8),
-            sender.WhenAnyObservable(obs9),
-            sender.WhenAnyObservable(obs10));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -854,9 +728,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -903,8 +777,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -923,31 +797,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(obs6);
-        ArgumentExceptionHelper.ThrowIfNull(obs7);
-        ArgumentExceptionHelper.ThrowIfNull(obs8);
-        ArgumentExceptionHelper.ThrowIfNull(obs9);
-        ArgumentExceptionHelper.ThrowIfNull(obs10);
-        ArgumentExceptionHelper.ThrowIfNull(obs11);
-
-        return Signal.Merge(
-            sender.WhenAnyObservable(obs1),
-            sender.WhenAnyObservable(obs2),
-            sender.WhenAnyObservable(obs3),
-            sender.WhenAnyObservable(obs4),
-            sender.WhenAnyObservable(obs5),
-            sender.WhenAnyObservable(obs6),
-            sender.WhenAnyObservable(obs7),
-            sender.WhenAnyObservable(obs8),
-            sender.WhenAnyObservable(obs9),
-            sender.WhenAnyObservable(obs10),
-            sender.WhenAnyObservable(obs11));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -982,9 +832,9 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -1034,8 +884,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits values from the merged observed observables.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(
         this TSender sender,
         Expression<Func<TSender, IObservable<TRet>?>> obs1,
@@ -1055,33 +905,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(obs3);
-        ArgumentExceptionHelper.ThrowIfNull(obs4);
-        ArgumentExceptionHelper.ThrowIfNull(obs5);
-        ArgumentExceptionHelper.ThrowIfNull(obs6);
-        ArgumentExceptionHelper.ThrowIfNull(obs7);
-        ArgumentExceptionHelper.ThrowIfNull(obs8);
-        ArgumentExceptionHelper.ThrowIfNull(obs9);
-        ArgumentExceptionHelper.ThrowIfNull(obs10);
-        ArgumentExceptionHelper.ThrowIfNull(obs11);
-        ArgumentExceptionHelper.ThrowIfNull(obs12);
-
-        return Signal.Merge(
-            sender.WhenAnyObservable(obs1),
-            sender.WhenAnyObservable(obs2),
-            sender.WhenAnyObservable(obs3),
-            sender.WhenAnyObservable(obs4),
-            sender.WhenAnyObservable(obs5),
-            sender.WhenAnyObservable(obs6),
-            sender.WhenAnyObservable(obs7),
-            sender.WhenAnyObservable(obs8),
-            sender.WhenAnyObservable(obs9),
-            sender.WhenAnyObservable(obs10),
-            sender.WhenAnyObservable(obs11),
-            sender.WhenAnyObservable(obs12));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1101,8 +925,8 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -1128,7 +952,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence of selector results.</returns>
-    [RequiresUnreferencedCode("Runtime observation fallback uses reflection-based expression analysis.")]
+    /// <exception cref="InvalidOperationException">No generated WhenAnyObservable dispatch matched this call site. Use WhenAnyObservableUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1, T2>(
         this TSender sender,
         Expression<Func<TSender, IObservable<T1>?>> obs1,
@@ -1139,16 +963,6 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(obs1);
-        ArgumentExceptionHelper.ThrowIfNull(obs2);
-        ArgumentExceptionHelper.ThrowIfNull(selector);
-
-        var o1 = ObservableChainHelpers.SwitchLatest(sender, obs1);
-        var o2 = ObservableChainHelpers.SwitchLatest(sender, obs2);
-        return CombineLatestObservable.Create(
-            o1,
-            o2,
-            (v1, v2) => selector(v1, v2));
+        throw new InvalidOperationException(NoWhenAnyObservableDispatchMessage);
     }
 }

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyValue.Selectors.WideArity.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyValue.Selectors.WideArity.Unsafe.cs
@@ -1,0 +1,1029 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+
+/// <summary>Resolves a WhenAnyValue expression by reflection, for a call site the generator could not read.</summary>
+/// <remarks>
+/// The opt-in half of <c>WhenAnyValue</c>. The unsuffixed overloads resolve at compile time and throw when no generated
+/// dispatch claimed the call site; these walk the chain by reflection instead, and are annotated so a consumer
+/// publishing trimmed or ahead-of-time sees the requirement at their own call site.
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>
+    /// Observes 1 property on the specified sender and applies a selector function to produce a result after it changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="selector">A function that converts the observed property value to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when the observed property changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<TSender, T1, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Func<T1, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(property1)
+            .Select(selector);
+
+    /// <summary>
+    /// Observes 2 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<TSender, T1, T2, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Func<T1, T2, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(property1, property2)
+            .Select(t => selector(t.Property1, t.Property2));
+
+    /// <summary>
+    /// Observes 3 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<TSender, T1, T2, T3, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Func<T1, T2, T3, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(
+            property1,
+            property2,
+            property3).Select(t => selector(t.Property1, t.Property2, t.Property3));
+
+    /// <summary>
+    /// Observes 4 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Func<T1, T2, T3, T4, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(
+            property1,
+            property2,
+            property3,
+            property4).Select(t => selector(t.Property1, t.Property2, t.Property3, t.Property4));
+
+    /// <summary>
+    /// Observes 5 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Func<T1, T2, T3, T4, T5, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5).Select(t => selector(t.Property1, t.Property2, t.Property3, t.Property4, t.Property5));
+
+    /// <summary>
+    /// Observes 6 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Func<T1, T2, T3, T4, T5, T6, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6).Select(t => selector(t.Property1, t.Property2, t.Property3, t.Property4, t.Property5, t.Property6));
+
+    /// <summary>
+    /// Observes 7 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6, T7, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Func<T1, T2, T3, T4, T5, T6, T7, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7).Select(t => selector(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7));
+
+    /// <summary>
+    /// Observes 8 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6, T7, T8, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8).Select(t => selector(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8));
+
+    /// <summary>
+    /// Observes 9 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9).Select(t => selector(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9));
+
+    /// <summary>
+    /// Observes 10 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10).Select(t => selector(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10));
+
+    /// <summary>
+    /// Observes 11 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Expression<Func<TSender, T11>> property11,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11).Select(t => selector(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11));
+
+    /// <summary>
+    /// Observes 12 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Expression<Func<TSender, T11>> property11,
+        Expression<Func<TSender, T12>> property12,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12).Select(t => selector(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12));
+
+    /// <summary>
+    /// Observes 13 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Expression<Func<TSender, T11>> property11,
+        Expression<Func<TSender, T12>> property12,
+        Expression<Func<TSender, T13>> property13,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12,
+            property13).Select(t => selector(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12,
+                t.Property13));
+
+    /// <summary>
+    /// Observes 14 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<
+        TSender,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Expression<Func<TSender, T11>> property11,
+        Expression<Func<TSender, T12>> property12,
+        Expression<Func<TSender, T13>> property13,
+        Expression<Func<TSender, T14>> property14,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12,
+            property13,
+            property14).Select(t => selector(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12,
+                t.Property13,
+                t.Property14));
+
+    /// <summary>
+    /// Observes 15 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="T15">The type of the fifteenth observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="property15">An expression that selects the fifteenth property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<
+        TSender,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Expression<Func<TSender, T11>> property11,
+        Expression<Func<TSender, T12>> property12,
+        Expression<Func<TSender, T13>> property13,
+        Expression<Func<TSender, T14>> property14,
+        Expression<Func<TSender, T15>> property15,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12,
+            property13,
+            property14,
+            property15).Select(t => selector(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12,
+                t.Property13,
+                t.Property14,
+                t.Property15));
+
+    /// <summary>
+    /// Observes 16 properties on the specified sender and applies a selector function to produce a result after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="T15">The type of the fifteenth observed property value.</typeparam>
+    /// <typeparam name="T16">The type of the sixteenth observed property value.</typeparam>
+    /// <typeparam name="TRet">The return type of the selector function.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="property15">An expression that selects the fifteenth property to observe.</param>
+    /// <param name="property16">An expression that selects the sixteenth property to observe.</param>
+    /// <param name="selector">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TRet> WhenAnyValueUnsafe<
+        TSender,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        TRet>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Expression<Func<TSender, T11>> property11,
+        Expression<Func<TSender, T12>> property12,
+        Expression<Func<TSender, T13>> property13,
+        Expression<Func<TSender, T14>> property14,
+        Expression<Func<TSender, T15>> property15,
+        Expression<Func<TSender, T16>> property16,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TRet> selector)
+        where TSender : class
+        => sender.WhenAnyValueUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12,
+            property13,
+            property14,
+            property15,
+            property16).Select(t => selector(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12,
+                t.Property13,
+                t.Property14,
+                t.Property15,
+                t.Property16));
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyValue.Selectors.WideArity.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyValue.Selectors.WideArity.cs
@@ -29,6 +29,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when the observed property changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAnyValue<TSender, T1, TRet>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -51,6 +52,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when the observed property changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAnyValue<TSender, T1, TRet>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -59,8 +61,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(property1, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber)
-            .Select(selector);
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -79,6 +80,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, TRet>(
         this TSender sender,
@@ -107,6 +109,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, TRet>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -116,8 +119,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(property1, property2, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber)
-            .Select(t => selector(t.Property1, t.Property2));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -139,6 +141,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, TRet>(
         this TSender sender,
@@ -172,6 +175,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, TRet>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -182,12 +186,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(
-            property1,
-            property2,
-            property3,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => selector(t.Property1, t.Property2, t.Property3));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -212,6 +211,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, TRet>(
         this TSender sender,
@@ -250,6 +250,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, TRet>(
         this TSender sender,
@@ -262,13 +263,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(
-            property1,
-            property2,
-            property3,
-            property4,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => selector(t.Property1, t.Property2, t.Property3, t.Property4));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -296,6 +291,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, TRet>(
@@ -340,6 +336,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, TRet>(
         this TSender sender,
@@ -353,14 +350,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => selector(t.Property1, t.Property2, t.Property3, t.Property4, t.Property5));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -391,6 +381,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, TRet>(
@@ -440,6 +431,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, TRet>(
         this TSender sender,
@@ -454,15 +446,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => selector(t.Property1, t.Property2, t.Property3, t.Property4, t.Property5, t.Property6));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -496,6 +480,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, TRet>(
@@ -550,6 +535,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, TRet>(
         this TSender sender,
@@ -565,23 +551,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => selector(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -618,6 +588,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, TRet>(
@@ -677,6 +648,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, TRet>(
         this TSender sender,
@@ -693,25 +665,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => selector(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -751,6 +705,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, TRet>(
@@ -815,6 +770,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, TRet>(
         this TSender sender,
@@ -832,27 +788,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => selector(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -895,6 +831,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TRet>(
@@ -964,6 +901,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TRet>(
         this TSender sender,
@@ -982,29 +920,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => selector(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1050,6 +966,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TRet>(
@@ -1124,6 +1041,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TRet>(
         this TSender sender,
@@ -1143,31 +1061,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => selector(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1216,6 +1110,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TRet>(
@@ -1295,6 +1190,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TRet>(
         this TSender sender,
@@ -1315,33 +1211,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => selector(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1393,6 +1263,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TRet>(
@@ -1477,6 +1348,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TRet>(
         this TSender sender,
@@ -1498,35 +1370,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            property13,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => selector(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12,
-                t.Property13));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1581,6 +1425,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<
@@ -1686,6 +1531,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TRet>(
         this TSender sender,
@@ -1708,37 +1554,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            property13,
-            property14,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => selector(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12,
-                t.Property13,
-                t.Property14));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1796,6 +1612,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<
@@ -1907,6 +1724,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TRet>(
         this TSender sender,
@@ -1930,39 +1748,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            property13,
-            property14,
-            property15,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => selector(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12,
-                t.Property13,
-                t.Property14,
-                t.Property15));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -2023,6 +1809,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TRet> WhenAnyValue<
@@ -2140,6 +1927,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the selector result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TRet> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TRet>(
         this TSender sender,
@@ -2164,39 +1952,5 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TSender : class
 #endif
-        => sender.WhenAnyValue(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            property13,
-            property14,
-            property15,
-            property16,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => selector(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12,
-                t.Property13,
-                t.Property14,
-                t.Property15,
-                t.Property16));
+        => throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
 }

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyValue.WideArity.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyValue.WideArity.Unsafe.cs
@@ -1,0 +1,1092 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+/// <summary>Observes property chains by reflection, for expressions the generator could not read (WhenAnyValue).</summary>
+/// <remarks>
+/// These are the opt-in half of <c>WhenAnyValue</c>. The unsuffixed overloads resolve at compile time and throw when no
+/// generated dispatch claimed the call site; these walk the chain by reflection instead, and say so, so a
+/// consumer publishing trimmed or ahead-of-time sees the requirement at their own call site.
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>
+    /// Observes a property on the specified sender and emits its value after it changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <returns>An observable sequence that emits the property value when it changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<T1> WhenAnyValueUnsafe<TSender, T1>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+
+        return RuntimeObservationFallback.WhenAnyValue(sender, property1);
+    }
+
+    /// <summary>
+    /// Observes 2 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2>> WhenAnyValueUnsafe<TSender, T1, T2>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            static (v1, v2) => new PropertyValues<T1, T2>(v1, v2));
+    }
+
+    /// <summary>
+    /// Observes 3 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3>> WhenAnyValueUnsafe<TSender, T1, T2, T3>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            RuntimeObservationFallback.WhenAnyValue(sender, property3),
+            static (v1, v2, v3) => new PropertyValues<T1, T2, T3>(v1, v2, v3));
+    }
+
+    /// <summary>
+    /// Observes 4 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4>> WhenAnyValueUnsafe<
+        TSender,
+        T1,
+        T2,
+        T3,
+        T4>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            RuntimeObservationFallback.WhenAnyValue(sender, property3),
+            RuntimeObservationFallback.WhenAnyValue(sender, property4),
+            static (v1, v2, v3, v4) => new PropertyValues<T1, T2, T3, T4>(v1, v2, v3, v4));
+    }
+
+    /// <summary>
+    /// Observes 5 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5>> WhenAnyValueUnsafe<
+        TSender,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            RuntimeObservationFallback.WhenAnyValue(sender, property3),
+            RuntimeObservationFallback.WhenAnyValue(sender, property4),
+            RuntimeObservationFallback.WhenAnyValue(sender, property5),
+            static (v1, v2, v3, v4, v5) => new PropertyValues<T1, T2, T3, T4, T5>(v1, v2, v3, v4, v5));
+    }
+
+    /// <summary>
+    /// Observes 6 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6>> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            RuntimeObservationFallback.WhenAnyValue(sender, property3),
+            RuntimeObservationFallback.WhenAnyValue(sender, property4),
+            RuntimeObservationFallback.WhenAnyValue(sender, property5),
+            RuntimeObservationFallback.WhenAnyValue(sender, property6),
+            static (v1, v2, v3, v4, v5, v6) => new PropertyValues<T1, T2, T3, T4, T5, T6>(v1, v2, v3, v4, v5, v6));
+    }
+
+    /// <summary>
+    /// Observes 7 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7>> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6, T7>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            RuntimeObservationFallback.WhenAnyValue(sender, property3),
+            RuntimeObservationFallback.WhenAnyValue(sender, property4),
+            RuntimeObservationFallback.WhenAnyValue(sender, property5),
+            RuntimeObservationFallback.WhenAnyValue(sender, property6),
+            RuntimeObservationFallback.WhenAnyValue(sender, property7),
+            static (v1, v2, v3, v4, v5, v6, v7) => new PropertyValues<T1, T2, T3, T4, T5, T6, T7>(v1, v2, v3, v4, v5, v6, v7));
+    }
+
+    /// <summary>
+    /// Observes 8 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8>> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6, T7, T8>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            RuntimeObservationFallback.WhenAnyValue(sender, property3),
+            RuntimeObservationFallback.WhenAnyValue(sender, property4),
+            RuntimeObservationFallback.WhenAnyValue(sender, property5),
+            RuntimeObservationFallback.WhenAnyValue(sender, property6),
+            RuntimeObservationFallback.WhenAnyValue(sender, property7),
+            RuntimeObservationFallback.WhenAnyValue(sender, property8),
+            static (v1, v2, v3, v4, v5, v6, v7, v8) => new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8>(v1, v2, v3, v4, v5, v6, v7, v8));
+    }
+
+    /// <summary>
+    /// Observes 9 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9>> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            RuntimeObservationFallback.WhenAnyValue(sender, property3),
+            RuntimeObservationFallback.WhenAnyValue(sender, property4),
+            RuntimeObservationFallback.WhenAnyValue(sender, property5),
+            RuntimeObservationFallback.WhenAnyValue(sender, property6),
+            RuntimeObservationFallback.WhenAnyValue(sender, property7),
+            RuntimeObservationFallback.WhenAnyValue(sender, property8),
+            RuntimeObservationFallback.WhenAnyValue(sender, property9),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9>(v1, v2, v3, v4, v5, v6, v7, v8, v9));
+    }
+
+    /// <summary>
+    /// Observes 10 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            RuntimeObservationFallback.WhenAnyValue(sender, property3),
+            RuntimeObservationFallback.WhenAnyValue(sender, property4),
+            RuntimeObservationFallback.WhenAnyValue(sender, property5),
+            RuntimeObservationFallback.WhenAnyValue(sender, property6),
+            RuntimeObservationFallback.WhenAnyValue(sender, property7),
+            RuntimeObservationFallback.WhenAnyValue(sender, property8),
+            RuntimeObservationFallback.WhenAnyValue(sender, property9),
+            RuntimeObservationFallback.WhenAnyValue(sender, property10),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10));
+    }
+
+    /// <summary>
+    /// Observes 11 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> WhenAnyValueUnsafe<
+                TSender,
+                T1,
+                T2,
+                T3,
+                T4,
+                T5,
+                T6,
+                T7,
+                T8,
+                T9,
+                T10,
+                T11>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Expression<Func<TSender, T11>> property11)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            RuntimeObservationFallback.WhenAnyValue(sender, property3),
+            RuntimeObservationFallback.WhenAnyValue(sender, property4),
+            RuntimeObservationFallback.WhenAnyValue(sender, property5),
+            RuntimeObservationFallback.WhenAnyValue(sender, property6),
+            RuntimeObservationFallback.WhenAnyValue(sender, property7),
+            RuntimeObservationFallback.WhenAnyValue(sender, property8),
+            RuntimeObservationFallback.WhenAnyValue(sender, property9),
+            RuntimeObservationFallback.WhenAnyValue(sender, property10),
+            RuntimeObservationFallback.WhenAnyValue(sender, property11),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11));
+    }
+
+    /// <summary>
+    /// Observes 12 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> WhenAnyValueUnsafe<
+                TSender,
+                T1,
+                T2,
+                T3,
+                T4,
+                T5,
+                T6,
+                T7,
+                T8,
+                T9,
+                T10,
+                T11,
+                T12>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Expression<Func<TSender, T11>> property11,
+        Expression<Func<TSender, T12>> property12)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            RuntimeObservationFallback.WhenAnyValue(sender, property3),
+            RuntimeObservationFallback.WhenAnyValue(sender, property4),
+            RuntimeObservationFallback.WhenAnyValue(sender, property5),
+            RuntimeObservationFallback.WhenAnyValue(sender, property6),
+            RuntimeObservationFallback.WhenAnyValue(sender, property7),
+            RuntimeObservationFallback.WhenAnyValue(sender, property8),
+            RuntimeObservationFallback.WhenAnyValue(sender, property9),
+            RuntimeObservationFallback.WhenAnyValue(sender, property10),
+            RuntimeObservationFallback.WhenAnyValue(sender, property11),
+            RuntimeObservationFallback.WhenAnyValue(sender, property12),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12));
+    }
+
+    /// <summary>
+    /// Observes 13 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> WhenAnyValueUnsafe<
+                TSender,
+                T1,
+                T2,
+                T3,
+                T4,
+                T5,
+                T6,
+                T7,
+                T8,
+                T9,
+                T10,
+                T11,
+                T12,
+                T13>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Expression<Func<TSender, T11>> property11,
+        Expression<Func<TSender, T12>> property12,
+        Expression<Func<TSender, T13>> property13)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+        ArgumentExceptionHelper.ThrowIfNull(property13);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            RuntimeObservationFallback.WhenAnyValue(sender, property3),
+            RuntimeObservationFallback.WhenAnyValue(sender, property4),
+            RuntimeObservationFallback.WhenAnyValue(sender, property5),
+            RuntimeObservationFallback.WhenAnyValue(sender, property6),
+            RuntimeObservationFallback.WhenAnyValue(sender, property7),
+            RuntimeObservationFallback.WhenAnyValue(sender, property8),
+            RuntimeObservationFallback.WhenAnyValue(sender, property9),
+            RuntimeObservationFallback.WhenAnyValue(sender, property10),
+            RuntimeObservationFallback.WhenAnyValue(sender, property11),
+            RuntimeObservationFallback.WhenAnyValue(sender, property12),
+            RuntimeObservationFallback.WhenAnyValue(sender, property13),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) =>
+
+                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13));
+    }
+
+    /// <summary>
+    /// Observes 14 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Expression<Func<TSender, T11>> property11,
+        Expression<Func<TSender, T12>> property12,
+        Expression<Func<TSender, T13>> property13,
+        Expression<Func<TSender, T14>> property14)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+        ArgumentExceptionHelper.ThrowIfNull(property13);
+        ArgumentExceptionHelper.ThrowIfNull(property14);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            RuntimeObservationFallback.WhenAnyValue(sender, property3),
+            RuntimeObservationFallback.WhenAnyValue(sender, property4),
+            RuntimeObservationFallback.WhenAnyValue(sender, property5),
+            RuntimeObservationFallback.WhenAnyValue(sender, property6),
+            RuntimeObservationFallback.WhenAnyValue(sender, property7),
+            RuntimeObservationFallback.WhenAnyValue(sender, property8),
+            RuntimeObservationFallback.WhenAnyValue(sender, property9),
+            RuntimeObservationFallback.WhenAnyValue(sender, property10),
+            RuntimeObservationFallback.WhenAnyValue(sender, property11),
+            RuntimeObservationFallback.WhenAnyValue(sender, property12),
+            RuntimeObservationFallback.WhenAnyValue(sender, property13),
+            RuntimeObservationFallback.WhenAnyValue(sender, property14),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) =>
+
+                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14));
+    }
+
+    /// <summary>
+    /// Observes 15 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="T15">The type of the fifteenth observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="property15">An expression that selects the fifteenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>
+        WhenAnyValueUnsafe<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Expression<Func<TSender, T11>> property11,
+        Expression<Func<TSender, T12>> property12,
+        Expression<Func<TSender, T13>> property13,
+        Expression<Func<TSender, T14>> property14,
+        Expression<Func<TSender, T15>> property15)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+        ArgumentExceptionHelper.ThrowIfNull(property13);
+        ArgumentExceptionHelper.ThrowIfNull(property14);
+        ArgumentExceptionHelper.ThrowIfNull(property15);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            RuntimeObservationFallback.WhenAnyValue(sender, property3),
+            RuntimeObservationFallback.WhenAnyValue(sender, property4),
+            RuntimeObservationFallback.WhenAnyValue(sender, property5),
+            RuntimeObservationFallback.WhenAnyValue(sender, property6),
+            RuntimeObservationFallback.WhenAnyValue(sender, property7),
+            RuntimeObservationFallback.WhenAnyValue(sender, property8),
+            RuntimeObservationFallback.WhenAnyValue(sender, property9),
+            RuntimeObservationFallback.WhenAnyValue(sender, property10),
+            RuntimeObservationFallback.WhenAnyValue(sender, property11),
+            RuntimeObservationFallback.WhenAnyValue(sender, property12),
+            RuntimeObservationFallback.WhenAnyValue(sender, property13),
+            RuntimeObservationFallback.WhenAnyValue(sender, property14),
+            RuntimeObservationFallback.WhenAnyValue(sender, property15),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) =>
+
+                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15));
+    }
+
+    /// <summary>
+    /// Observes 16 properties of the specified sender and emits their values as a tuple after any property changes. This is a ReactiveUI compatibility shim.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="T15">The type of the fifteenth observed property value.</typeparam>
+    /// <typeparam name="T16">The type of the sixteenth observed property value.</typeparam>
+    /// <param name="sender">The sender instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="property15">An expression that selects the fifteenth property to observe.</param>
+    /// <param name="property16">An expression that selects the sixteenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> WhenAnyValueUnsafe<
+                TSender,
+                T1,
+                T2,
+                T3,
+                T4,
+                T5,
+                T6,
+                T7,
+                T8,
+                T9,
+                T10,
+                T11,
+                T12,
+                T13,
+                T14,
+                T15,
+                T16>(
+        this TSender sender,
+        Expression<Func<TSender, T1>> property1,
+        Expression<Func<TSender, T2>> property2,
+        Expression<Func<TSender, T3>> property3,
+        Expression<Func<TSender, T4>> property4,
+        Expression<Func<TSender, T5>> property5,
+        Expression<Func<TSender, T6>> property6,
+        Expression<Func<TSender, T7>> property7,
+        Expression<Func<TSender, T8>> property8,
+        Expression<Func<TSender, T9>> property9,
+        Expression<Func<TSender, T10>> property10,
+        Expression<Func<TSender, T11>> property11,
+        Expression<Func<TSender, T12>> property12,
+        Expression<Func<TSender, T13>> property13,
+        Expression<Func<TSender, T14>> property14,
+        Expression<Func<TSender, T15>> property15,
+        Expression<Func<TSender, T16>> property16)
+        where TSender : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sender);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+        ArgumentExceptionHelper.ThrowIfNull(property13);
+        ArgumentExceptionHelper.ThrowIfNull(property14);
+        ArgumentExceptionHelper.ThrowIfNull(property15);
+        ArgumentExceptionHelper.ThrowIfNull(property16);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenAnyValue(sender, property1),
+            RuntimeObservationFallback.WhenAnyValue(sender, property2),
+            RuntimeObservationFallback.WhenAnyValue(sender, property3),
+            RuntimeObservationFallback.WhenAnyValue(sender, property4),
+            RuntimeObservationFallback.WhenAnyValue(sender, property5),
+            RuntimeObservationFallback.WhenAnyValue(sender, property6),
+            RuntimeObservationFallback.WhenAnyValue(sender, property7),
+            RuntimeObservationFallback.WhenAnyValue(sender, property8),
+            RuntimeObservationFallback.WhenAnyValue(sender, property9),
+            RuntimeObservationFallback.WhenAnyValue(sender, property10),
+            RuntimeObservationFallback.WhenAnyValue(sender, property11),
+            RuntimeObservationFallback.WhenAnyValue(sender, property12),
+            RuntimeObservationFallback.WhenAnyValue(sender, property13),
+            RuntimeObservationFallback.WhenAnyValue(sender, property14),
+            RuntimeObservationFallback.WhenAnyValue(sender, property15),
+            RuntimeObservationFallback.WhenAnyValue(sender, property16),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16));
+    }
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyValue.WideArity.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenAnyValue.WideArity.cs
@@ -13,6 +13,10 @@ namespace ReactiveUI.Binding;
 /// <summary>Extension methods for observing property changes using ReactiveUI conventions (WhenAnyValue).</summary>
 public static partial class ReactiveUIBindingExtensions
 {
+    /// <summary>Reported when no generated dispatch claimed a WhenAnyValue call site.</summary>
+    private const string NoWhenAnyValueDispatchMessage =
+        "No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.";
+
 #if NET8_0_OR_GREATER
     /// <summary>
     /// Observes a property on the specified sender and emits its value after it changes. This is a ReactiveUI compatibility shim.
@@ -25,6 +29,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the property value when it changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     public static IObservable<T1> WhenAnyValue<TSender, T1>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -44,6 +49,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the property value when it changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     public static IObservable<T1> WhenAnyValue<TSender, T1>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -52,10 +58,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-
-        return RuntimeObservationFallback.WhenAnyValue(sender, property1);
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -73,6 +76,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     public static IObservable<PropertyValues<T1, T2>> WhenAnyValue<TSender, T1, T2>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -97,6 +101,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     public static IObservable<PropertyValues<T1, T2>> WhenAnyValue<TSender, T1, T2>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -106,14 +111,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            static (v1, v2) => new PropertyValues<T1, T2>(v1, v2));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -134,6 +132,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3>> WhenAnyValue<TSender, T1, T2, T3>(
         this TSender sender,
@@ -164,6 +163,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     public static IObservable<PropertyValues<T1, T2, T3>> WhenAnyValue<TSender, T1, T2, T3>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -174,16 +174,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            RuntimeObservationFallback.WhenAnyValue(sender, property3),
-            static (v1, v2, v3) => new PropertyValues<T1, T2, T3>(v1, v2, v3));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -207,6 +198,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4>> WhenAnyValue<
@@ -248,6 +240,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     public static IObservable<PropertyValues<T1, T2, T3, T4>> WhenAnyValue<TSender, T1, T2, T3, T4>(
         this TSender sender,
         Expression<Func<TSender, T1>> property1,
@@ -259,18 +252,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            RuntimeObservationFallback.WhenAnyValue(sender, property3),
-            RuntimeObservationFallback.WhenAnyValue(sender, property4),
-            static (v1, v2, v3, v4) => new PropertyValues<T1, T2, T3, T4>(v1, v2, v3, v4));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -297,6 +279,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5>> WhenAnyValue<
@@ -344,6 +327,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5>> WhenAnyValue<TSender, T1, T2, T3, T4, T5>(
         this TSender sender,
@@ -357,20 +341,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            RuntimeObservationFallback.WhenAnyValue(sender, property3),
-            RuntimeObservationFallback.WhenAnyValue(sender, property4),
-            RuntimeObservationFallback.WhenAnyValue(sender, property5),
-            static (v1, v2, v3, v4, v5) => new PropertyValues<T1, T2, T3, T4, T5>(v1, v2, v3, v4, v5));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -400,6 +371,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6>>
@@ -447,6 +419,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6>> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6>(
         this TSender sender,
@@ -461,22 +434,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            RuntimeObservationFallback.WhenAnyValue(sender, property3),
-            RuntimeObservationFallback.WhenAnyValue(sender, property4),
-            RuntimeObservationFallback.WhenAnyValue(sender, property5),
-            RuntimeObservationFallback.WhenAnyValue(sender, property6),
-            static (v1, v2, v3, v4, v5, v6) => new PropertyValues<T1, T2, T3, T4, T5, T6>(v1, v2, v3, v4, v5, v6));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -509,6 +467,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -562,6 +521,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7>> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7>(
         this TSender sender,
@@ -577,24 +537,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            RuntimeObservationFallback.WhenAnyValue(sender, property3),
-            RuntimeObservationFallback.WhenAnyValue(sender, property4),
-            RuntimeObservationFallback.WhenAnyValue(sender, property5),
-            RuntimeObservationFallback.WhenAnyValue(sender, property6),
-            RuntimeObservationFallback.WhenAnyValue(sender, property7),
-            static (v1, v2, v3, v4, v5, v6, v7) => new PropertyValues<T1, T2, T3, T4, T5, T6, T7>(v1, v2, v3, v4, v5, v6, v7));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -630,6 +573,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -687,6 +631,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8>> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8>(
         this TSender sender,
@@ -703,26 +648,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            RuntimeObservationFallback.WhenAnyValue(sender, property3),
-            RuntimeObservationFallback.WhenAnyValue(sender, property4),
-            RuntimeObservationFallback.WhenAnyValue(sender, property5),
-            RuntimeObservationFallback.WhenAnyValue(sender, property6),
-            RuntimeObservationFallback.WhenAnyValue(sender, property7),
-            RuntimeObservationFallback.WhenAnyValue(sender, property8),
-            static (v1, v2, v3, v4, v5, v6, v7, v8) => new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8>(v1, v2, v3, v4, v5, v6, v7, v8));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -761,6 +687,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -823,6 +750,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9>> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
         this TSender sender,
@@ -840,29 +768,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            RuntimeObservationFallback.WhenAnyValue(sender, property3),
-            RuntimeObservationFallback.WhenAnyValue(sender, property4),
-            RuntimeObservationFallback.WhenAnyValue(sender, property5),
-            RuntimeObservationFallback.WhenAnyValue(sender, property6),
-            RuntimeObservationFallback.WhenAnyValue(sender, property7),
-            RuntimeObservationFallback.WhenAnyValue(sender, property8),
-            RuntimeObservationFallback.WhenAnyValue(sender, property9),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9>(v1, v2, v3, v4, v5, v6, v7, v8, v9));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -904,6 +810,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -971,6 +878,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
         this TSender sender,
@@ -989,31 +897,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            RuntimeObservationFallback.WhenAnyValue(sender, property3),
-            RuntimeObservationFallback.WhenAnyValue(sender, property4),
-            RuntimeObservationFallback.WhenAnyValue(sender, property5),
-            RuntimeObservationFallback.WhenAnyValue(sender, property6),
-            RuntimeObservationFallback.WhenAnyValue(sender, property7),
-            RuntimeObservationFallback.WhenAnyValue(sender, property8),
-            RuntimeObservationFallback.WhenAnyValue(sender, property9),
-            RuntimeObservationFallback.WhenAnyValue(sender, property10),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1058,6 +942,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1142,6 +1027,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
         this TSender sender,
@@ -1161,33 +1047,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            RuntimeObservationFallback.WhenAnyValue(sender, property3),
-            RuntimeObservationFallback.WhenAnyValue(sender, property4),
-            RuntimeObservationFallback.WhenAnyValue(sender, property5),
-            RuntimeObservationFallback.WhenAnyValue(sender, property6),
-            RuntimeObservationFallback.WhenAnyValue(sender, property7),
-            RuntimeObservationFallback.WhenAnyValue(sender, property8),
-            RuntimeObservationFallback.WhenAnyValue(sender, property9),
-            RuntimeObservationFallback.WhenAnyValue(sender, property10),
-            RuntimeObservationFallback.WhenAnyValue(sender, property11),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1235,6 +1095,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1325,6 +1186,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
@@ -1346,35 +1208,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            RuntimeObservationFallback.WhenAnyValue(sender, property3),
-            RuntimeObservationFallback.WhenAnyValue(sender, property4),
-            RuntimeObservationFallback.WhenAnyValue(sender, property5),
-            RuntimeObservationFallback.WhenAnyValue(sender, property6),
-            RuntimeObservationFallback.WhenAnyValue(sender, property7),
-            RuntimeObservationFallback.WhenAnyValue(sender, property8),
-            RuntimeObservationFallback.WhenAnyValue(sender, property9),
-            RuntimeObservationFallback.WhenAnyValue(sender, property10),
-            RuntimeObservationFallback.WhenAnyValue(sender, property11),
-            RuntimeObservationFallback.WhenAnyValue(sender, property12),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1425,6 +1259,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1521,6 +1356,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
@@ -1543,38 +1379,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-        ArgumentExceptionHelper.ThrowIfNull(property13);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            RuntimeObservationFallback.WhenAnyValue(sender, property3),
-            RuntimeObservationFallback.WhenAnyValue(sender, property4),
-            RuntimeObservationFallback.WhenAnyValue(sender, property5),
-            RuntimeObservationFallback.WhenAnyValue(sender, property6),
-            RuntimeObservationFallback.WhenAnyValue(sender, property7),
-            RuntimeObservationFallback.WhenAnyValue(sender, property8),
-            RuntimeObservationFallback.WhenAnyValue(sender, property9),
-            RuntimeObservationFallback.WhenAnyValue(sender, property10),
-            RuntimeObservationFallback.WhenAnyValue(sender, property11),
-            RuntimeObservationFallback.WhenAnyValue(sender, property12),
-            RuntimeObservationFallback.WhenAnyValue(sender, property13),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) =>
-
-                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1628,6 +1433,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1716,6 +1522,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
@@ -1739,40 +1546,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-        ArgumentExceptionHelper.ThrowIfNull(property13);
-        ArgumentExceptionHelper.ThrowIfNull(property14);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            RuntimeObservationFallback.WhenAnyValue(sender, property3),
-            RuntimeObservationFallback.WhenAnyValue(sender, property4),
-            RuntimeObservationFallback.WhenAnyValue(sender, property5),
-            RuntimeObservationFallback.WhenAnyValue(sender, property6),
-            RuntimeObservationFallback.WhenAnyValue(sender, property7),
-            RuntimeObservationFallback.WhenAnyValue(sender, property8),
-            RuntimeObservationFallback.WhenAnyValue(sender, property9),
-            RuntimeObservationFallback.WhenAnyValue(sender, property10),
-            RuntimeObservationFallback.WhenAnyValue(sender, property11),
-            RuntimeObservationFallback.WhenAnyValue(sender, property12),
-            RuntimeObservationFallback.WhenAnyValue(sender, property13),
-            RuntimeObservationFallback.WhenAnyValue(sender, property14),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) =>
-
-                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1829,6 +1603,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1921,6 +1696,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> WhenAnyValue<TSender, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
@@ -1945,42 +1721,7 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-        ArgumentExceptionHelper.ThrowIfNull(property13);
-        ArgumentExceptionHelper.ThrowIfNull(property14);
-        ArgumentExceptionHelper.ThrowIfNull(property15);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            RuntimeObservationFallback.WhenAnyValue(sender, property3),
-            RuntimeObservationFallback.WhenAnyValue(sender, property4),
-            RuntimeObservationFallback.WhenAnyValue(sender, property5),
-            RuntimeObservationFallback.WhenAnyValue(sender, property6),
-            RuntimeObservationFallback.WhenAnyValue(sender, property7),
-            RuntimeObservationFallback.WhenAnyValue(sender, property8),
-            RuntimeObservationFallback.WhenAnyValue(sender, property9),
-            RuntimeObservationFallback.WhenAnyValue(sender, property10),
-            RuntimeObservationFallback.WhenAnyValue(sender, property11),
-            RuntimeObservationFallback.WhenAnyValue(sender, property12),
-            RuntimeObservationFallback.WhenAnyValue(sender, property13),
-            RuntimeObservationFallback.WhenAnyValue(sender, property14),
-            RuntimeObservationFallback.WhenAnyValue(sender, property15),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) =>
-
-                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -2040,6 +1781,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -2154,6 +1896,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenAnyValue dispatch matched this call site. Use WhenAnyValueUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<
@@ -2195,42 +1938,6 @@ public static partial class ReactiveUIBindingExtensions
         where TSender : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(sender);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-        ArgumentExceptionHelper.ThrowIfNull(property13);
-        ArgumentExceptionHelper.ThrowIfNull(property14);
-        ArgumentExceptionHelper.ThrowIfNull(property15);
-        ArgumentExceptionHelper.ThrowIfNull(property16);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenAnyValue(sender, property1),
-            RuntimeObservationFallback.WhenAnyValue(sender, property2),
-            RuntimeObservationFallback.WhenAnyValue(sender, property3),
-            RuntimeObservationFallback.WhenAnyValue(sender, property4),
-            RuntimeObservationFallback.WhenAnyValue(sender, property5),
-            RuntimeObservationFallback.WhenAnyValue(sender, property6),
-            RuntimeObservationFallback.WhenAnyValue(sender, property7),
-            RuntimeObservationFallback.WhenAnyValue(sender, property8),
-            RuntimeObservationFallback.WhenAnyValue(sender, property9),
-            RuntimeObservationFallback.WhenAnyValue(sender, property10),
-            RuntimeObservationFallback.WhenAnyValue(sender, property11),
-            RuntimeObservationFallback.WhenAnyValue(sender, property12),
-            RuntimeObservationFallback.WhenAnyValue(sender, property13),
-            RuntimeObservationFallback.WhenAnyValue(sender, property14),
-            RuntimeObservationFallback.WhenAnyValue(sender, property15),
-            RuntimeObservationFallback.WhenAnyValue(sender, property16),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16));
+        throw new InvalidOperationException(NoWhenAnyValueDispatchMessage);
     }
 }

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanged.Selectors.WideArity.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanged.Selectors.WideArity.Unsafe.cs
@@ -1,0 +1,1024 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+
+/// <summary>Resolves a WhenChanged expression by reflection, for a call site the generator could not read.</summary>
+/// <remarks>
+/// The opt-in half of <c>WhenChanged</c>. The unsuffixed overloads resolve at compile time and throw when no generated
+/// dispatch claimed the call site; these walk the chain by reflection instead, and are annotated so a consumer
+/// publishing trimmed or ahead-of-time sees the requirement at their own call site.
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>
+    /// Observes changes on 2 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<TObj, T1, T2, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Func<T1, T2, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2).Select(t => conversionFunc(t.Property1, t.Property2));
+
+    /// <summary>
+    /// Observes changes on 3 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<TObj, T1, T2, T3, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Func<T1, T2, T3, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2,
+            property3).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3));
+
+    /// <summary>
+    /// Observes changes on 4 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<TObj, T1, T2, T3, T4, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Func<T1, T2, T3, T4, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2,
+            property3,
+            property4).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3, t.Property4));
+
+    /// <summary>
+    /// Observes changes on 5 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Func<T1, T2, T3, T4, T5, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3, t.Property4, t.Property5));
+
+    /// <summary>
+    /// Observes changes on 6 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, T6, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Func<T1, T2, T3, T4, T5, T6, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3, t.Property4, t.Property5, t.Property6));
+
+    /// <summary>
+    /// Observes changes on 7 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Func<T1, T2, T3, T4, T5, T6, T7, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7));
+
+    /// <summary>
+    /// Observes changes on 8 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8));
+
+    /// <summary>
+    /// Observes changes on 9 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9));
+
+    /// <summary>
+    /// Observes changes on 10 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10));
+
+    /// <summary>
+    /// Observes changes on 11 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11));
+
+    /// <summary>
+    /// Observes changes on 12 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12));
+
+    /// <summary>
+    /// Observes changes on 13 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<
+        TObj,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12,
+            property13).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12,
+                t.Property13));
+
+    /// <summary>
+    /// Observes changes on 14 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<
+        TObj,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13,
+        Expression<Func<TObj, T14>> property14,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12,
+            property13,
+            property14).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12,
+                t.Property13,
+                t.Property14));
+
+    /// <summary>
+    /// Observes changes on 15 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="T15">The type of the fifteenth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="property15">An expression that selects the fifteenth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<
+        TObj,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13,
+        Expression<Func<TObj, T14>> property14,
+        Expression<Func<TObj, T15>> property15,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12,
+            property13,
+            property14,
+            property15).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12,
+                t.Property13,
+                t.Property14,
+                t.Property15));
+
+    /// <summary>
+    /// Observes changes on 16 properties on the specified object and applies a conversion function to produce a result after any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="T15">The type of the fifteenth observed property value.</typeparam>
+    /// <typeparam name="T16">The type of the sixteenth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="property15">An expression that selects the fifteenth property to observe.</param>
+    /// <param name="property16">An expression that selects the sixteenth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangedUnsafe<
+        TObj,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13,
+        Expression<Func<TObj, T14>> property14,
+        Expression<Func<TObj, T15>> property15,
+        Expression<Func<TObj, T16>> property16,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangedUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12,
+            property13,
+            property14,
+            property15,
+            property16).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12,
+                t.Property13,
+                t.Property14,
+                t.Property15,
+                t.Property16));
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanged.Selectors.WideArity.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanged.Selectors.WideArity.cs
@@ -30,6 +30,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, TReturn>(
         this TObj objectToMonitor,
@@ -58,6 +59,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, TReturn>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -67,11 +69,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(t.Property1, t.Property2));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -93,6 +91,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, TReturn>(
         this TObj objectToMonitor,
@@ -126,6 +125,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, TReturn>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -136,12 +136,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            property3,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -166,6 +161,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, TReturn>(
         this TObj objectToMonitor,
@@ -204,6 +200,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, TReturn>(
         this TObj objectToMonitor,
@@ -216,13 +213,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            property3,
-            property4,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3, t.Property4));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -250,6 +241,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, TReturn>(
@@ -294,6 +286,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, TReturn>(
         this TObj objectToMonitor,
@@ -307,14 +300,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3, t.Property4, t.Property5));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -345,6 +331,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, TReturn>(
@@ -394,6 +381,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, TReturn>(
         this TObj objectToMonitor,
@@ -408,15 +396,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3, t.Property4, t.Property5, t.Property6));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -450,6 +430,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, TReturn>(
@@ -504,6 +485,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, TReturn>(
         this TObj objectToMonitor,
@@ -519,23 +501,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -572,6 +538,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(
@@ -631,6 +598,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(
         this TObj objectToMonitor,
@@ -647,25 +615,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -705,6 +655,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn>(
@@ -769,6 +720,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn>(
         this TObj objectToMonitor,
@@ -786,27 +738,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -849,6 +781,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TReturn>(
@@ -918,6 +851,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TReturn>(
         this TObj objectToMonitor,
@@ -936,29 +870,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1004,6 +916,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn>(
@@ -1078,6 +991,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn>(
         this TObj objectToMonitor,
@@ -1097,31 +1011,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1170,6 +1060,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn>(
@@ -1249,6 +1140,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn>(
         this TObj objectToMonitor,
@@ -1269,33 +1161,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1347,6 +1213,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<
@@ -1446,6 +1313,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TReturn>(
         this TObj objectToMonitor,
@@ -1467,35 +1335,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            property13,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12,
-                t.Property13));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1550,6 +1390,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<
@@ -1655,6 +1496,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TReturn>(
         this TObj objectToMonitor,
@@ -1677,37 +1519,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            property13,
-            property14,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12,
-                t.Property13,
-                t.Property14));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1765,6 +1577,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<
@@ -1876,6 +1689,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TReturn>(
         this TObj objectToMonitor,
@@ -1899,39 +1713,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            property13,
-            property14,
-            property15,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12,
-                t.Property13,
-                t.Property14,
-                t.Property15));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1992,6 +1774,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanged<
@@ -2109,6 +1892,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result when any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TReturn>(
         this TObj objectToMonitor,
@@ -2133,39 +1917,5 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanged(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            property13,
-            property14,
-            property15,
-            property16,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12,
-                t.Property13,
-                t.Property14,
-                t.Property15,
-                t.Property16));
+        => throw new InvalidOperationException(NoWhenChangedDispatchMessage);
 }

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanged.WideArity.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanged.WideArity.Unsafe.cs
@@ -1,0 +1,1053 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+/// <summary>Observes property chains by reflection, for expressions the generator could not read (WhenChanged).</summary>
+/// <remarks>
+/// These are the opt-in half of <c>WhenChanged</c>. The unsuffixed overloads resolve at compile time and throw when no
+/// generated dispatch claimed the call site; these walk the chain by reflection instead, and say so, so a
+/// consumer publishing trimmed or ahead-of-time sees the requirement at their own call site.
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>Observes a property change on the specified object and emits the value after it changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <returns>An observable sequence that emits the property value when it changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<T1> WhenChangedUnsafe<TObj, T1>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+
+        return RuntimeObservationFallback.WhenChanged(objectToMonitor, property1);
+    }
+
+    /// <summary>Observes changes on 2 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2>> WhenChangedUnsafe<TObj, T1, T2>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+
+        return RuntimeObservationFallback.WhenChanged(objectToMonitor, property1, property2);
+    }
+
+    /// <summary>Observes changes on 3 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3>> WhenChangedUnsafe<TObj, T1, T2, T3>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+
+        return RuntimeObservationFallback.WhenChanged(objectToMonitor, property1, property2, property3);
+    }
+
+    /// <summary>Observes changes on 4 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4>> WhenChangedUnsafe<
+        TObj,
+        T1,
+        T2,
+        T3,
+        T4>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
+            static (v1, v2, v3, v4) => new PropertyValues<T1, T2, T3, T4>(v1, v2, v3, v4));
+    }
+
+    /// <summary>Observes changes on 5 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5>> WhenChangedUnsafe<
+        TObj,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
+            static (v1, v2, v3, v4, v5) => new PropertyValues<T1, T2, T3, T4, T5>(v1, v2, v3, v4, v5));
+    }
+
+    /// <summary>Observes changes on 6 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6>> WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, T6>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
+            static (v1, v2, v3, v4, v5, v6) => new PropertyValues<T1, T2, T3, T4, T5, T6>(v1, v2, v3, v4, v5, v6));
+    }
+
+    /// <summary>Observes changes on 7 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7>> WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
+            static (v1, v2, v3, v4, v5, v6, v7) => new PropertyValues<T1, T2, T3, T4, T5, T6, T7>(v1, v2, v3, v4, v5, v6, v7));
+    }
+
+    /// <summary>Observes changes on 8 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8>> WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
+            static (v1, v2, v3, v4, v5, v6, v7, v8) => new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8>(v1, v2, v3, v4, v5, v6, v7, v8));
+    }
+
+    /// <summary>Observes changes on 9 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9>> WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9>(v1, v2, v3, v4, v5, v6, v7, v8, v9));
+    }
+
+    /// <summary>Observes changes on 10 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property10),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10));
+    }
+
+    /// <summary>Observes changes on 11 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> WhenChangedUnsafe<
+                TObj,
+                T1,
+                T2,
+                T3,
+                T4,
+                T5,
+                T6,
+                T7,
+                T8,
+                T9,
+                T10,
+                T11>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property10),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property11),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11));
+    }
+
+    /// <summary>Observes changes on 12 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> WhenChangedUnsafe<
+                TObj,
+                T1,
+                T2,
+                T3,
+                T4,
+                T5,
+                T6,
+                T7,
+                T8,
+                T9,
+                T10,
+                T11,
+                T12>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property10),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property11),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property12),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12));
+    }
+
+    /// <summary>Observes changes on 13 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> WhenChangedUnsafe<
+                TObj,
+                T1,
+                T2,
+                T3,
+                T4,
+                T5,
+                T6,
+                T7,
+                T8,
+                T9,
+                T10,
+                T11,
+                T12,
+                T13>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+        ArgumentExceptionHelper.ThrowIfNull(property13);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property10),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property11),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property12),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property13),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) =>
+
+                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13));
+    }
+
+    /// <summary>Observes changes on 14 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13,
+        Expression<Func<TObj, T14>> property14)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+        ArgumentExceptionHelper.ThrowIfNull(property13);
+        ArgumentExceptionHelper.ThrowIfNull(property14);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property10),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property11),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property12),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property13),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property14),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) =>
+
+                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14));
+    }
+
+    /// <summary>Observes changes on 15 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="T15">The type of the fifteenth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="property15">An expression that selects the fifteenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>
+        WhenChangedUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13,
+        Expression<Func<TObj, T14>> property14,
+        Expression<Func<TObj, T15>> property15)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+        ArgumentExceptionHelper.ThrowIfNull(property13);
+        ArgumentExceptionHelper.ThrowIfNull(property14);
+        ArgumentExceptionHelper.ThrowIfNull(property15);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property10),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property11),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property12),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property13),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property14),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property15),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) =>
+
+                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15));
+    }
+
+    /// <summary>Observes changes on 16 properties on the specified object and emits their values as a tuple after any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="T15">The type of the fifteenth observed property value.</typeparam>
+    /// <typeparam name="T16">The type of the sixteenth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="property15">An expression that selects the fifteenth property to observe.</param>
+    /// <param name="property16">An expression that selects the sixteenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> WhenChangedUnsafe<
+                TObj,
+                T1,
+                T2,
+                T3,
+                T4,
+                T5,
+                T6,
+                T7,
+                T8,
+                T9,
+                T10,
+                T11,
+                T12,
+                T13,
+                T14,
+                T15,
+                T16>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13,
+        Expression<Func<TObj, T14>> property14,
+        Expression<Func<TObj, T15>> property15,
+        Expression<Func<TObj, T16>> property16)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+        ArgumentExceptionHelper.ThrowIfNull(property13);
+        ArgumentExceptionHelper.ThrowIfNull(property14);
+        ArgumentExceptionHelper.ThrowIfNull(property15);
+        ArgumentExceptionHelper.ThrowIfNull(property16);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property10),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property11),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property12),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property13),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property14),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property15),
+            RuntimeObservationFallback.WhenChanged(objectToMonitor, property16),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16));
+    }
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanged.WideArity.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanged.WideArity.cs
@@ -13,6 +13,10 @@ namespace ReactiveUI.Binding;
 /// <summary>Extension methods for observing property changes after they occur (WhenChanged).</summary>
 public static partial class ReactiveUIBindingExtensions
 {
+    /// <summary>Reported when no generated dispatch claimed a WhenChanged call site.</summary>
+    private const string NoWhenChangedDispatchMessage =
+        "No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.";
+
 #if NET8_0_OR_GREATER
     /// <summary>Observes a property change on the specified object and emits the value after it changes.</summary>
     /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
@@ -23,6 +27,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the property value when it changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     public static IObservable<T1> WhenChanged<TObj, T1>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -40,6 +45,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the property value when it changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     public static IObservable<T1> WhenChanged<TObj, T1>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -48,10 +54,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-
-        return RuntimeObservationFallback.WhenChanged(objectToMonitor, property1);
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -67,6 +70,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     public static IObservable<PropertyValues<T1, T2>> WhenChanged<TObj, T1, T2>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -89,6 +93,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     public static IObservable<PropertyValues<T1, T2>> WhenChanged<TObj, T1, T2>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -98,11 +103,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-
-        return RuntimeObservationFallback.WhenChanged(objectToMonitor, property1, property2);
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -121,6 +122,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3>> WhenChanged<TObj, T1, T2, T3>(
         this TObj objectToMonitor,
@@ -149,6 +151,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     public static IObservable<PropertyValues<T1, T2, T3>> WhenChanged<TObj, T1, T2, T3>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -159,12 +162,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-
-        return RuntimeObservationFallback.WhenChanged(objectToMonitor, property1, property2, property3);
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -186,6 +184,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4>> WhenChanged<
@@ -225,6 +224,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     public static IObservable<PropertyValues<T1, T2, T3, T4>> WhenChanged<TObj, T1, T2, T3, T4>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -236,18 +236,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
-            static (v1, v2, v3, v4) => new PropertyValues<T1, T2, T3, T4>(v1, v2, v3, v4));
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -272,6 +261,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5>> WhenChanged<
@@ -317,6 +307,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5>> WhenChanged<TObj, T1, T2, T3, T4, T5>(
         this TObj objectToMonitor,
@@ -330,20 +321,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
-            static (v1, v2, v3, v4, v5) => new PropertyValues<T1, T2, T3, T4, T5>(v1, v2, v3, v4, v5));
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -371,6 +349,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6>>
@@ -416,6 +395,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6>> WhenChanged<TObj, T1, T2, T3, T4, T5, T6>(
         this TObj objectToMonitor,
@@ -430,22 +410,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
-            static (v1, v2, v3, v4, v5, v6) => new PropertyValues<T1, T2, T3, T4, T5, T6>(v1, v2, v3, v4, v5, v6));
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -476,6 +441,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -527,6 +493,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7>> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7>(
         this TObj objectToMonitor,
@@ -542,24 +509,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
-            static (v1, v2, v3, v4, v5, v6, v7) => new PropertyValues<T1, T2, T3, T4, T5, T6, T7>(v1, v2, v3, v4, v5, v6, v7));
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -593,6 +543,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -648,6 +599,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8>> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8>(
         this TObj objectToMonitor,
@@ -664,26 +616,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
-            static (v1, v2, v3, v4, v5, v6, v7, v8) => new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8>(v1, v2, v3, v4, v5, v6, v7, v8));
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -720,6 +653,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -780,6 +714,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9>> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
         this TObj objectToMonitor,
@@ -797,29 +732,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9>(v1, v2, v3, v4, v5, v6, v7, v8, v9));
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -859,6 +772,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -924,6 +838,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
         this TObj objectToMonitor,
@@ -942,31 +857,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property10),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10));
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1009,6 +900,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1091,6 +983,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
         this TObj objectToMonitor,
@@ -1110,33 +1003,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property10),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property11),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11));
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1182,6 +1049,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1270,6 +1138,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
@@ -1291,35 +1160,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property10),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property11),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property12),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12));
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1368,6 +1209,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1462,6 +1304,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
@@ -1484,38 +1327,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-        ArgumentExceptionHelper.ThrowIfNull(property13);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property10),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property11),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property12),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property13),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) =>
-
-                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13));
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1567,6 +1379,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1653,6 +1466,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
@@ -1676,40 +1490,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-        ArgumentExceptionHelper.ThrowIfNull(property13);
-        ArgumentExceptionHelper.ThrowIfNull(property14);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property10),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property11),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property12),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property13),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property14),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) =>
-
-                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14));
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1764,6 +1545,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1854,6 +1636,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> WhenChanged<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
@@ -1878,42 +1661,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-        ArgumentExceptionHelper.ThrowIfNull(property13);
-        ArgumentExceptionHelper.ThrowIfNull(property14);
-        ArgumentExceptionHelper.ThrowIfNull(property15);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property10),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property11),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property12),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property13),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property14),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property15),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) =>
-
-                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15));
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1971,6 +1719,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -2083,6 +1832,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values when any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanged dispatch matched this call site. Use WhenChangedUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<
@@ -2124,42 +1874,6 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-        ArgumentExceptionHelper.ThrowIfNull(property13);
-        ArgumentExceptionHelper.ThrowIfNull(property14);
-        ArgumentExceptionHelper.ThrowIfNull(property15);
-        ArgumentExceptionHelper.ThrowIfNull(property16);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property9),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property10),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property11),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property12),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property13),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property14),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property15),
-            RuntimeObservationFallback.WhenChanged(objectToMonitor, property16),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16));
+        throw new InvalidOperationException(NoWhenChangedDispatchMessage);
     }
 }

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanging.Selectors.WideArity.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanging.Selectors.WideArity.Unsafe.cs
@@ -1,0 +1,1024 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+
+/// <summary>Resolves a WhenChanging expression by reflection, for a call site the generator could not read.</summary>
+/// <remarks>
+/// The opt-in half of <c>WhenChanging</c>. The unsuffixed overloads resolve at compile time and throw when no generated
+/// dispatch claimed the call site; these walk the chain by reflection instead, and are annotated so a consumer
+/// publishing trimmed or ahead-of-time sees the requirement at their own call site.
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>
+    /// Observes changes on 2 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<TObj, T1, T2, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Func<T1, T2, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2).Select(t => conversionFunc(t.Property1, t.Property2));
+
+    /// <summary>
+    /// Observes changes on 3 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<TObj, T1, T2, T3, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Func<T1, T2, T3, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2,
+            property3).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3));
+
+    /// <summary>
+    /// Observes changes on 4 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<TObj, T1, T2, T3, T4, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Func<T1, T2, T3, T4, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2,
+            property3,
+            property4).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3, t.Property4));
+
+    /// <summary>
+    /// Observes changes on 5 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Func<T1, T2, T3, T4, T5, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3, t.Property4, t.Property5));
+
+    /// <summary>
+    /// Observes changes on 6 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, T6, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Func<T1, T2, T3, T4, T5, T6, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3, t.Property4, t.Property5, t.Property6));
+
+    /// <summary>
+    /// Observes changes on 7 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Func<T1, T2, T3, T4, T5, T6, T7, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7));
+
+    /// <summary>
+    /// Observes changes on 8 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8));
+
+    /// <summary>
+    /// Observes changes on 9 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9));
+
+    /// <summary>
+    /// Observes changes on 10 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10));
+
+    /// <summary>
+    /// Observes changes on 11 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11));
+
+    /// <summary>
+    /// Observes changes on 12 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12));
+
+    /// <summary>
+    /// Observes changes on 13 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<
+        TObj,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12,
+            property13).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12,
+                t.Property13));
+
+    /// <summary>
+    /// Observes changes on 14 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<
+        TObj,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13,
+        Expression<Func<TObj, T14>> property14,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12,
+            property13,
+            property14).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12,
+                t.Property13,
+                t.Property14));
+
+    /// <summary>
+    /// Observes changes on 15 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="T15">The type of the fifteenth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="property15">An expression that selects the fifteenth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<
+        TObj,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13,
+        Expression<Func<TObj, T14>> property14,
+        Expression<Func<TObj, T15>> property15,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12,
+            property13,
+            property14,
+            property15).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12,
+                t.Property13,
+                t.Property14,
+                t.Property15));
+
+    /// <summary>
+    /// Observes changes on 16 properties on the specified object and applies a conversion function to produce a result before any property changes.
+    /// </summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="T15">The type of the fifteenth observed property value.</typeparam>
+    /// <typeparam name="T16">The type of the sixteenth observed property value.</typeparam>
+    /// <typeparam name="TReturn">The return type of the conversion function.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="property15">An expression that selects the fifteenth property to observe.</param>
+    /// <param name="property16">An expression that selects the sixteenth property to observe.</param>
+    /// <param name="conversionFunc">A function that converts the observed property values to the return type.</param>
+    /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<TReturn> WhenChangingUnsafe<
+        TObj,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        TReturn>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13,
+        Expression<Func<TObj, T14>> property14,
+        Expression<Func<TObj, T15>> property15,
+        Expression<Func<TObj, T16>> property16,
+        Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TReturn> conversionFunc)
+        where TObj : class
+        => objectToMonitor.WhenChangingUnsafe(
+            property1,
+            property2,
+            property3,
+            property4,
+            property5,
+            property6,
+            property7,
+            property8,
+            property9,
+            property10,
+            property11,
+            property12,
+            property13,
+            property14,
+            property15,
+            property16).Select(t => conversionFunc(
+                t.Property1,
+                t.Property2,
+                t.Property3,
+                t.Property4,
+                t.Property5,
+                t.Property6,
+                t.Property7,
+                t.Property8,
+                t.Property9,
+                t.Property10,
+                t.Property11,
+                t.Property12,
+                t.Property13,
+                t.Property14,
+                t.Property15,
+                t.Property16));
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanging.Selectors.WideArity.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanging.Selectors.WideArity.cs
@@ -32,6 +32,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, TReturn>(
         this TObj objectToMonitor,
@@ -60,6 +61,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, TReturn>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -69,11 +71,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(t.Property1, t.Property2));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -95,6 +93,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, TReturn>(
         this TObj objectToMonitor,
@@ -128,6 +127,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, TReturn>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -138,12 +138,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            property3,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -168,6 +163,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, TReturn>(
         this TObj objectToMonitor,
@@ -206,6 +202,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, TReturn>(
         this TObj objectToMonitor,
@@ -218,13 +215,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            property3,
-            property4,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3, t.Property4));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -252,6 +243,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, TReturn>(
@@ -296,6 +288,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, TReturn>(
         this TObj objectToMonitor,
@@ -309,14 +302,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3, t.Property4, t.Property5));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -347,6 +333,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, TReturn>(
@@ -396,6 +383,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, TReturn>(
         this TObj objectToMonitor,
@@ -410,15 +398,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(t.Property1, t.Property2, t.Property3, t.Property4, t.Property5, t.Property6));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -452,6 +432,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, TReturn>(
@@ -506,6 +487,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, TReturn>(
         this TObj objectToMonitor,
@@ -521,23 +503,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -574,6 +540,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(
@@ -633,6 +600,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(
         this TObj objectToMonitor,
@@ -649,25 +617,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -707,6 +657,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn>(
@@ -771,6 +722,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, TReturn>(
         this TObj objectToMonitor,
@@ -788,27 +740,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -851,6 +783,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TReturn>(
@@ -920,6 +853,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TReturn>(
         this TObj objectToMonitor,
@@ -938,29 +872,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1006,6 +918,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn>(
@@ -1080,6 +993,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TReturn>(
         this TObj objectToMonitor,
@@ -1099,31 +1013,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1172,6 +1062,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn>(
@@ -1251,6 +1142,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TReturn>(
         this TObj objectToMonitor,
@@ -1271,33 +1163,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1349,6 +1215,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<
@@ -1448,6 +1315,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TReturn>(
         this TObj objectToMonitor,
@@ -1469,35 +1337,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            property13,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12,
-                t.Property13));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1552,6 +1392,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<
@@ -1657,6 +1498,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TReturn>(
         this TObj objectToMonitor,
@@ -1679,37 +1521,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            property13,
-            property14,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12,
-                t.Property13,
-                t.Property14));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1767,6 +1579,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<
@@ -1878,6 +1691,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TReturn>(
         this TObj objectToMonitor,
@@ -1901,39 +1715,7 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            property13,
-            property14,
-            property15,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12,
-                t.Property13,
-                t.Property14,
-                t.Property15));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 
 #if NET8_0_OR_GREATER
     /// <summary>
@@ -1994,6 +1776,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<TReturn> WhenChanging<
@@ -2111,6 +1894,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the converted result before any of the observed properties changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<TReturn> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TReturn>(
         this TObj objectToMonitor,
@@ -2135,39 +1919,5 @@ public static partial class ReactiveUIBindingExtensions
         [CallerLineNumber] int callerLineNumber = 0)
         where TObj : class
 #endif
-        => objectToMonitor.WhenChanging(
-            property1,
-            property2,
-            property3,
-            property4,
-            property5,
-            property6,
-            property7,
-            property8,
-            property9,
-            property10,
-            property11,
-            property12,
-            property13,
-            property14,
-            property15,
-            property16,
-            callerFilePath: callerFilePath,
-            callerLineNumber: callerLineNumber).Select(t => conversionFunc(
-                t.Property1,
-                t.Property2,
-                t.Property3,
-                t.Property4,
-                t.Property5,
-                t.Property6,
-                t.Property7,
-                t.Property8,
-                t.Property9,
-                t.Property10,
-                t.Property11,
-                t.Property12,
-                t.Property13,
-                t.Property14,
-                t.Property15,
-                t.Property16));
+        => throw new InvalidOperationException(NoWhenChangingDispatchMessage);
 }

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanging.WideArity.Unsafe.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanging.WideArity.Unsafe.cs
@@ -1,0 +1,1060 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Binding.Reactive;
+#else
+namespace ReactiveUI.Binding;
+#endif
+/// <summary>Observes property chains by reflection, for expressions the generator could not read (WhenChanging).</summary>
+/// <remarks>
+/// These are the opt-in half of <c>WhenChanging</c>. The unsuffixed overloads resolve at compile time and throw when no
+/// generated dispatch claimed the call site; these walk the chain by reflection instead, and say so, so a
+/// consumer publishing trimmed or ahead-of-time sees the requirement at their own call site.
+/// </remarks>
+public static partial class ReactiveUIBindingExtensions
+{
+    /// <summary>Observes a property on the specified object and emits the value before it changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <returns>An observable sequence that emits the property value before it changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<T1> WhenChangingUnsafe<TObj, T1>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+
+        return RuntimeObservationFallback.WhenChanging(objectToMonitor, property1);
+    }
+
+    /// <summary>Observes 2 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2>> WhenChangingUnsafe<TObj, T1, T2>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            static (v1, v2) => new PropertyValues<T1, T2>(v1, v2));
+    }
+
+    /// <summary>Observes 3 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3>> WhenChangingUnsafe<TObj, T1, T2, T3>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
+            static (v1, v2, v3) => new PropertyValues<T1, T2, T3>(v1, v2, v3));
+    }
+
+    /// <summary>Observes 4 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4>> WhenChangingUnsafe<
+        TObj,
+        T1,
+        T2,
+        T3,
+        T4>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
+            static (v1, v2, v3, v4) => new PropertyValues<T1, T2, T3, T4>(v1, v2, v3, v4));
+    }
+
+    /// <summary>Observes 5 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5>> WhenChangingUnsafe<
+        TObj,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
+            static (v1, v2, v3, v4, v5) => new PropertyValues<T1, T2, T3, T4, T5>(v1, v2, v3, v4, v5));
+    }
+
+    /// <summary>Observes 6 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6>> WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, T6>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
+            static (v1, v2, v3, v4, v5, v6) => new PropertyValues<T1, T2, T3, T4, T5, T6>(v1, v2, v3, v4, v5, v6));
+    }
+
+    /// <summary>Observes 7 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7>> WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
+            static (v1, v2, v3, v4, v5, v6, v7) => new PropertyValues<T1, T2, T3, T4, T5, T6, T7>(v1, v2, v3, v4, v5, v6, v7));
+    }
+
+    /// <summary>Observes 8 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8>> WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
+            static (v1, v2, v3, v4, v5, v6, v7, v8) => new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8>(v1, v2, v3, v4, v5, v6, v7, v8));
+    }
+
+    /// <summary>Observes 9 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9>> WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9>(v1, v2, v3, v4, v5, v6, v7, v8, v9));
+    }
+
+    /// <summary>Observes 10 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property10),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10));
+    }
+
+    /// <summary>Observes 11 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> WhenChangingUnsafe<
+                TObj,
+                T1,
+                T2,
+                T3,
+                T4,
+                T5,
+                T6,
+                T7,
+                T8,
+                T9,
+                T10,
+                T11>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property10),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property11),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11));
+    }
+
+    /// <summary>Observes 12 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> WhenChangingUnsafe<
+                TObj,
+                T1,
+                T2,
+                T3,
+                T4,
+                T5,
+                T6,
+                T7,
+                T8,
+                T9,
+                T10,
+                T11,
+                T12>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property10),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property11),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property12),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12));
+    }
+
+    /// <summary>Observes 13 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> WhenChangingUnsafe<
+                TObj,
+                T1,
+                T2,
+                T3,
+                T4,
+                T5,
+                T6,
+                T7,
+                T8,
+                T9,
+                T10,
+                T11,
+                T12,
+                T13>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+        ArgumentExceptionHelper.ThrowIfNull(property13);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property10),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property11),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property12),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property13),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) =>
+
+                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13));
+    }
+
+    /// <summary>Observes 14 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13,
+        Expression<Func<TObj, T14>> property14)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+        ArgumentExceptionHelper.ThrowIfNull(property13);
+        ArgumentExceptionHelper.ThrowIfNull(property14);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property10),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property11),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property12),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property13),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property14),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) =>
+
+                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14));
+    }
+
+    /// <summary>Observes 15 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="T15">The type of the fifteenth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="property15">An expression that selects the fifteenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>
+        WhenChangingUnsafe<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13,
+        Expression<Func<TObj, T14>> property14,
+        Expression<Func<TObj, T15>> property15)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+        ArgumentExceptionHelper.ThrowIfNull(property13);
+        ArgumentExceptionHelper.ThrowIfNull(property14);
+        ArgumentExceptionHelper.ThrowIfNull(property15);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property10),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property11),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property12),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property13),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property14),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property15),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) =>
+
+                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15));
+    }
+
+    /// <summary>Observes 16 properties of the specified object and emits their values as a tuple before any property changes.</summary>
+    /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
+    /// <typeparam name="T1">The type of the first observed property value.</typeparam>
+    /// <typeparam name="T2">The type of the second observed property value.</typeparam>
+    /// <typeparam name="T3">The type of the third observed property value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth observed property value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth observed property value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth observed property value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh observed property value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth observed property value.</typeparam>
+    /// <typeparam name="T9">The type of the ninth observed property value.</typeparam>
+    /// <typeparam name="T10">The type of the tenth observed property value.</typeparam>
+    /// <typeparam name="T11">The type of the eleventh observed property value.</typeparam>
+    /// <typeparam name="T12">The type of the twelfth observed property value.</typeparam>
+    /// <typeparam name="T13">The type of the thirteenth observed property value.</typeparam>
+    /// <typeparam name="T14">The type of the fourteenth observed property value.</typeparam>
+    /// <typeparam name="T15">The type of the fifteenth observed property value.</typeparam>
+    /// <typeparam name="T16">The type of the sixteenth observed property value.</typeparam>
+    /// <param name="objectToMonitor">The object instance to observe for property changes.</param>
+    /// <param name="property1">An expression that selects the first property to observe.</param>
+    /// <param name="property2">An expression that selects the second property to observe.</param>
+    /// <param name="property3">An expression that selects the third property to observe.</param>
+    /// <param name="property4">An expression that selects the fourth property to observe.</param>
+    /// <param name="property5">An expression that selects the fifth property to observe.</param>
+    /// <param name="property6">An expression that selects the sixth property to observe.</param>
+    /// <param name="property7">An expression that selects the seventh property to observe.</param>
+    /// <param name="property8">An expression that selects the eighth property to observe.</param>
+    /// <param name="property9">An expression that selects the ninth property to observe.</param>
+    /// <param name="property10">An expression that selects the tenth property to observe.</param>
+    /// <param name="property11">An expression that selects the eleventh property to observe.</param>
+    /// <param name="property12">An expression that selects the twelfth property to observe.</param>
+    /// <param name="property13">An expression that selects the thirteenth property to observe.</param>
+    /// <param name="property14">An expression that selects the fourteenth property to observe.</param>
+    /// <param name="property15">An expression that selects the fifteenth property to observe.</param>
+    /// <param name="property16">An expression that selects the sixteenth property to observe.</param>
+    /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <remarks>Resolves the property chain by reflection, for an expression the generator could not read.</remarks>
+    [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
+    [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
+    [RequiresUnreferencedCode(DynamicChainRequiresUnreferencedCode)]
+    public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> WhenChangingUnsafe<
+                TObj,
+                T1,
+                T2,
+                T3,
+                T4,
+                T5,
+                T6,
+                T7,
+                T8,
+                T9,
+                T10,
+                T11,
+                T12,
+                T13,
+                T14,
+                T15,
+                T16>(
+        this TObj objectToMonitor,
+        Expression<Func<TObj, T1>> property1,
+        Expression<Func<TObj, T2>> property2,
+        Expression<Func<TObj, T3>> property3,
+        Expression<Func<TObj, T4>> property4,
+        Expression<Func<TObj, T5>> property5,
+        Expression<Func<TObj, T6>> property6,
+        Expression<Func<TObj, T7>> property7,
+        Expression<Func<TObj, T8>> property8,
+        Expression<Func<TObj, T9>> property9,
+        Expression<Func<TObj, T10>> property10,
+        Expression<Func<TObj, T11>> property11,
+        Expression<Func<TObj, T12>> property12,
+        Expression<Func<TObj, T13>> property13,
+        Expression<Func<TObj, T14>> property14,
+        Expression<Func<TObj, T15>> property15,
+        Expression<Func<TObj, T16>> property16)
+        where TObj : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
+        ArgumentExceptionHelper.ThrowIfNull(property1);
+        ArgumentExceptionHelper.ThrowIfNull(property2);
+        ArgumentExceptionHelper.ThrowIfNull(property3);
+        ArgumentExceptionHelper.ThrowIfNull(property4);
+        ArgumentExceptionHelper.ThrowIfNull(property5);
+        ArgumentExceptionHelper.ThrowIfNull(property6);
+        ArgumentExceptionHelper.ThrowIfNull(property7);
+        ArgumentExceptionHelper.ThrowIfNull(property8);
+        ArgumentExceptionHelper.ThrowIfNull(property9);
+        ArgumentExceptionHelper.ThrowIfNull(property10);
+        ArgumentExceptionHelper.ThrowIfNull(property11);
+        ArgumentExceptionHelper.ThrowIfNull(property12);
+        ArgumentExceptionHelper.ThrowIfNull(property13);
+        ArgumentExceptionHelper.ThrowIfNull(property14);
+        ArgumentExceptionHelper.ThrowIfNull(property15);
+        ArgumentExceptionHelper.ThrowIfNull(property16);
+
+        return CombineLatestObservable.Create(
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property10),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property11),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property12),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property13),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property14),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property15),
+            RuntimeObservationFallback.WhenChanging(objectToMonitor, property16),
+            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) =>
+                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16));
+    }
+}

--- a/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanging.WideArity.cs
+++ b/src/ReactiveUI.Binding.Shared/Mixins/ReactiveUIBindingExtensions.WhenChanging.WideArity.cs
@@ -13,6 +13,10 @@ namespace ReactiveUI.Binding;
 /// <summary>Extension methods for observing property changes before they occur (WhenChanging).</summary>
 public static partial class ReactiveUIBindingExtensions
 {
+    /// <summary>Reported when no generated dispatch claimed a WhenChanging call site.</summary>
+    private const string NoWhenChangingDispatchMessage =
+        "No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.";
+
 #if NET8_0_OR_GREATER
     /// <summary>Observes a property on the specified object and emits the value before it changes.</summary>
     /// <typeparam name="TObj">The type of the object to monitor for property changes.</typeparam>
@@ -23,6 +27,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the property value before it changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     public static IObservable<T1> WhenChanging<TObj, T1>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -40,6 +45,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits the property value before it changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     public static IObservable<T1> WhenChanging<TObj, T1>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -48,10 +54,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-
-        return RuntimeObservationFallback.WhenChanging(objectToMonitor, property1);
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -67,6 +70,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     public static IObservable<PropertyValues<T1, T2>> WhenChanging<TObj, T1, T2>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -89,6 +93,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     public static IObservable<PropertyValues<T1, T2>> WhenChanging<TObj, T1, T2>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -98,14 +103,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            static (v1, v2) => new PropertyValues<T1, T2>(v1, v2));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -124,6 +122,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3>> WhenChanging<TObj, T1, T2, T3>(
         this TObj objectToMonitor,
@@ -152,6 +151,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     public static IObservable<PropertyValues<T1, T2, T3>> WhenChanging<TObj, T1, T2, T3>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -162,16 +162,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
-            static (v1, v2, v3) => new PropertyValues<T1, T2, T3>(v1, v2, v3));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -193,6 +184,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4>> WhenChanging<
@@ -232,6 +224,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     public static IObservable<PropertyValues<T1, T2, T3, T4>> WhenChanging<TObj, T1, T2, T3, T4>(
         this TObj objectToMonitor,
         Expression<Func<TObj, T1>> property1,
@@ -243,18 +236,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
-            static (v1, v2, v3, v4) => new PropertyValues<T1, T2, T3, T4>(v1, v2, v3, v4));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -279,6 +261,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5>> WhenChanging<
@@ -324,6 +307,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5>> WhenChanging<TObj, T1, T2, T3, T4, T5>(
         this TObj objectToMonitor,
@@ -337,20 +321,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
-            static (v1, v2, v3, v4, v5) => new PropertyValues<T1, T2, T3, T4, T5>(v1, v2, v3, v4, v5));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -378,6 +349,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6>>
@@ -423,6 +395,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6>> WhenChanging<TObj, T1, T2, T3, T4, T5, T6>(
         this TObj objectToMonitor,
@@ -437,22 +410,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
-            static (v1, v2, v3, v4, v5, v6) => new PropertyValues<T1, T2, T3, T4, T5, T6>(v1, v2, v3, v4, v5, v6));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -483,6 +441,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -534,6 +493,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7>> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7>(
         this TObj objectToMonitor,
@@ -549,24 +509,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
-            static (v1, v2, v3, v4, v5, v6, v7) => new PropertyValues<T1, T2, T3, T4, T5, T6, T7>(v1, v2, v3, v4, v5, v6, v7));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -600,6 +543,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -655,6 +599,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8>> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8>(
         this TObj objectToMonitor,
@@ -671,26 +616,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
-            static (v1, v2, v3, v4, v5, v6, v7, v8) => new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8>(v1, v2, v3, v4, v5, v6, v7, v8));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -727,6 +653,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -787,6 +714,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9>> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
         this TObj objectToMonitor,
@@ -804,29 +732,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9>(v1, v2, v3, v4, v5, v6, v7, v8, v9));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -866,6 +772,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -931,6 +838,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
         this TObj objectToMonitor,
@@ -949,31 +857,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property10),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1016,6 +900,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1098,6 +983,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
         this TObj objectToMonitor,
@@ -1117,33 +1003,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property10),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property11),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1189,6 +1049,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1277,6 +1138,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
@@ -1298,35 +1160,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property10),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property11),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property12),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1375,6 +1209,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1469,6 +1304,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
@@ -1491,38 +1327,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-        ArgumentExceptionHelper.ThrowIfNull(property13);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property10),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property11),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property12),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property13),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) =>
-
-                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1574,6 +1379,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1660,6 +1466,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
@@ -1683,40 +1490,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-        ArgumentExceptionHelper.ThrowIfNull(property13);
-        ArgumentExceptionHelper.ThrowIfNull(property14);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property10),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property11),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property12),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property13),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property14),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) =>
-
-                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1771,6 +1545,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -1861,6 +1636,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> WhenChanging<TObj, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
@@ -1885,42 +1661,7 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-        ArgumentExceptionHelper.ThrowIfNull(property13);
-        ArgumentExceptionHelper.ThrowIfNull(property14);
-        ArgumentExceptionHelper.ThrowIfNull(property15);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property10),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property11),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property12),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property13),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property14),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property15),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) =>
-
-                    new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 
 #if NET8_0_OR_GREATER
@@ -1978,6 +1719,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1472", Justification = "one selector per observed property; the parameter count is the shape of this overload")]
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     public static
@@ -2090,6 +1832,7 @@ public static partial class ReactiveUIBindingExtensions
     /// <param name="callerFilePath">The source file path of the caller. Auto-populated by the compiler.</param>
     /// <param name="callerLineNumber">The source line number of the caller. Auto-populated by the compiler.</param>
     /// <returns>An observable sequence that emits a tuple of all observed property values before any of them changes.</returns>
+    /// <exception cref="InvalidOperationException">No generated WhenChanging dispatch matched this call site. Use WhenChangingUnsafe to resolve the expression at run time.</exception>
     [SuppressMessage("Design", "SST1523", Justification = "one observation step per observed property; the length is the shape of this overload")]
     [SuppressMessage("Design", "SST1472", Justification = "parameter count is inherent to the N-property dispatch stub and its CallerInfo contract")]
     public static IObservable<PropertyValues<
@@ -2131,42 +1874,6 @@ public static partial class ReactiveUIBindingExtensions
         where TObj : class
 #endif
     {
-        ArgumentExceptionHelper.ThrowIfNull(objectToMonitor);
-        ArgumentExceptionHelper.ThrowIfNull(property1);
-        ArgumentExceptionHelper.ThrowIfNull(property2);
-        ArgumentExceptionHelper.ThrowIfNull(property3);
-        ArgumentExceptionHelper.ThrowIfNull(property4);
-        ArgumentExceptionHelper.ThrowIfNull(property5);
-        ArgumentExceptionHelper.ThrowIfNull(property6);
-        ArgumentExceptionHelper.ThrowIfNull(property7);
-        ArgumentExceptionHelper.ThrowIfNull(property8);
-        ArgumentExceptionHelper.ThrowIfNull(property9);
-        ArgumentExceptionHelper.ThrowIfNull(property10);
-        ArgumentExceptionHelper.ThrowIfNull(property11);
-        ArgumentExceptionHelper.ThrowIfNull(property12);
-        ArgumentExceptionHelper.ThrowIfNull(property13);
-        ArgumentExceptionHelper.ThrowIfNull(property14);
-        ArgumentExceptionHelper.ThrowIfNull(property15);
-        ArgumentExceptionHelper.ThrowIfNull(property16);
-
-        return CombineLatestObservable.Create(
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property1),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property2),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property3),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property4),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property5),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property6),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property7),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property8),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property9),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property10),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property11),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property12),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property13),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property14),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property15),
-            RuntimeObservationFallback.WhenChanging(objectToMonitor, property16),
-            static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) =>
-                new PropertyValues<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16));
+        throw new InvalidOperationException(NoWhenChangingDispatchMessage);
     }
 }

--- a/src/ReactiveUI.Binding.Shared/ObservableForProperty/INPCObservableForProperty.cs
+++ b/src/ReactiveUI.Binding.Shared/ObservableForProperty/INPCObservableForProperty.cs
@@ -18,14 +18,12 @@ public class INPCObservableForProperty : ICreatesObservableForProperty
     private static readonly int SupportedAffinity = BindingAffinity.Explicit;
 
     /// <inheritdoc/>
-    [RequiresUnreferencedCode("Uses reflection over runtime types which is not trim- or AOT-safe.")]
     public int GetAffinityForObject(Type type, string propertyName, bool beforeChanged) =>
         (beforeChanged ? typeof(INotifyPropertyChanging) : typeof(INotifyPropertyChanged)).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo())
             ? SupportedAffinity
             : 0;
 
     /// <inheritdoc/>
-    [RequiresUnreferencedCode("Uses reflection over runtime types which is not trim- or AOT-safe.")]
     public IObservable<IObservedChange<object, object?>> GetNotificationForProperty(
         object sender,
         Expression expression,

--- a/src/ReactiveUI.Binding.Shared/ObservableForProperty/POCOObservableForProperty.cs
+++ b/src/ReactiveUI.Binding.Shared/ObservableForProperty/POCOObservableForProperty.cs
@@ -20,7 +20,6 @@ public sealed class POCOObservableForProperty : ICreatesObservableForProperty
     private static readonly ConcurrentDictionary<ObservedPropertyKey, byte> HasWarned = new();
 
     /// <inheritdoc/>
-    [RequiresUnreferencedCode("Uses reflection over runtime types which is not trim- or AOT-safe.")]
     public int GetAffinityForObject(Type type, string propertyName, bool beforeChanged)
     {
         ArgumentExceptionHelper.ThrowIfNull(type);
@@ -30,7 +29,6 @@ public sealed class POCOObservableForProperty : ICreatesObservableForProperty
     }
 
     /// <inheritdoc/>
-    [RequiresUnreferencedCode("Uses reflection over runtime types which is not trim- or AOT-safe.")]
     public IObservable<IObservedChange<object, object?>> GetNotificationForProperty(
         object sender,
         Expression expression,

--- a/src/ReactiveUI.Binding.Shared/View/DefaultViewLocator.cs
+++ b/src/ReactiveUI.Binding.Shared/View/DefaultViewLocator.cs
@@ -166,6 +166,7 @@ public sealed class DefaultViewLocator : IViewLocator
     }
 
     /// <inheritdoc/>
+    [RequiresDynamicCode("Resolving a view from an object closes IViewFor<> over its runtime type. Use the generic overload, or register the view, to stay ahead-of-time safe.")]
     public IViewFor? ResolveView(object? viewModel, string? contract)
     {
         if (viewModel is null)
@@ -195,7 +196,7 @@ public sealed class DefaultViewLocator : IViewLocator
             return view;
         }
 
-        // 3. MakeGenericType fallback (non-AOT, for compatibility)
+        // 3. Closing IViewFor<> over the runtime type, which needs an instantiation the compiler never saw
         return TryResolveViaReflection(viewModel, normalizedContract);
     }
 
@@ -216,7 +217,13 @@ public sealed class DefaultViewLocator : IViewLocator
     /// <param name="viewModel">The view model instance.</param>
     /// <param name="contract">The normalized contract string.</param>
     /// <returns>The resolved view, or <see langword="null"/>.</returns>
+    /// <remarks>
+    /// Closing <c>IViewFor&lt;&gt;</c> over a runtime type needs the runtime to build an instantiation the
+    /// compiler never saw, which an ahead-of-time build cannot do. Asking the runtime whether it can rather
+    /// than attempting it and catching keeps this tier off the AOT analyser's books and off the exception path.
+    /// </remarks>
     [ExcludeFromCodeCoverage]
+    [RequiresDynamicCode("Closes IViewFor<> over the view model's runtime type, which needs an instantiation the compiler never saw.")]
     private static IViewFor? TryResolveViaReflection(object viewModel, string contract)
     {
         try
@@ -232,8 +239,8 @@ public sealed class DefaultViewLocator : IViewLocator
         }
         catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException or TypeLoadException or ArgumentException)
         {
-            // MakeGenericType cannot build the closed IViewFor<> on AOT platforms where the
-            // instantiation was trimmed; the caller falls back to the other resolution tiers.
+            // A closed IViewFor<> the compiler never saw cannot be built where its instantiation was trimmed,
+            // so the caller falls back to the other resolution tiers
         }
 
         return null;

--- a/src/ReactiveUI.Binding.SourceGenerators.slnx
+++ b/src/ReactiveUI.Binding.SourceGenerators.slnx
@@ -50,6 +50,7 @@
             Path="tests/ReactiveUI.Binding.GeneratedCode.TestModels/ReactiveUI.Binding.GeneratedCode.TestModels.csproj"/>
         <Project Path="tests/ReactiveUI.Binding.GeneratedCode.Tests/ReactiveUI.Binding.GeneratedCode.Tests.csproj"/>
         <Project Path="tests/ReactiveUI.Binding.AotValidation/ReactiveUI.Binding.AotValidation.csproj"/>
+        <Project Path="tests/ReactiveUI.Binding.TrimValidation/ReactiveUI.Binding.TrimValidation.csproj"/>
         <Project Path="tests/ReactiveUI.Binding.Wpf.Tests/ReactiveUI.Binding.Wpf.Tests.csproj"/>
         <Project Path="tests/ReactiveUI.Binding.Wpf.Tests.Reactive/ReactiveUI.Binding.Wpf.Tests.Reactive.csproj"/>
         <Project Path="tests/ReactiveUI.Binding.WinForms.Tests/ReactiveUI.Binding.WinForms.Tests.csproj"/>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindInteractionCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindInteractionCodeGenerator.cs
@@ -30,10 +30,6 @@ internal static class BindInteractionCodeGenerator
     /// <summary>Closes the view model parameter of a generated binding worker.</summary>
     private const string ViewModelParameterSuffix = " viewModel,";
 
-    /// <summary>Declares the local the interaction property is observed into, up to the observation type.</summary>
-    private const string InteractionObservationOpen =
-        "        var interactionObs = new global::ReactiveUI.Binding.Observables.";
-
     /// <summary>Generates concrete typed overloads and binding methods for BindInteraction invocations.</summary>
     /// <param name="invocations">All detected BindInteraction invocations.</param>
     /// <param name="allClasses">All detected class binding info.</param>
@@ -333,15 +329,16 @@ internal static class BindInteractionCodeGenerator
         }
     }
 
-    /// <summary>
-    /// Emits the null guard and the observation of the interaction property. A single-segment path
-    /// observes the property directly; a deeper path delegates to the shared chain emitter.
-    /// </summary>
+    /// <summary>Emits the null guard and the observation of the interaction property.</summary>
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="inv">The BindInteraction invocation info.</param>
     /// <param name="viewModelClassInfo">The view model type's binding info, when known.</param>
     /// <param name="viewClassInfo">The view type's binding info, which says whether it exposes a view model.</param>
     /// <param name="interactionType">The fully qualified interaction type being observed.</param>
+    /// <remarks>
+    /// The shared chain emitter answers every path length, so a single-segment interaction property is offered
+    /// to a registered plugin on the same terms as a deeper one and as every other binding API.
+    /// </remarks>
     private static void EmitInteractionObservation(
         StringBuilder sb,
         BindInteractionInvocationInfo inv,
@@ -358,33 +355,13 @@ internal static class BindInteractionCodeGenerator
             viewModelClassInfo,
             viewClassInfo);
 
-        if (observation.Path.Length != 1)
-        {
-            ObservationCodeGenerator.EmitInlineObservation(
-                sb,
-                observation.RootVariable,
-                observation.Path,
-                interactionType,
-                observation.RootClassInfo,
-                "interactionObs");
-            return;
-        }
-
-        var propertyName = inv.InteractionPropertyPath[0].PropertyName;
-        _ = sb.AppendLine();
-
-        if (ObservationCodeGenerator.IsINPC(viewModelClassInfo))
-        {
-            _ = sb.Append(InteractionObservationOpen)
-                .Append("PropertyObservable<").Append(interactionType).AppendLine(">(").AppendLine("            viewModel,")
-                .Append("            \"").Append(propertyName).AppendLine("\",")
-                .Append("            (global::System.ComponentModel.INotifyPropertyChanged __o) => ((").Append(inv.ViewModelTypeFullName)
-                .Append(GeneratedSyntax.ObserverCastClose).Append(propertyName).AppendLine(",").AppendLine("            true);");
-            return;
-        }
-
-        _ = sb.Append(InteractionObservationOpen)
-            .Append("UnchangingPropertyObservable<").Append(interactionType).Append(">(viewModel.").Append(propertyName).AppendLine(");");
+        ObservationCodeGenerator.EmitInlineObservation(
+            sb,
+            observation.RootVariable,
+            observation.Path,
+            interactionType,
+            observation.RootClassInfo,
+            "interactionObs");
     }
 
     /// <summary>Appends the guard that leaves the binding inert until the view is given a view model.</summary>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindToCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindToCodeGenerator.cs
@@ -30,6 +30,15 @@ internal static class BindToCodeGenerator
     /// <summary>The indentation and arrow an interceptor forwards to its binding behind.</summary>
     private const string ForwardingBodyPrefix = "            => ";
 
+    /// <summary>The selector a call site the runtime engine serves hands its worker, ahead of the conversion arguments.</summary>
+    private const string ReflectionPropertyArgument = ", property";
+
+    /// <summary>The indentation a forwarded argument sits at.</summary>
+    private const string ArgumentIndent = "                ";
+
+    /// <summary>The opening of a worker's return statement.</summary>
+    private const string ReturnPrefix = "            return ";
+
     /// <summary>Generates concrete typed overloads and binding methods for <c>BindTo</c> invocations.</summary>
     /// <param name="invocations">All detected <c>BindTo</c> invocations.</param>
     /// <param name="features">The consumer compilation's C# language-feature snapshot (dispatch strategy and nullable support).</param>
@@ -193,11 +202,11 @@ internal static class BindToCodeGenerator
 
             _ = sb.Append("            ").Append(condition).Append(" (propertyExpression == \"").Append(escapedTargetExpr).AppendLine("\")")
                 .AppendLine(GeneratedSyntax.StatementBlockOpen);
-            AppendWorkerInvocation(sb, ReturnStatementPrefix, BindToMethodSuffix(inv), extraArguments);
+            AppendWorkerInvocation(sb, ReturnStatementPrefix, BindToMethodSuffix(inv), WorkerArgumentsFor(inv, extraArguments));
             _ = sb.AppendLine("            }");
         }
 
-        _ = sb.Append("            throw new ").Append(GeneratedTypeNames.InvalidOperationException).AppendLine("(").Append("                \"")
+        _ = sb.Append("            throw new ").Append(GeneratedTypeNames.InvalidOperationException).AppendLine("(").Append(ArgumentIndent).Append('"')
             .Append(NoBindingFoundMessage).AppendLine("\");").AppendLine(GeneratedSyntax.MemberBodyClose);
     }
 
@@ -232,11 +241,11 @@ internal static class BindToCodeGenerator
             _ = sb.Append("            ").Append(condition).Append(" (callerLineNumber == ").Append(inv.CallerLineNumber).AppendLine()
                 .Append("                && callerFilePath.EndsWith(\"").Append(CodeGeneratorHelpers.EscapeString(pathSuffix)).Append("\", ")
                 .Append(OrdinalIgnoreCase).AppendLine("))").AppendLine(GeneratedSyntax.StatementBlockOpen);
-            AppendWorkerInvocation(sb, ReturnStatementPrefix, BindToMethodSuffix(inv), extraArguments);
+            AppendWorkerInvocation(sb, ReturnStatementPrefix, BindToMethodSuffix(inv), WorkerArgumentsFor(inv, extraArguments));
             _ = sb.AppendLine("            }");
         }
 
-        _ = sb.Append("            throw new ").Append(GeneratedTypeNames.InvalidOperationException).AppendLine("(").Append("                \"")
+        _ = sb.Append("            throw new ").Append(GeneratedTypeNames.InvalidOperationException).AppendLine("(").Append(ArgumentIndent).Append('"')
             .Append(NoBindingFoundMessage).AppendLine("\");").AppendLine(GeneratedSyntax.MemberBodyClose);
     }
 
@@ -249,6 +258,12 @@ internal static class BindToCodeGenerator
     /// <param name="suffix">The stable method-name suffix.</param>
     internal static void GenerateBindToMethod(StringBuilder sb, BindToInvocationInfo inv, string suffix)
     {
+        if (inv.ReflectionOnly)
+        {
+            GenerateReflectionBindToMethod(sb, inv, suffix);
+            return;
+        }
+
         var directAssignment = CodeGeneratorHelpers.BuildGuardedAssignment(
             "target",
             inv.TargetPropertyPath,
@@ -272,13 +287,13 @@ internal static class BindToCodeGenerator
 
         if (directAssign)
         {
-            _ = sb.Append("            return ").Append(BindingErrors).AppendLine(".Subscribe(source, value =>").AppendLine(GeneratedSyntax.StatementBlockOpen)
+            _ = sb.Append(ReturnPrefix).Append(BindingErrors).AppendLine(".Subscribe(source, value =>").AppendLine(GeneratedSyntax.StatementBlockOpen)
                 .Append("                ").Append(directAssignment).AppendLine().Append("            }, \"")
                 .Append(CodeGeneratorHelpers.EscapeString(inv.TargetExpressionText)).AppendLine("\");").AppendLine(GeneratedSyntax.MemberBodyClose).AppendLine();
         }
         else
         {
-            _ = sb.Append("            return ").Append(BindingErrors).AppendLine(".Subscribe(source, value =>").AppendLine(GeneratedSyntax.StatementBlockOpen)
+            _ = sb.Append(ReturnPrefix).Append(BindingErrors).AppendLine(".Subscribe(source, value =>").AppendLine(GeneratedSyntax.StatementBlockOpen)
                 .Append("                if (").Append(RuntimeBindingConverter).Append(".TryConvert<").Append(inv.SourceValueTypeFullName).Append(", ")
                 .Append(inv.TargetPropertyTypeFullName).Append(">(value, ").Append(FormatConversionArguments(inv)).AppendLine(", out var __converted))")
                 .AppendLine("                {").Append("                    ").Append(convertedAssignment).AppendLine().AppendLine("                }")
@@ -286,6 +301,41 @@ internal static class BindToCodeGenerator
                 .AppendLine(GeneratedSyntax.MemberBodyClose).AppendLine();
         }
     }
+
+    /// <summary>Emits the worker for a call site whose selector only the runtime engine can resolve.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="inv">The call site being served.</param>
+    /// <param name="suffix">The stable suffix naming this worker.</param>
+    /// <remarks>
+    /// The attribute is what makes this worth generating rather than leaving the call to the stub: a trimming or
+    /// ahead-of-time publish reports this call site and no other, where annotating the shared overload would
+    /// report every call site that merely has the same types.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GenerateReflectionBindToMethod(StringBuilder sb, BindToInvocationInfo inv, string suffix) =>
+        sb.Append(InterceptorEmitter.MemberIndent).AppendLine(GeneratedTypeNames.RequiresUnreferencedCodeAttribute)
+            .Append("        private static ").Append(GeneratedTypeNames.IDisposable).Append(" __BindTo_").Append(suffix).Append('(')
+            .Append(ObservableOf(inv.SourceValueTypeFullName)).Append(" source, ").Append(inv.TargetTypeFullName).Append(" target, ")
+            .Append(PropertyExpression(inv.TargetTypeFullName, inv.TargetPropertyTypeFullName)).Append(" property")
+            .Append(FormatExtraMethodParams(inv)).AppendLine(")")
+            .AppendLine(GeneratedSyntax.MemberBodyOpen)
+            .AppendLine("            // BindTo: the selector resolves at run time, so the engine reads the path.")
+            .Append(ReturnPrefix).Append(GeneratedTypeNames.RuntimeBindingFallback).AppendLine(".BindTo(")
+            .AppendLine("                source,")
+            .AppendLine("                target,")
+            .AppendLine("                property,")
+            .Append(ArgumentIndent).Append(FormatConversionArguments(inv)).AppendLine(",")
+            .AppendLine("                null,")
+            .Append(ArgumentIndent).Append('"').Append(CodeGeneratorHelpers.EscapeString(inv.TargetExpressionText)).AppendLine("\");")
+            .AppendLine(GeneratedSyntax.MemberBodyClose).AppendLine();
+
+    /// <summary>Names the arguments a call site hands its worker, which the runtime path needs the selector in.</summary>
+    /// <param name="inv">The call site being dispatched.</param>
+    /// <param name="extraArguments">The conversion arguments this group's overload forwards.</param>
+    /// <returns>The argument list, as written into the generated call.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static string WorkerArgumentsFor(BindToInvocationInfo inv, string extraArguments) =>
+        inv.ReflectionOnly ? ReflectionPropertyArgument + extraArguments : extraArguments;
 
     /// <summary>Appends the conversion-hint and converter-override parameters to the concrete overload signature.</summary>
     /// <param name="sb">The string builder to append to.</param>
@@ -361,12 +411,17 @@ internal static class BindToCodeGenerator
                 InterceptorEmitter.AppendAttribute(sb, callSite.Interceptor, InterceptorEmitter.MemberIndent);
             }
 
+            if (entry.Value[0].ReflectionOnly)
+            {
+                _ = sb.Append(InterceptorEmitter.MemberIndent).AppendLine(GeneratedTypeNames.RequiresUnreferencedCodeAttribute);
+            }
+
             _ = sb.Append("        internal static ").Append(GeneratedTypeNames.IDisposable).Append(" __Intercept_BindTo_")
                 .Append(entry.Key).AppendLine("(");
 
             AppendParameterList(sb, group, dispatchesOnExpressionText, supportsNullable, stubHasExpressionParameters);
 
-            AppendWorkerInvocation(sb, ForwardingBodyPrefix, entry.Key, extraArguments);
+            AppendWorkerInvocation(sb, ForwardingBodyPrefix, entry.Key, WorkerArgumentsFor(entry.Value[0], extraArguments));
             _ = sb.AppendLine();
         }
     }

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindToCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindToCodeGenerator.cs
@@ -141,6 +141,7 @@ internal static class BindToCodeGenerator
                 first.SourceValueTypeFullName,
                 first.TargetTypeFullName,
                 first.TargetPropertyTypeFullName,
+                first.TargetPropertyIsReferenceType,
                 first.HasConversionHint,
                 first.HasConverterOverride,
                 [.. kvp.Value]));
@@ -444,7 +445,10 @@ internal static class BindToCodeGenerator
         bool supportsNullable,
         bool stubHasExpressionParameters)
     {
-        var targetPropType = CodeGeneratorHelpers.NullableSelectorLeafType(group.Invocations[0].TargetPropertyPath, supportsNullable);
+        var targetPropType = CodeGeneratorHelpers.NullableSelectorType(
+            group.TargetPropertyTypeFullName,
+            group.TargetPropertyIsReferenceType,
+            supportsNullable);
 
         _ = sb.Append("            this ").Append(ObservableOf(group.SourceValueTypeFullName))
             .AppendLine(" source,").Append("            ").Append(group.TargetTypeFullName).AppendLine(" target,")
@@ -490,6 +494,7 @@ internal static class BindToCodeGenerator
     /// <param name="SourceValueTypeFullName">The fully qualified observable value type.</param>
     /// <param name="TargetTypeFullName">The fully qualified target object type.</param>
     /// <param name="TargetPropertyTypeFullName">The fully qualified target property type.</param>
+    /// <param name="TargetPropertyIsReferenceType">Whether that type is a reference type, which annotates the selector parameter.</param>
     /// <param name="HasConversionHint">Whether this group's overload takes a conversion hint.</param>
     /// <param name="HasConverterOverride">Whether this group's overload takes an explicit converter.</param>
     /// <param name="Invocations">All invocations sharing this overload signature.</param>
@@ -497,6 +502,7 @@ internal static class BindToCodeGenerator
         string SourceValueTypeFullName,
         string TargetTypeFullName,
         string TargetPropertyTypeFullName,
+        bool TargetPropertyIsReferenceType,
         bool HasConversionHint,
         bool HasConverterOverride,
         BindToInvocationInfo[] Invocations);

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/CodeGeneratorHelpers.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/CodeGeneratorHelpers.cs
@@ -77,10 +77,20 @@ internal static class CodeGeneratorHelpers
     internal static string NullableSelectorLeafType(EquatableArray<PropertyPathSegment> path, bool supportsNullable)
     {
         var leaf = path[path.Length - 1];
-        return supportsNullable && leaf.IsReferenceType
-            ? $"{leaf.PropertyTypeFullName}?"
-            : leaf.PropertyTypeFullName;
+        return NullableSelectorType(leaf.PropertyTypeFullName, leaf.IsReferenceType, supportsNullable);
     }
+
+    /// <summary>Annotates a selector's produced type the way the stub declares it.</summary>
+    /// <param name="typeFullName">The fully qualified produced type.</param>
+    /// <param name="isReferenceType">Whether that type is a reference type.</param>
+    /// <param name="supportsNullable">Whether the target supports nullable reference types (C# 8+).</param>
+    /// <returns>The type name, suffixed with <c>?</c> where appropriate.</returns>
+    /// <remarks>
+    /// Taken as the type rather than as a path, because a selector the compiler could not read names no path and
+    /// its produced type comes from the method the call resolved to instead.
+    /// </remarks>
+    internal static string NullableSelectorType(string typeFullName, bool isReferenceType, bool supportsNullable) =>
+        supportsNullable && isReferenceType ? $"{typeFullName}?" : typeFullName;
 
     /// <summary>Builds a dotted property access chain from a root variable and property path segments.</summary>
     /// <param name="root">The root variable name (e.g., "obj", "source").</param>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/CodeGeneratorHelpers.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/CodeGeneratorHelpers.cs
@@ -549,6 +549,37 @@ internal static class CodeGeneratorHelpers
         return kept.Count == invocations.Length ? invocations : [.. kept];
     }
 
+    /// <summary>Emits the tail of a generated overload as a call to the stub the overload displaces.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="methodName">The API being generated, which names the stub method to call.</param>
+    /// <param name="typeArguments">The stub's type arguments, or empty to let them be inferred.</param>
+    /// <param name="arguments">The arguments to forward, in the stub's parameter order.</param>
+    /// <remarks>
+    /// A generated overload wins overload resolution for every call site of its types, including the ones whose
+    /// lambdas it could not read - an expression held in a variable, or built at run time. Generating an overload
+    /// therefore takes the stub out of reach, so the overload has to end where the stub would have: at the runtime
+    /// engine, for the APIs whose stub offers one. Naming the class makes it a static call rather than an
+    /// extension call, so it binds to the stub instead of recursing into the overload emitting it.
+    /// The type arguments are stated wherever a generated parameter carries the leaf type's nullable annotation
+    /// while the selector alongside it does not, which is enough to defeat inference.
+    /// </remarks>
+    internal static void AppendStubFallbackCall(
+        StringBuilder sb,
+        string methodName,
+        string typeArguments,
+        string arguments)
+    {
+        _ = sb.Append("            return global::").Append(Constants.SharedGeneratedNamespace).Append('.')
+            .Append(Constants.StubExtensionClassName).Append('.').Append(methodName);
+
+        if (typeArguments.Length > 0)
+        {
+            _ = sb.Append('<').Append(typeArguments).Append('>');
+        }
+
+        _ = sb.Append('(').Append(arguments).AppendLine(");");
+    }
+
     /// <summary>Emits a whole dispatch file: the extension class, and one overload per group of call sites.</summary>
     /// <typeparam name="TInvocation">The call-site model this API extracts.</typeparam>
     /// <typeparam name="TGroup">The group of call sites that share one overload.</typeparam>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/GeneratedTypeNames.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/GeneratedTypeNames.cs
@@ -137,6 +137,20 @@ internal static class GeneratedTypeNames
     /// <summary>The fully qualified name of <c>ReactiveUI.Binding.Fallback.RuntimeBindingConverter</c>.</summary>
     internal const string RuntimeBindingConverter = "global::ReactiveUI.Binding.Fallback.RuntimeBindingConverter";
 
+    /// <summary>The fully qualified name of <c>ReactiveUI.Binding.Fallback.RuntimeCommandFallback</c>.</summary>
+    internal const string RuntimeCommandFallback = "global::ReactiveUI.Binding.Fallback.RuntimeCommandFallback";
+
+    /// <summary>The fully qualified name of <c>ReactiveUI.Binding.Fallback.RuntimeBindingFallback</c>.</summary>
+    internal const string RuntimeBindingFallback = "global::ReactiveUI.Binding.Fallback.RuntimeBindingFallback";
+
+    /// <summary>
+    /// The attribute a generated member carries when it reaches the runtime expression engine, so a trimming or
+    /// ahead-of-time publish reports the call sites that reflect rather than the ones beside them that do not.
+    /// </summary>
+    internal const string RequiresUnreferencedCodeAttribute =
+        "[global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("
+        + "\"This call site names a property path the compiler could not read, so it is resolved by reflection.\")]";
+
     /// <summary>The fully qualified name of <c>ReactiveUI.Binding.Fallback.ObservationAffinityChecker</c>.</summary>
     internal const string ObservationAffinityChecker = "global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker";
 

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/InvokeCommandCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/InvokeCommandCodeGenerator.cs
@@ -30,6 +30,15 @@ internal static class InvokeCommandCodeGenerator
     /// <summary>The objects a worker takes, in its own parameter order.</summary>
     private const string WorkerArguments = "source, target";
 
+    /// <summary>What a call site the runtime engine serves hands its worker, the selector included.</summary>
+    private const string ReflectionWorkerArguments = "source, target, commandProperty";
+
+    /// <summary>The declaration of the parameter a worker takes its values from.</summary>
+    private const string SourceParameter = " source,";
+
+    /// <summary>The indentation a generated member and its attributes sit at.</summary>
+    private const string MemberIndent = "        ";
+
     /// <summary>The indentation and arrow an interceptor forwards to its worker behind.</summary>
     private const string ForwardingBodyPrefix = "            => ";
 
@@ -111,7 +120,7 @@ internal static class InvokeCommandCodeGenerator
         ImmutableArray<ClassBindingInfo> allClasses,
         in LanguageFeatures features)
     {
-        var collapsible = features.SupportsCallerArgExpr && !features.SupportsInterceptors;
+        var collapsible = features.CollapsesIndistinguishableCallSites;
         var emitted = collapsible
             ? group with
             {
@@ -198,7 +207,7 @@ internal static class InvokeCommandCodeGenerator
                     CodeGeneratorHelpers.ComputePathSuffix(inv.CallerFilePath));
             }
 
-            CodeGeneratorHelpers.AppendDispatchReturn(sb, WorkerMethodPrefix + WorkerSuffix(inv), WorkerArguments);
+            CodeGeneratorHelpers.AppendDispatchReturn(sb, WorkerMethodPrefix + WorkerSuffix(inv), WorkerArgumentsFor(inv));
         }
 
         CodeGeneratorHelpers.AppendBindingDispatchFallthrough(sb);
@@ -224,13 +233,21 @@ internal static class InvokeCommandCodeGenerator
                 InterceptorEmitter.AppendAttribute(sb, callSite.Interceptor, InterceptorEmitter.MemberIndent);
             }
 
+            // An interceptor replaces the consumer's call outright, so this is the member their trimming or
+            // ahead-of-time publish sees. Annotating it is what puts the warning on the call that reflects,
+            // where the same attribute on the worker alone would never leave this file
+            if (entry.Value[0].ReflectionOnly)
+            {
+                _ = sb.Append(MemberIndent).AppendLine(GeneratedTypeNames.RequiresUnreferencedCodeAttribute);
+            }
+
             _ = sb.Append("        internal static ").Append(GeneratedTypeNames.IDisposable).Append(" __Intercept_")
                 .Append(Constants.InvokeCommandMethodName).Append('_').Append(entry.Key).AppendLine("(");
 
             AppendParameterList(sb, group, dispatchesOnExpressionText, supportsNullable, stubHasExpressionParameters);
 
             _ = sb.Append(ForwardingBodyPrefix).Append(WorkerMethodPrefix).Append(entry.Key)
-                .Append('(').Append(WorkerArguments).AppendLine(");").AppendLine();
+                .Append('(').Append(WorkerArgumentsFor(entry.Value[0])).AppendLine(");").AppendLine();
         }
     }
 
@@ -255,7 +272,7 @@ internal static class InvokeCommandCodeGenerator
     {
         var commandType = supportsNullable ? $"{ICommand}?" : ICommand;
 
-        _ = sb.Append("            this ").Append(ObservableOf(group.SourceValueTypeFullName)).AppendLine(" source,")
+        _ = sb.Append("            this ").Append(ObservableOf(group.SourceValueTypeFullName)).AppendLine(SourceParameter)
             .Append(CodeGeneratorHelpers.ParameterIndent).Append(group.TargetTypeFullName).AppendLine(" target,")
             .Append(CodeGeneratorHelpers.ParameterIndent)
             .Append(PropertyExpression(group.TargetTypeFullName, commandType)).AppendLine(" commandProperty,");
@@ -288,13 +305,19 @@ internal static class InvokeCommandCodeGenerator
         ImmutableArray<ClassBindingInfo> allClasses,
         string suffix)
     {
+        if (inv.ReflectionOnly)
+        {
+            GenerateReflectionWorker(sb, inv, suffix);
+            return;
+        }
+
         var classInfo = CodeGeneratorHelpers.ResolveObservedTypeInfo(
             allClasses,
             inv.TargetTypeFullName,
             inv.CommandPropertyPath);
 
         _ = sb.Append("        private static ").Append(GeneratedTypeNames.IDisposable).Append(' ').Append(WorkerMethodPrefix).Append(suffix).AppendLine("(")
-            .Append(CodeGeneratorHelpers.ParameterIndent).Append(ObservableOf(inv.SourceValueTypeFullName)).AppendLine(" source,")
+            .Append(CodeGeneratorHelpers.ParameterIndent).Append(ObservableOf(inv.SourceValueTypeFullName)).AppendLine(SourceParameter)
             .Append(CodeGeneratorHelpers.ParameterIndent).Append(inv.TargetTypeFullName).AppendLine(" target)")
             .AppendLine(GeneratedSyntax.MemberBodyOpen)
             .Append("            // InvokeCommand: values -> ")
@@ -316,6 +339,37 @@ internal static class InvokeCommandCodeGenerator
         _ = sb.Append("            return ").Append(CommandInvoker).Append(".Invoke(source, ").Append(CommandVariable).AppendLine(");")
             .AppendLine(GeneratedSyntax.MemberBodyClose).AppendLine();
     }
+
+    /// <summary>Emits the worker for a call site whose selector only the runtime engine can resolve.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="inv">The call site being served.</param>
+    /// <param name="suffix">The stable suffix naming this worker.</param>
+    /// <remarks>
+    /// The attribute is what makes this worth generating rather than leaving the call to the stub: a trimming or
+    /// ahead-of-time publish reports this call site and no other, where annotating the shared overload would
+    /// report every call site that merely has the same types.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void GenerateReflectionWorker(StringBuilder sb, InvokeCommandInvocationInfo inv, string suffix) =>
+        sb.Append(MemberIndent).AppendLine(GeneratedTypeNames.RequiresUnreferencedCodeAttribute)
+            .Append("        private static ").Append(GeneratedTypeNames.IDisposable).Append(' ').Append(WorkerMethodPrefix)
+            .Append(suffix).AppendLine("(")
+            .Append(CodeGeneratorHelpers.ParameterIndent).Append(ObservableOf(inv.SourceValueTypeFullName)).AppendLine(SourceParameter)
+            .Append(CodeGeneratorHelpers.ParameterIndent).Append(inv.TargetTypeFullName).AppendLine(" target,")
+            .Append(CodeGeneratorHelpers.ParameterIndent)
+            .Append(PropertyExpression(inv.TargetTypeFullName, ICommand)).AppendLine(" commandProperty)")
+            .AppendLine(GeneratedSyntax.MemberBodyOpen)
+            .AppendLine("            // InvokeCommand: the selector resolves at run time, so the engine reads the path.")
+            .Append("            return ").Append(GeneratedTypeNames.RuntimeCommandFallback)
+            .AppendLine(".InvokeCommand(source, target, commandProperty);")
+            .AppendLine(GeneratedSyntax.MemberBodyClose).AppendLine();
+
+    /// <summary>Names the arguments a call site hands its worker, which the runtime path needs the selector in.</summary>
+    /// <param name="inv">The call site being dispatched.</param>
+    /// <returns>The argument list, as written into the generated call.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string WorkerArgumentsFor(InvokeCommandInvocationInfo inv) =>
+        inv.ReflectionOnly ? ReflectionWorkerArguments : WorkerArguments;
 
     /// <summary>Names the worker a call site reaches.</summary>
     /// <param name="inv">The call site.</param>

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using ReactiveUI.Binding.SourceGenerators.Models;
 using ReactiveUI.Binding.SourceGenerators.Plugins;
+using ReactiveUI.Binding.SourceGenerators.Plugins.Observation;
 
 using static ReactiveUI.Binding.SourceGenerators.CodeGeneration.GeneratedTypeNames;
 
@@ -37,11 +38,17 @@ internal static class ObservationCodeGenerator
     /// <summary>Passes the observed object as the first argument of a generated call.</summary>
     private const string MonitoredObjectArgument = "(objectToMonitor";
 
+    /// <summary>The name the generated overloads give the observed object.</summary>
+    private const string MonitoredObjectName = "objectToMonitor";
+
     /// <summary>Opens the observation a property that never notifies is read through.</summary>
     private const string UnchangingObservableOpen = ")new global::ReactiveUI.Binding.Observables.UnchangingPropertyObservable<";
 
     /// <summary>Opens a before-change observation cast to the interface the chain stage expects.</summary>
     private const string ChangingObservableOpen = ">)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<";
+
+    /// <summary>The indent an argument takes when the choice is written in an expression position.</summary>
+    private const string ExpressionChoiceArgumentIndent = "                ";
 
     /// <summary>Names the local holding the observation the generator's own mechanism builds.</summary>
     private const string MechanismVariableSuffix = "Mechanism";
@@ -260,6 +267,17 @@ internal static class ObservationCodeGenerator
         var segment = path[0];
         var plugin = ResolveRootPlugin(classInfo, segment);
 
+        ChainRegistrationEmitter.AppendChoiceOpen(
+            sb,
+            "obj",
+            segment,
+            plugin?.Affinity ?? 0,
+            isBeforeChange,
+            string.Empty,
+            ExpressionChoiceArgumentIndent);
+
+        _ = sb.Append(ExpressionChoiceArgumentIndent);
+
         if (plugin is not null)
         {
             plugin.EmitShallowObservation(sb, "obj", segment, GetTypeCastName(classInfo), isBeforeChange, true);
@@ -277,6 +295,8 @@ internal static class ObservationCodeGenerator
             _ = sb.Append("new global::ReactiveUI.Binding.Observables.UnchangingPropertyObservable<").Append(segment.PropertyTypeFullName)
                 .Append(">(").Append(propertyAccess).Append(')');
         }
+
+        _ = sb.Append(')');
     }
 
     /// <summary>
@@ -357,24 +377,7 @@ internal static class ObservationCodeGenerator
         var obs0Var = $"{varName}_s0";
         var rootPlugin = ResolveRootPlugin(classInfo, seg0);
 
-        if (rootPlugin is not null)
-        {
-            rootPlugin.EmitDeepChainRootSegment(sb, "obj", seg0, GetTypeCastName(classInfo), isBeforeChange, obs0Var);
-        }
-        else if (IsINPChanging(classInfo) && isBeforeChange)
-        {
-            _ = sb.Append(GeneratedSyntax.BodyLocalDeclaration).Append(obs0Var).Append(" = (global::System.IObservable<").Append(seg0.PropertyTypeFullName)
-                .Append(ChangingObservableOpen).Append(seg0.PropertyTypeFullName).AppendLine(">(")
-                .AppendLine(ChangingSourceArgument).Append(GeneratedSyntax.QuotedArgumentOpen)
-                .Append(seg0.PropertyName).AppendLine("\",").Append(ChangingReaderLambdaOpen)
-                .Append(GetTypeCastName(classInfo)).Append(GeneratedSyntax.ObserverCastClose).Append(seg0.PropertyName).AppendLine(");");
-        }
-        else
-        {
-            _ = sb.Append(GeneratedSyntax.BodyLocalDeclaration).Append(obs0Var).Append(" = (global::System.IObservable<").Append(seg0.PropertyTypeFullName).Append('>')
-                .Append(UnchangingObservableOpen).Append(seg0.PropertyTypeFullName).Append(">(obj.")
-                .Append(seg0.PropertyName).AppendLine(");");
-        }
+        EmitChainRootWithChoice(sb, "obj", seg0, classInfo, rootPlugin, isBeforeChange, obs0Var);
 
         EmitDeepChainInnerSegments(sb, path, isBeforeChange, varName);
 
@@ -458,22 +461,49 @@ internal static class ObservationCodeGenerator
         // one property at a time, so the dispatch itself has nothing to decide.
         EmitDispatchTable(sb, group, supportsCallerArgExpr, methodPrefix, propCount, hasSelector);
 
-        GenerateRuntimeFallback(sb, methodPrefix);
+        GenerateRuntimeFallback(sb, first, methodPrefix, propCount, hasSelector);
 
         _ = sb.AppendLine("        }");
     }
 
-    /// <summary>
-    /// Generates the throw path for when no generated dispatch match is found.
-    /// Since the source generator matched all invocations at compile time, an unmatched
-    /// dispatch indicates a caching issue — never falls back to runtime reflection.
-    /// </summary>
+    /// <summary>Ends the overload where the stub it displaces would have ended: at the runtime engine.</summary>
     /// <param name="sb">The string builder to append to.</param>
+    /// <param name="first">The invocation whose types the whole group shares.</param>
     /// <param name="methodPrefix">The method name prefix.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GenerateRuntimeFallback(StringBuilder sb, string methodPrefix) =>
-    sb.Append("            throw new global::System.InvalidOperationException(\"No generated ").Append(methodPrefix)
-        .AppendLine(" dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.\");");
+    /// <param name="propCount">The number of observed properties.</param>
+    /// <param name="hasSelector">Whether the overload takes a selector.</param>
+    internal static void GenerateRuntimeFallback(
+        StringBuilder sb,
+        InvocationInfo first,
+        string methodPrefix,
+        int propCount,
+        bool hasSelector)
+    {
+        var typeArguments = new PooledStringBuilder(CodeGeneratorHelpers.FragmentBufferCapacity);
+        var arguments = new PooledStringBuilder(CodeGeneratorHelpers.FragmentBufferCapacity);
+
+        _ = typeArguments.Append(first.SourceTypeFullName);
+        _ = arguments.Append(MonitoredObjectName);
+
+        for (var i = 0; i < propCount; i++)
+        {
+            var path = first.PropertyPaths[i];
+            _ = typeArguments.Append(", ").Append(path[path.Length - 1].PropertyTypeFullName);
+            _ = arguments.Append(", property").Append(i + 1);
+        }
+
+        if (hasSelector)
+        {
+            _ = typeArguments.Append(", ").Append(first.ReturnTypeFullName);
+            _ = arguments.Append(", selector");
+        }
+
+        CodeGeneratorHelpers.AppendStubFallbackCall(
+            sb,
+            methodPrefix,
+            typeArguments.ToStringAndReturn(),
+            arguments.ToStringAndReturn());
+    }
 
     /// <summary>Generates a single-property observation method body using plugin dispatch.</summary>
     /// <param name="sb">The string builder to append to.</param>
@@ -493,28 +523,39 @@ internal static class ObservationCodeGenerator
         var plugin = classInfo is not null
             ? ObservationPluginRegistry.GetBestPlugin(classInfo, propertyName)
             : null;
+        var segment = inv.PropertyPaths[0][0];
+
+        ChainRegistrationEmitter.AppendChoiceOpen(
+            sb,
+            "obj",
+            segment,
+            plugin?.Affinity ?? 0,
+            isBeforeChange,
+            "            return ",
+            ExpressionChoiceArgumentIndent);
+
+        _ = sb.Append(ExpressionChoiceArgumentIndent);
 
         if (plugin is not null)
         {
-            var segment = inv.PropertyPaths[0][0];
-            _ = sb.Append("            return ");
             plugin.EmitShallowObservation(sb, "obj", segment, GetTypeCastName(classInfo), isBeforeChange, true);
-            _ = sb.Append(';');
         }
         else if (IsINPChanging(classInfo) && isBeforeChange)
         {
             // INPChanging-only type (no INPC, no IReactiveObject) — can observe before-change
-            _ = sb.Append("            return new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<")
+            _ = sb.Append("new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<")
                 .Append(inv.ReturnTypeFullName).AppendLine(">(").AppendLine(ChangingSourceArgument)
                 .Append(GeneratedSyntax.QuotedArgumentOpen).Append(propertyName).AppendLine("\",")
                 .Append(ChangingReaderLambdaOpen).Append(inv.SourceTypeFullName)
-                .Append(GeneratedSyntax.ObserverCastClose).Append(propertyName).Append(");");
+                .Append(GeneratedSyntax.ObserverCastClose).Append(propertyName).Append(')');
         }
         else
         {
-            _ = sb.Append("            return new global::ReactiveUI.Binding.Observables.UnchangingPropertyObservable<")
-                .Append(inv.ReturnTypeFullName).Append(">(").Append(propertyAccess).Append(");");
+            _ = sb.Append("new global::ReactiveUI.Binding.Observables.UnchangingPropertyObservable<")
+                .Append(inv.ReturnTypeFullName).Append(">(").Append(propertyAccess).Append(')');
         }
+
+        _ = sb.Append(");");
     }
 
     /// <summary>Generates a deep chain observation method body using plugin dispatch for the root segment and inner segments.</summary>
@@ -533,24 +574,7 @@ internal static class ObservationCodeGenerator
         var rootPlugin = ResolveRootPlugin(classInfo, seg0);
 
         // First segment: observe root object for first property
-        if (rootPlugin is not null)
-        {
-            rootPlugin.EmitDeepChainRootSegment(sb, "obj", seg0, GetTypeCastName(classInfo), isBeforeChange, "__obs0");
-        }
-        else if (IsINPChanging(classInfo) && isBeforeChange)
-        {
-            _ = sb.Append("            var __obs0 = (global::System.IObservable<").Append(seg0.PropertyTypeFullName)
-                .Append(ChangingObservableOpen).Append(seg0.PropertyTypeFullName).AppendLine(">(")
-                .AppendLine(ChangingSourceArgument).Append(GeneratedSyntax.QuotedArgumentOpen)
-                .Append(seg0.PropertyName).AppendLine("\",").Append(ChangingReaderLambdaOpen)
-                .Append(GetTypeCastName(classInfo)).Append(GeneratedSyntax.ObserverCastClose).Append(seg0.PropertyName).AppendLine(");");
-        }
-        else
-        {
-            _ = sb.Append("            var __obs0 = (global::System.IObservable<").Append(seg0.PropertyTypeFullName).Append('>')
-                .Append(UnchangingObservableOpen).Append(seg0.PropertyTypeFullName).Append(">(obj.")
-                .Append(seg0.PropertyName).AppendLine(");");
-        }
+        EmitChainRootWithChoice(sb, "obj", seg0, classInfo, rootPlugin, isBeforeChange, "__obs0");
 
         EmitObservationChainInnerSegments(sb, path, isBeforeChange);
 
@@ -603,7 +627,8 @@ internal static class ObservationCodeGenerator
                 segment,
                 plugin?.Affinity ?? 0,
                 false,
-                new(GeneratedSyntax.InlineLocalDeclaration, "            ", mechanismVariable, variableName));
+                new(GeneratedSyntax.InlineLocalDeclaration, "            ", mechanismVariable, variableName),
+                propertyTypeFullName);
             _ = sb.AppendLine();
         }
         else
@@ -625,12 +650,20 @@ internal static class ObservationCodeGenerator
     /// <param name="generatedAffinity">The affinity of the mechanism the generator picked.</param>
     /// <param name="isBeforeChange">Whether before-change notifications are being observed.</param>
     /// <param name="layout">Where the choice is written and what it names the locals it declares.</param>
+    /// <param name="valueTypeOverride">
+    /// The element type the surrounding code expects, where it is not the property's own declared type.
+    /// </param>
     /// <remarks>
     /// The registration is resolved where the observation is built rather than at the call site's dispatch, so a
     /// binding keeps its generated write and only its reading changes. The property is named as a literal and
     /// read through an emitted accessor, and the expression handed to the registration is a lambda the compiler
     /// built, so nothing on this path is resolved by name and an ahead-of-time consumer carries no expression
     /// engine for it.
+    /// <para>
+    /// The element type is overridable because a caller can want the property's interface rather than its
+    /// declared type - an interaction property declared as <c>Interaction</c> is observed as
+    /// <c>IInteraction</c> - and the choice has to be typed the same way as the mechanism it wraps.
+    /// </para>
     /// </remarks>
     private static void EmitInlinePluginChoice(
         StringBuilder sb,
@@ -638,10 +671,11 @@ internal static class ObservationCodeGenerator
         PropertyPathSegment segment,
         int generatedAffinity,
         bool isBeforeChange,
-        in PluginChoiceLayout layout)
+        in PluginChoiceLayout layout,
+        string? valueTypeOverride = null)
     {
         var declaringType = segment.DeclaringTypeFullName;
-        var valueType = segment.PropertyTypeFullName;
+        var valueType = valueTypeOverride ?? segment.PropertyTypeFullName;
         var pluginVariable = layout.VariableName + RegistrationVariableSuffix;
         var argumentIndent = $"{layout.ContinuationIndent}    ";
         const string observableOpen = "? (global::System.IObservable<";
@@ -662,6 +696,68 @@ internal static class ObservationCodeGenerator
             .Append(argumentIndent).Append(BooleanLiteral(isBeforeChange)).AppendLine(",")
             .Append(argumentIndent).Append("true);");
     }
+
+    /// <summary>Emits the first link of a chain into a local, and the choice a registration can win for it.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="rootVar">The variable holding the chain root.</param>
+    /// <param name="seg0">The first segment of the path.</param>
+    /// <param name="classInfo">The root type's binding info, when known.</param>
+    /// <param name="rootPlugin">The plugin for the root type, when one matched.</param>
+    /// <param name="isBeforeChange">Whether before-change notifications are being observed.</param>
+    /// <param name="obsVar">The local the link's observation is assigned to.</param>
+    /// <remarks>
+    /// The first link is offered to a registration on the same terms as every later one. Without this the root
+    /// of a chain was the one link a registered plugin could not take, which made the honouring depend on where
+    /// in a path the property sat.
+    /// </remarks>
+    private static void EmitChainRootWithChoice(
+        StringBuilder sb,
+        string rootVar,
+        PropertyPathSegment seg0,
+        ClassBindingInfo? classInfo,
+        IObservationPlugin? rootPlugin,
+        bool isBeforeChange,
+        string obsVar)
+    {
+        var mechanismVariable = obsVar + MechanismVariableSuffix;
+
+        if (rootPlugin is not null)
+        {
+            rootPlugin.EmitDeepChainRootSegment(sb, rootVar, seg0, GetTypeCastName(classInfo), isBeforeChange, mechanismVariable);
+        }
+        else if (IsINPChanging(classInfo) && isBeforeChange)
+        {
+            _ = sb.Append(GeneratedSyntax.BodyLocalDeclaration).Append(mechanismVariable)
+                .Append(" = (global::System.IObservable<").Append(seg0.PropertyTypeFullName)
+                .Append(ChangingObservableOpen).Append(seg0.PropertyTypeFullName).AppendLine(">(")
+                .Append(ChangingSourceArgumentFor(rootVar)).Append(GeneratedSyntax.QuotedArgumentOpen)
+                .Append(seg0.PropertyName).AppendLine("\",").Append(ChangingReaderLambdaOpen)
+                .Append(GetTypeCastName(classInfo)).Append(GeneratedSyntax.ObserverCastClose)
+                .Append(seg0.PropertyName).AppendLine(");");
+        }
+        else
+        {
+            _ = sb.Append(GeneratedSyntax.BodyLocalDeclaration).Append(mechanismVariable)
+                .Append(" = (global::System.IObservable<").Append(seg0.PropertyTypeFullName).Append('>')
+                .Append(UnchangingObservableOpen).Append(seg0.PropertyTypeFullName).Append(">(").Append(rootVar).Append('.')
+                .Append(seg0.PropertyName).AppendLine(");");
+        }
+
+        EmitInlinePluginChoice(
+            sb,
+            rootVar,
+            seg0,
+            rootPlugin?.Affinity ?? 0,
+            isBeforeChange,
+            new(GeneratedSyntax.BodyLocalDeclaration, "                ", mechanismVariable, obsVar));
+    }
+
+    /// <summary>Renders the before-change observable's source argument for a given root.</summary>
+    /// <param name="rootVar">The variable holding the observed object.</param>
+    /// <returns>The argument line the before-change observable takes.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string ChangingSourceArgumentFor(string rootVar) =>
+        $"                (global::System.ComponentModel.INotifyPropertyChanging){rootVar},\n";
 
     /// <summary>Picks the observation plugin for the type that declares a chain segment's property.</summary>
     /// <param name="segment">The chain segment, which carries how its declaring type notifies.</param>
@@ -863,16 +959,7 @@ internal static class ObservationCodeGenerator
     {
         var seg0 = propertyPath[0];
 
-        if (plugin is not null)
-        {
-            plugin.EmitDeepChainRootSegment(sb, rootVar, seg0, GetTypeCastName(classInfo), false, $"__{variableName}_s0");
-        }
-        else
-        {
-            _ = sb.Append("            var __").Append(variableName).Append("_s0 = (global::System.IObservable<").Append(seg0.PropertyTypeFullName)
-                .Append('>').Append(UnchangingObservableOpen).Append(seg0.PropertyTypeFullName)
-                .Append(">(").Append(rootVar).Append('.').Append(seg0.PropertyName).AppendLine(");");
-        }
+        EmitChainRootWithChoice(sb, rootVar, seg0, classInfo, plugin, false, $"__{variableName}_s0");
 
         for (var s = 1; s < propertyPath.Length; s++)
         {

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/WhenAnyCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/WhenAnyCodeGenerator.cs
@@ -65,21 +65,42 @@ internal static class WhenAnyCodeGenerator
         CodeGeneratorHelpers.AppendIndexedStaticPrefixNormalization(sb, supportsCallerArgExpr, "property", propCount);
         EmitDispatchTable(sb, group, supportsCallerArgExpr, propCount);
 
-        // Runtime fallback
-        GenerateRuntimeFallback(sb);
+        GenerateRuntimeFallback(sb, first, propCount);
 
         _ = sb.AppendLine("        }");
     }
 
-    /// <summary>
-    /// Generates the throw path for when no generated WhenAny dispatch match is found.
-    /// Since the source generator matched all invocations at compile time, an unmatched
-    /// dispatch indicates a caching issue — never falls back to runtime reflection.
-    /// </summary>
+    /// <summary>Ends the overload where the stub it displaces would have ended: at the runtime engine.</summary>
     /// <param name="sb">The string builder to append to.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GenerateRuntimeFallback(StringBuilder sb) => sb.AppendLine(
-        "            throw new global::System.InvalidOperationException(\"No generated WhenAny dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.\");");
+    /// <param name="first">The invocation whose types the whole group shares.</param>
+    /// <param name="propCount">The number of observed properties.</param>
+    /// <remarks>
+    /// WhenAny states its projected type before the observed ones - <c>WhenAny&lt;TSender, TRet, T1...&gt;</c> -
+    /// unlike the observation APIs, which put the projection last.
+    /// </remarks>
+    internal static void GenerateRuntimeFallback(StringBuilder sb, InvocationInfo first, int propCount)
+    {
+        var typeArguments = new PooledStringBuilder(CodeGeneratorHelpers.FragmentBufferCapacity);
+        var arguments = new PooledStringBuilder(CodeGeneratorHelpers.FragmentBufferCapacity);
+
+        _ = typeArguments.Append(first.SourceTypeFullName).Append(", ").Append(first.ReturnTypeFullName);
+        _ = arguments.Append("objectToMonitor");
+
+        for (var i = 0; i < propCount; i++)
+        {
+            var path = first.PropertyPaths[i];
+            _ = typeArguments.Append(", ").Append(path[path.Length - 1].PropertyTypeFullName);
+            _ = arguments.Append(", property").Append(i + 1);
+        }
+
+        _ = arguments.Append(", selector");
+
+        CodeGeneratorHelpers.AppendStubFallbackCall(
+            sb,
+            Constants.WhenAnyMethodName,
+            typeArguments.ToStringAndReturn(),
+            arguments.ToStringAndReturn());
+    }
 
     /// <summary>
     /// Generates an observation method for a single WhenAny invocation.
@@ -246,11 +267,20 @@ internal static class WhenAnyCodeGenerator
         ImmutableArray<ClassBindingInfo> allClasses,
         in LanguageFeatures features)
     {
+        var emitted = features.CollapsesIndistinguishableCallSites
+            ? group with
+            {
+                Invocations = CodeGeneratorHelpers.CollapseIndistinguishableCallSites(
+                    group.Invocations,
+                    static x => string.Join("|", x.ExpressionTexts)),
+            }
+            : group;
+
         if (features.SupportsInterceptors)
         {
             InterceptorEmitter.GenerateInterceptors(
                 sb,
-                group,
+                emitted,
                 Constants.WhenAnyMethodName,
                 ObservationMethodSuffix,
                 in features,
@@ -265,7 +295,7 @@ internal static class WhenAnyCodeGenerator
         {
             GenerateConcreteOverload(
                 sb,
-                group,
+                emitted,
                 features.SupportsCallerArgExpr,
                 features.SupportsNullable,
                 features.StubHasExpressionParameters);
@@ -273,9 +303,9 @@ internal static class WhenAnyCodeGenerator
 
         _ = sb.AppendLine();
 
-        for (var i = 0; i < group.Invocations.Length; i++)
+        for (var i = 0; i < emitted.Invocations.Length; i++)
         {
-            var inv = group.Invocations[i];
+            var inv = emitted.Invocations[i];
             GenerateObservationMethod(
                 sb,
                 inv,

--- a/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/WhenAnyObservableCodeGenerator.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/WhenAnyObservableCodeGenerator.cs
@@ -33,6 +33,9 @@ internal static class WhenAnyObservableCodeGenerator
     /// <summary>The base name used to build emitted local variable identifiers for the raw observable property.</summary>
     private const string ObsPropertyVarName = "__obsProperty";
 
+    /// <summary>The selector forwarded after the observed properties, where the overload takes one.</summary>
+    private const string SelectorArgument = ", selector";
+
     /// <summary>Generates concrete typed overloads and observation methods for WhenAnyObservable invocations.</summary>
     /// <param name="invocations">All detected WhenAnyObservable invocations.</param>
     /// <param name="allClasses">All detected class binding info for type mechanism lookup.</param>
@@ -77,10 +80,9 @@ internal static class WhenAnyObservableCodeGenerator
         CodeGeneratorHelpers.AppendIndexedStaticPrefixNormalization(sb, supportsCallerArgExpr, "obs", propCount);
         EmitDispatchTable(sb, group, supportsCallerArgExpr, propCount, hasSelector);
 
-        // Runtime fallback: throw for now (WhenAnyObservable doesn't have a simple fallback path)
-        _ = sb.AppendLine(
-                "            throw new global::System.InvalidOperationException(\"No generated WhenAnyObservable dispatch matched. This indicates a source generator caching issue.\");")
-            .AppendLine("        }");
+        GenerateRuntimeFallback(sb, propCount, hasSelector);
+
+        _ = sb.AppendLine("        }");
     }
 
     /// <summary>Generates an observation method for a single WhenAnyObservable invocation.</summary>
@@ -307,15 +309,24 @@ internal static class WhenAnyObservableCodeGenerator
         ImmutableArray<ClassBindingInfo> allClasses,
         in LanguageFeatures features)
     {
+        var emitted = features.CollapsesIndistinguishableCallSites
+            ? group with
+            {
+                Invocations = CodeGeneratorHelpers.CollapseIndistinguishableCallSites(
+                    group.Invocations,
+                    static x => string.Join("|", x.ExpressionTexts)),
+            }
+            : group;
+
         if (features.SupportsInterceptors)
         {
-            GenerateInterceptors(sb, group, in features);
+            GenerateInterceptors(sb, emitted, in features);
         }
         else
         {
             GenerateConcreteOverload(
                 sb,
-                group,
+                emitted,
                 features.SupportsCallerArgExpr,
                 features.SupportsNullable,
                 features.StubHasExpressionParameters);
@@ -323,9 +334,9 @@ internal static class WhenAnyObservableCodeGenerator
 
         _ = sb.AppendLine();
 
-        for (var i = 0; i < group.Invocations.Length; i++)
+        for (var i = 0; i < emitted.Invocations.Length; i++)
         {
-            var inv = group.Invocations[i];
+            var inv = emitted.Invocations[i];
             GenerateObservationMethod(
                 sb,
                 inv,
@@ -362,7 +373,7 @@ internal static class WhenAnyObservableCodeGenerator
             AppendParameterList(sb, first, supportsCallerArgExpr, supportsNullable, stubHasExpressionParameters);
 
             _ = sb.Append("            => __WhenAnyObservable_").Append(entry.Key).Append("(objectToMonitor")
-                .Append(first.HasSelector ? ", selector" : string.Empty).AppendLine(");").AppendLine();
+                .Append(first.HasSelector ? SelectorArgument : string.Empty).AppendLine(");").AppendLine();
         }
     }
 
@@ -416,6 +427,37 @@ internal static class WhenAnyObservableCodeGenerator
         _ = sb.AppendLine(CodeGeneratorHelpers.CallerInfoParameterList);
     }
 
+    /// <summary>Ends the overload where the stub it displaces would have ended: at the runtime engine.</summary>
+    /// <param name="sb">The string builder to append to.</param>
+    /// <param name="propCount">The number of observed observable properties.</param>
+    /// <param name="hasSelector">Whether the overload takes a selector.</param>
+    /// <remarks>
+    /// The type arguments are left to inference here. WhenAnyObservable states the element type carried by each
+    /// observed <c>IObservable&lt;T&gt;</c> rather than the property's own type, and the generated parameters
+    /// already spell that out, so inference reaches it without the generator taking the type name apart.
+    /// </remarks>
+    private static void GenerateRuntimeFallback(StringBuilder sb, int propCount, bool hasSelector)
+    {
+        var arguments = new PooledStringBuilder(CodeGeneratorHelpers.FragmentBufferCapacity);
+        _ = arguments.Append("objectToMonitor");
+
+        for (var i = 0; i < propCount; i++)
+        {
+            _ = arguments.Append(", obs").Append(i + 1);
+        }
+
+        if (hasSelector)
+        {
+            _ = arguments.Append(SelectorArgument);
+        }
+
+        CodeGeneratorHelpers.AppendStubFallbackCall(
+            sb,
+            Constants.WhenAnyObservableMethodName,
+            string.Empty,
+            arguments.ToStringAndReturn());
+    }
+
     /// <summary>Emits the if/else-if dispatch table that routes each matched invocation to its generated method.</summary>
     /// <param name="sb">The string builder to append to.</param>
     /// <param name="group">The type group containing invocations that share a signature.</param>
@@ -453,7 +495,7 @@ internal static class WhenAnyObservableCodeGenerator
             }
 
             _ = sb.AppendLine("            {");
-            var selectorArg = hasSelector ? ", selector" : string.Empty;
+            var selectorArg = hasSelector ? SelectorArgument : string.Empty;
             var methodSuffix = CodeGeneratorHelpers.ComputeStableMethodSuffix(
                 inv.SourceTypeFullName,
                 inv.CallerFilePath,

--- a/src/ReactiveUI.Binding.SourceGenerators/DiagnosticWarnings.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/DiagnosticWarnings.cs
@@ -22,7 +22,8 @@ internal static class DiagnosticWarnings
     internal static readonly DiagnosticDescriptor NonInlineLambda = new(
         "RXUIBIND001",
         "Expression must be inline lambda",
-        "Expression argument must be an inline lambda expression for compile-time optimization. Variable or method references fall back to runtime.",
+        "Expression argument must be an inline lambda expression for compile-time optimization. A variable or "
+        + "method reference is not generated, so the call throws unless it names the Unsafe overload.",
         UsageCategory,
         DiagnosticSeverity.Info,
         true,
@@ -72,7 +73,7 @@ internal static class DiagnosticWarnings
     internal static readonly DiagnosticDescriptor NoBeforeChangeSupport = new(
         "RXUIBIND004",
         "Type does not support before-change notifications",
-        "Type '{0}' does not support before-change notifications via {1}; WhenChanging will fall back to runtime",
+        "Type '{0}' does not support before-change notifications via {1}; WhenChanging reads the value once and then stays silent",
         UsageCategory,
         DiagnosticSeverity.Warning,
         true,
@@ -92,10 +93,10 @@ internal static class DiagnosticWarnings
     internal static readonly DiagnosticDescriptor DispatchOutOfReach = new(
         "RXUIBIND009",
         "Generated binding dispatch is out of reach here",
-        "This binding falls back to runtime observation. The assembly exposes its internals, so on C# 9 and "
-        + "below the generated dispatch has to live in the root namespace '{0}' to stay unambiguous, and this "
-        + "file's namespace '{1}' is not under it. Move the file under the root namespace, or raise the "
-        + "language version to 10 or later.",
+        "This binding throws rather than reaching its generated code. The assembly exposes its internals, so on "
+        + "C# 9 and below the generated dispatch has to live in the root namespace '{0}' to stay unambiguous, and "
+        + "this file's namespace '{1}' is not under it. Move the file under the root namespace, raise the language "
+        + "version to 10 or later, or name the Unsafe overload to resolve the expression at run time.",
         UsageCategory,
         DiagnosticSeverity.Warning,
         true,
@@ -105,7 +106,7 @@ internal static class DiagnosticWarnings
     internal static readonly DiagnosticDescriptor UnsupportedPathSegment = new(
         "RXUIBIND006",
         "Expression contains unsupported path segment",
-        "Expression contains '{0}' which is not a simple property access. Indexers, fields, and method calls cannot be observed by the source generator and will fall back to runtime.",
+        "Expression contains '{0}' which is not a simple property access. Indexers, fields, and method calls are not generated, so the call throws unless it names the Unsafe overload.",
         UsageCategory,
         DiagnosticSeverity.Warning,
         true,
@@ -136,13 +137,16 @@ internal static class DiagnosticWarnings
         "Compile-time dispatch is chosen by extension-method lookup, which only reaches an overload declared "
         + "in a namespace enclosing the call site. Before C# 10 there is no global using to widen that, and an "
         + "assembly that exposes its internals cannot leave the overloads in the shared namespace without "
-        + "risking an ambiguous call against the assembly it exposes them to. Files outside the root namespace "
-        + "therefore bind to the runtime stub instead.";
+        + "risking an ambiguous call against the assembly it exposes them to. A file outside the root namespace "
+        + "therefore binds to the stub, which throws and names the Unsafe overload that resolves the expression "
+        + "by reflection.";
 
     /// <summary>The string description of the none inline lambda.</summary>
     private const string NoneInlineLambdaDescription =
         "The source generator can only optimize inline lambda expressions (e.g., x => x.Property). "
-        + "Variable references, method calls, or other non-inline expressions will fall back to runtime expression-tree analysis.";
+        + "A variable reference, a method call, or any other non-inline expression produces no generated dispatch, "
+        + "so the call throws. Name the Unsafe overload - WhenChangedUnsafe, BindOneWayUnsafe and so on - to walk "
+        + "the chain by reflection instead, which reports the requirement at the call site under trimming.";
 
     /// <summary>The string description of the no observable properties warning.</summary>
     private const string NoObservablePropertiesDescription =
@@ -152,12 +156,13 @@ internal static class DiagnosticWarnings
     /// <summary>The string description of the private member warning.</summary>
     private const string PrivateMemberDescription =
         "The source generator generates extension methods which cannot access private or protected members. "
-        + "The binding will fall back to runtime reflection.";
+        + "No dispatch is emitted for the call, so it throws unless it names the Unsafe overload.";
 
     /// <summary>The string description of the no before-change support warning.</summary>
     private const string NoBeforeChangeSupportDescription =
         "The notification mechanism for this type does not provide before-change events. "
-        + "WPF DependencyObjects, WinForms Components, and Android Views only support after-change notifications.";
+        + "WPF DependencyObjects, WinForms Components, and Android Views only support after-change notifications, "
+        + "so the observation reports the value as it stands, once, and then nothing further.";
 
     /// <summary>The string description of the validation not generated warning.</summary>
     private const string ValidationNotGeneratedDescription =

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/BindToExtractor.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/BindToExtractor.cs
@@ -65,8 +65,8 @@ internal static class BindToExtractor
         }
 
         var reflectionOnly = targetPropertyPath is null || targetPropertyPath.Length == 0;
-        var targetPropertyTypeFullName = WrittenPropertyType(methodSymbol, targetPropertyPath, reflectionOnly);
-        if (targetPropertyTypeFullName is null)
+        var written = WrittenProperty(methodSymbol, targetPropertyPath, reflectionOnly);
+        if (written is null)
         {
             return null;
         }
@@ -87,7 +87,8 @@ internal static class BindToExtractor
             sourceValueTypeFullName,
             targetTypeName,
             targetPath,
-            targetPropertyTypeFullName,
+            written.Value.TypeFullName,
+            written.Value.IsReferenceType,
             hasConversionHint,
             hasConverterOverride,
             targetExpressionText,
@@ -125,19 +126,30 @@ internal static class BindToExtractor
     /// <param name="methodSymbol">The method the call resolved to.</param>
     /// <param name="targetPropertyPath">The path read from the selector, where one could be read.</param>
     /// <param name="reflectionOnly">Whether the selector resolved to no path at compile time.</param>
-    /// <returns>The fully qualified property type, or <see langword="null"/> when nothing declarable is there.</returns>
+    /// <returns>The written type, or <see langword="null"/> when nothing declarable is there.</returns>
     /// <remarks>
     /// A selector the compiler could read names the type at the end of the path. One it could not still resolved
     /// to a method, whose last type argument is that same property's type, so the call is served rather than
     /// dropped for want of a name the path would have supplied.
     /// </remarks>
-    private static string? WrittenPropertyType(
+    private static WrittenPropertyType? WrittenProperty(
         IMethodSymbol methodSymbol,
         PropertyPathSegment[]? targetPropertyPath,
-        bool reflectionOnly) =>
-        reflectionOnly
-            ? ExtractorValidation.TypeArgumentDisplayName(methodSymbol, methodSymbol.TypeArguments.Length - 1)
-            : targetPropertyPath![^1].PropertyTypeFullName;
+        bool reflectionOnly)
+    {
+        if (!reflectionOnly)
+        {
+            var leaf = targetPropertyPath![targetPropertyPath.Length - 1];
+            return new(leaf.PropertyTypeFullName, leaf.IsReferenceType);
+        }
+
+        var written = ExtractorValidation.DeclarableTypeArgument(methodSymbol, methodSymbol.TypeArguments.Length - 1);
+        return written is null
+            ? null
+            : new WrittenPropertyType(
+                written.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                written.IsReferenceType);
+    }
 
     /// <summary>Determines whether a type is the framework's own <c>System.IObservable&lt;T&gt;</c>.</summary>
     /// <param name="type">The type to judge.</param>
@@ -182,4 +194,9 @@ internal static class BindToExtractor
             }
         }
     }
+
+    /// <summary>The type a <c>BindTo</c> call writes to.</summary>
+    /// <param name="TypeFullName">The fully qualified property type.</param>
+    /// <param name="IsReferenceType">Whether that type is a reference type.</param>
+    private readonly record struct WrittenPropertyType(string TypeFullName, bool IsReferenceType);
 }

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/BindToExtractor.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/BindToExtractor.cs
@@ -58,15 +58,21 @@ internal static class BindToExtractor
         var targetTypeName =
             ExtractorValidation.GetDeclarableTypeDisplayName(semanticModel.GetTypeInfo(args[0].Expression, ct).Type);
 
-        // One guard for both: a target the model could not name is as unusable as a property path it could
-        // not read, and the target type is only reachable through an argument the path check already covers.
-        if (targetPropertyPath is null || targetPropertyPath.Length == 0 || targetTypeName is null)
+        // A target the model cannot name leaves nothing to declare a member against, generated or otherwise.
+        if (targetTypeName is null)
+        {
+            return null;
+        }
+
+        var reflectionOnly = targetPropertyPath is null || targetPropertyPath.Length == 0;
+        var targetPropertyTypeFullName = WrittenPropertyType(methodSymbol, targetPropertyPath, reflectionOnly);
+        if (targetPropertyTypeFullName is null)
         {
             return null;
         }
 
         var sourceValueTypeFullName = sourceValueType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-        var targetPropertyTypeFullName = targetPropertyPath[^1].PropertyTypeFullName;
+        EquatableArray<PropertyPathSegment> targetPath = reflectionOnly ? default : new(targetPropertyPath!);
 
         DetectConversionParameters(methodSymbol, out var hasConversionHint, out var hasConverterOverride);
 
@@ -80,12 +86,13 @@ internal static class BindToExtractor
             lineNumber,
             sourceValueTypeFullName,
             targetTypeName,
-            new(targetPropertyPath),
+            targetPath,
             targetPropertyTypeFullName,
             hasConversionHint,
             hasConverterOverride,
             targetExpressionText,
-            InterceptableLocationReader.Read(semanticModel, invocation, ct));
+            InterceptableLocationReader.Read(semanticModel, invocation, ct),
+            reflectionOnly);
     }
 
     /// <summary>
@@ -113,6 +120,24 @@ internal static class BindToExtractor
 
         return null;
     }
+
+    /// <summary>Names the type of the property a call writes, however the call names it.</summary>
+    /// <param name="methodSymbol">The method the call resolved to.</param>
+    /// <param name="targetPropertyPath">The path read from the selector, where one could be read.</param>
+    /// <param name="reflectionOnly">Whether the selector resolved to no path at compile time.</param>
+    /// <returns>The fully qualified property type, or <see langword="null"/> when nothing declarable is there.</returns>
+    /// <remarks>
+    /// A selector the compiler could read names the type at the end of the path. One it could not still resolved
+    /// to a method, whose last type argument is that same property's type, so the call is served rather than
+    /// dropped for want of a name the path would have supplied.
+    /// </remarks>
+    private static string? WrittenPropertyType(
+        IMethodSymbol methodSymbol,
+        PropertyPathSegment[]? targetPropertyPath,
+        bool reflectionOnly) =>
+        reflectionOnly
+            ? ExtractorValidation.TypeArgumentDisplayName(methodSymbol, methodSymbol.TypeArguments.Length - 1)
+            : targetPropertyPath![^1].PropertyTypeFullName;
 
     /// <summary>Determines whether a type is the framework's own <c>System.IObservable&lt;T&gt;</c>.</summary>
     /// <param name="type">The type to judge.</param>

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/ExtractorValidation.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/ExtractorValidation.cs
@@ -158,44 +158,22 @@ internal static class ExtractorValidation
             : "global::System.EventArgs";
     }
 
-    /// <summary>Names one of the type arguments the compiler settled on for a resolved call.</summary>
+    /// <summary>Takes one of the type arguments the compiler settled on for a resolved call.</summary>
     /// <param name="methodSymbol">The method the call resolved to.</param>
-    /// <param name="index">Which of its type arguments to name.</param>
-    /// <returns>The fully qualified name, or <see langword="null"/> when nothing declarable is there.</returns>
+    /// <param name="index">Which of its type arguments to take.</param>
+    /// <returns>The type, or <see langword="null"/> when nothing a member could declare is there.</returns>
     /// <remarks>
     /// The route to a type when the property path is not one: a selector built at run time still resolves to a
     /// method whose type arguments the compiler inferred, and those are the types the generated member has to
     /// declare. An index outside the list answers null rather than throwing, so a caller reading a shape this
     /// package does not serve declines the call site instead of failing the whole generation pass.
     /// </remarks>
-    internal static string? TypeArgumentDisplayName(IMethodSymbol methodSymbol, int index) =>
-        index < 0 || index >= methodSymbol.TypeArguments.Length
-            ? null
-            : GetDeclarableTypeDisplayName(methodSymbol.TypeArguments[index]);
-
-    /// <summary>Names the type a selector produces, read from the selector rather than from its body.</summary>
-    /// <param name="semanticModel">The semantic model for the call site.</param>
-    /// <param name="selector">The argument the selector was passed as.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The fully qualified produced type, or <see langword="null"/> when nothing declarable is there.</returns>
-    /// <remarks>
-    /// A selector held in a variable, or built at run time, has no body a path can be read from - but it still
-    /// has a type, and that type is <c>Expression&lt;Func&lt;TInput, TProduced&gt;&gt;</c>. Taking the produced
-    /// type from there is what lets a call site the compiler could not read still be served, because the
-    /// generated member has to declare exactly the types the call already has.
-    /// </remarks>
-    internal static string? SelectorProducedTypeDisplayName(
-        SemanticModel semanticModel,
-        Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax selector,
-        CancellationToken ct)
-    {
-        // Expression<Func<TInput, TProduced>>: unwrap the expression, then take what the delegate returns.
-        return semanticModel.GetTypeInfo(selector, ct).ConvertedType
-                is INamedTypeSymbol { TypeArguments.Length: 1 } expression
-            && expression.TypeArguments[0] is INamedTypeSymbol { TypeArguments.Length: > 1 } func
-            ? GetTypeDisplayName(func.TypeArguments[func.TypeArguments.Length - 1])
+    internal static INamedTypeSymbol? DeclarableTypeArgument(IMethodSymbol methodSymbol, int index) =>
+        index >= 0
+        && index < methodSymbol.TypeArguments.Length
+        && methodSymbol.TypeArguments[index] is INamedTypeSymbol { IsStatic: false } named
+            ? named
             : null;
-    }
 
     /// <summary>Checks whether a type is the synthesized grouping type that holds an extension block's members.</summary>
     /// <param name="type">The type to check.</param>

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/ExtractorValidation.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/ExtractorValidation.cs
@@ -158,6 +158,45 @@ internal static class ExtractorValidation
             : "global::System.EventArgs";
     }
 
+    /// <summary>Names one of the type arguments the compiler settled on for a resolved call.</summary>
+    /// <param name="methodSymbol">The method the call resolved to.</param>
+    /// <param name="index">Which of its type arguments to name.</param>
+    /// <returns>The fully qualified name, or <see langword="null"/> when nothing declarable is there.</returns>
+    /// <remarks>
+    /// The route to a type when the property path is not one: a selector built at run time still resolves to a
+    /// method whose type arguments the compiler inferred, and those are the types the generated member has to
+    /// declare. An index outside the list answers null rather than throwing, so a caller reading a shape this
+    /// package does not serve declines the call site instead of failing the whole generation pass.
+    /// </remarks>
+    internal static string? TypeArgumentDisplayName(IMethodSymbol methodSymbol, int index) =>
+        index < 0 || index >= methodSymbol.TypeArguments.Length
+            ? null
+            : GetDeclarableTypeDisplayName(methodSymbol.TypeArguments[index]);
+
+    /// <summary>Names the type a selector produces, read from the selector rather than from its body.</summary>
+    /// <param name="semanticModel">The semantic model for the call site.</param>
+    /// <param name="selector">The argument the selector was passed as.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The fully qualified produced type, or <see langword="null"/> when nothing declarable is there.</returns>
+    /// <remarks>
+    /// A selector held in a variable, or built at run time, has no body a path can be read from - but it still
+    /// has a type, and that type is <c>Expression&lt;Func&lt;TInput, TProduced&gt;&gt;</c>. Taking the produced
+    /// type from there is what lets a call site the compiler could not read still be served, because the
+    /// generated member has to declare exactly the types the call already has.
+    /// </remarks>
+    internal static string? SelectorProducedTypeDisplayName(
+        SemanticModel semanticModel,
+        Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax selector,
+        CancellationToken ct)
+    {
+        // Expression<Func<TInput, TProduced>>: unwrap the expression, then take what the delegate returns.
+        return semanticModel.GetTypeInfo(selector, ct).ConvertedType
+                is INamedTypeSymbol { TypeArguments.Length: 1 } expression
+            && expression.TypeArguments[0] is INamedTypeSymbol { TypeArguments.Length: > 1 } func
+            ? GetTypeDisplayName(func.TypeArguments[func.TypeArguments.Length - 1])
+            : null;
+    }
+
     /// <summary>Checks whether a type is the synthesized grouping type that holds an extension block's members.</summary>
     /// <param name="type">The type to check.</param>
     /// <returns><see langword="true"/> if the type is an extension grouping type; otherwise <see langword="false"/>.</returns>

--- a/src/ReactiveUI.Binding.SourceGenerators/Helpers/InvokeCommandExtractor.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Helpers/InvokeCommandExtractor.cs
@@ -64,16 +64,25 @@ internal static class InvokeCommandExtractor
         var targetTypeName =
             ExtractorValidation.GetDeclarableTypeDisplayName(semanticModel.GetTypeInfo(args[0].Expression, ct).Type);
 
-        // One guard for both: a target the model could not name is as unusable as a path it could not read.
-        return commandPropertyPath is null || commandPropertyPath.Length == 0 || targetTypeName is null
-            ? null
-            : new InvokeCommandInvocationInfo(
-                invocation.SyntaxTree.FilePath,
-                invocation.GetLocation().GetLineSpan().StartLinePosition.Line + 1,
-                sourceValueType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                targetTypeName,
-                new(commandPropertyPath),
-                CodeGeneration.CodeGeneratorHelpers.NormalizeLambdaText(commandArg.ToString()),
-                InterceptableLocationReader.Read(semanticModel, invocation, ct));
+        // A target the model cannot name leaves nothing to declare a member against, generated or otherwise.
+        if (targetTypeName is null)
+        {
+            return null;
+        }
+
+        // A path the compiler could not read is still a call this package answers - through the runtime engine
+        // rather than a generated observation - so it is carried on instead of dropped, marked for the emitter.
+        var reflectionOnly = commandPropertyPath is null || commandPropertyPath.Length == 0;
+        EquatableArray<PropertyPathSegment> path = reflectionOnly ? default : new(commandPropertyPath!);
+
+        return new(
+            invocation.SyntaxTree.FilePath,
+            invocation.GetLocation().GetLineSpan().StartLinePosition.Line + 1,
+            sourceValueType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            targetTypeName,
+            path,
+            CodeGeneration.CodeGeneratorHelpers.NormalizeLambdaText(commandArg.ToString()),
+            InterceptableLocationReader.Read(semanticModel, invocation, ct),
+            reflectionOnly);
     }
 }

--- a/src/ReactiveUI.Binding.SourceGenerators/Models/BindToInvocationInfo.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Models/BindToInvocationInfo.cs
@@ -21,6 +21,13 @@ namespace ReactiveUI.Binding.SourceGenerators.Models;
 /// <param name="Interceptor">
 /// Where this call site is, for a build that claims call sites outright rather than competing for them.
 /// </param>
+/// <param name="ReflectionOnly">
+/// Whether the selector named a path the compiler could read. A selector built at run time, or held in a
+/// variable, resolves to nothing at compile time, so the call site is served by the runtime engine and the member
+/// claiming it says so with <c>[RequiresUnreferencedCode]</c> - which puts the warning on the call that reflects
+/// rather than on every call sharing its types. The types still come from the call, read off the method the
+/// compiler resolved rather than off the path it could not.
+/// </param>
 internal sealed record BindToInvocationInfo(
     string CallerFilePath,
     int CallerLineNumber,
@@ -31,4 +38,5 @@ internal sealed record BindToInvocationInfo(
     bool HasConversionHint,
     bool HasConverterOverride,
     string TargetExpressionText,
-    InterceptorLocation Interceptor = default);
+    InterceptorLocation Interceptor = default,
+    bool ReflectionOnly = false);

--- a/src/ReactiveUI.Binding.SourceGenerators/Models/BindToInvocationInfo.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Models/BindToInvocationInfo.cs
@@ -15,6 +15,10 @@ namespace ReactiveUI.Binding.SourceGenerators.Models;
 /// <param name="TargetTypeFullName">The fully qualified name of the target object type.</param>
 /// <param name="TargetPropertyPath">The property path chain from the target lambda expression.</param>
 /// <param name="TargetPropertyTypeFullName">The fully qualified type of the target property (leaf of the target path).</param>
+/// <param name="TargetPropertyIsReferenceType">
+/// Whether that type is a reference type, which decides whether the generated selector parameter is annotated
+/// nullable. It has to match the stub's own annotation or the overload is merely applicable rather than better.
+/// </param>
 /// <param name="HasConversionHint">Whether the invocation supplies a <c>conversionHint</c> argument.</param>
 /// <param name="HasConverterOverride">Whether the invocation supplies an explicit <c>IBindingTypeConverter</c> argument.</param>
 /// <param name="TargetExpressionText">The original expression text of the target lambda argument.</param>
@@ -35,6 +39,7 @@ internal sealed record BindToInvocationInfo(
     string TargetTypeFullName,
     EquatableArray<PropertyPathSegment> TargetPropertyPath,
     string TargetPropertyTypeFullName,
+    bool TargetPropertyIsReferenceType,
     bool HasConversionHint,
     bool HasConverterOverride,
     string TargetExpressionText,

--- a/src/ReactiveUI.Binding.SourceGenerators/Models/InvokeCommandInvocationInfo.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Models/InvokeCommandInvocationInfo.cs
@@ -18,6 +18,12 @@ namespace ReactiveUI.Binding.SourceGenerators.Models;
 /// <param name="Interceptor">
 /// Where this call site is, for a build that claims call sites outright rather than competing for them.
 /// </param>
+/// <param name="ReflectionOnly">
+/// Whether the selector named a path the compiler could read. A selector built at run time, or held in a
+/// variable, resolves to nothing at compile time, so the call site is served by the runtime engine instead of a
+/// generated observation - and the member claiming it says so with <c>[RequiresUnreferencedCode]</c>, which is
+/// what puts the warning on the call that actually reflects rather than on every call sharing its types.
+/// </param>
 internal sealed record InvokeCommandInvocationInfo(
     string CallerFilePath,
     int CallerLineNumber,
@@ -25,4 +31,5 @@ internal sealed record InvokeCommandInvocationInfo(
     string TargetTypeFullName,
     EquatableArray<PropertyPathSegment> CommandPropertyPath,
     string CommandExpressionText,
-    InterceptorLocation Interceptor = default);
+    InterceptorLocation Interceptor = default,
+    bool ReflectionOnly = false);

--- a/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/ChainRegistrationEmitter.cs
+++ b/src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/ChainRegistrationEmitter.cs
@@ -17,30 +17,45 @@ namespace ReactiveUI.Binding.SourceGenerators.Plugins.Observation;
 /// </remarks>
 internal static class ChainRegistrationEmitter
 {
+    /// <summary>The opening a link inside a switch expression is written with.</summary>
+    internal const string TernaryOpening = "                ? ";
+
+    /// <summary>The argument indent a link inside a switch expression is written with.</summary>
+    internal const string TernaryArgumentIndent = "                    ";
+
     /// <summary>Appends the chooser and its arguments, leaving the mechanism's observation to follow.</summary>
     /// <param name="sb">The string builder to append to.</param>
-    /// <param name="lambdaParam">The name the switch lambda gives the parent value.</param>
+    /// <param name="sourceExpression">The expression naming the object the property is read from.</param>
     /// <param name="segment">The property path segment being observed.</param>
     /// <param name="generatedAffinity">The affinity of the mechanism this link was built from.</param>
     /// <param name="isBeforeChange">Whether before-change notifications are being observed.</param>
+    /// <param name="opening">What the call is written after, which differs by the position it sits in.</param>
+    /// <param name="argumentIndent">The indent each argument is written at.</param>
+    /// <remarks>
+    /// A link inside a switch expression is written after a <c>?</c>; the first link of a chain and a
+    /// single-property observation are written after a <c>return</c>. The arguments are the same either way, so
+    /// the position is handed in rather than the call being written twice.
+    /// </remarks>
     internal static void AppendChoiceOpen(
         StringBuilder sb,
-        string lambdaParam,
+        string sourceExpression,
         PropertyPathSegment segment,
         int generatedAffinity,
-        bool isBeforeChange)
+        bool isBeforeChange,
+        string opening = TernaryOpening,
+        string argumentIndent = TernaryArgumentIndent)
     {
         var declaringType = segment.DeclaringTypeFullName;
         var valueType = segment.PropertyTypeFullName;
 
-        _ = sb.Append("                ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<")
+        _ = sb.Append(opening).Append("global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<")
             .Append(valueType).AppendLine(">(")
-            .Append("                    ").Append(lambdaParam).AppendLine(",")
-            .Append("                    ((global::System.Linq.Expressions.Expression<global::System.Func<").Append(declaringType).Append(", ")
+            .Append(argumentIndent).Append(sourceExpression).AppendLine(",")
+            .Append(argumentIndent).Append("((global::System.Linq.Expressions.Expression<global::System.Func<").Append(declaringType).Append(", ")
             .Append(valueType).Append(">>)(__e => __e.").Append(segment.PropertyName).AppendLine(")).Body,")
-            .Append("                    \"").Append(segment.PropertyName).AppendLine("\",")
-            .Append("                    ").Append(isBeforeChange ? "true" : "false").AppendLine(",")
-            .Append("                    ").Append(generatedAffinity).AppendLine(",")
-            .Append("                    (object __o) => ((").Append(declaringType).Append(")__o).").Append(segment.PropertyName).AppendLine(",");
+            .Append(argumentIndent).Append('"').Append(segment.PropertyName).AppendLine("\",")
+            .Append(argumentIndent).Append(isBeforeChange ? "true" : "false").AppendLine(",")
+            .Append(argumentIndent).Append(generatedAffinity).AppendLine(",")
+            .Append(argumentIndent).Append("(object __o) => ((").Append(declaringType).Append(")__o).").Append(segment.PropertyName).AppendLine(",");
     }
 }

--- a/src/ReactiveUI.Binding/ReactiveUI.Binding.csproj
+++ b/src/ReactiveUI.Binding/ReactiveUI.Binding.csproj
@@ -5,6 +5,14 @@
     <PackageTags>reactiveui;binding;observableforproperty</PackageTags>
   </PropertyGroup>
 
+  <!-- The .editorconfig sets every IL20xx/IL30xx rule to error; the analysers that raise them only run when
+       these are set, so without this the policy never reaches the source that ships. Only the frameworks that
+       have a linker - net4x has neither a trimmer nor an AOT compiler. -->
+  <PropertyGroup Condition="!$(TargetFramework.StartsWith('net4'))">
+    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
   <!-- The seam source, compiled here with the lean identity: ISequencer resolves to
        ReactiveUI.Primitives.Concurrency and the namespaces stay unshifted. ReactiveUI.Binding.Reactive
        links these same files under REACTIVE_SHIM. -->

--- a/src/tests/ReactiveUI.Binding.Analyzer.Tests/Helpers/AnalyzerTestHelper.cs
+++ b/src/tests/ReactiveUI.Binding.Analyzer.Tests/Helpers/AnalyzerTestHelper.cs
@@ -179,7 +179,7 @@ public static class AnalyzerTestHelper
         private const string RootNamespaceKey = "build_property.RootNamespace";
 
         /// <summary>The shared empty option map.</summary>
-        private static readonly Dictionary<string, string> EmptyOptions = new(StringComparer.Ordinal);
+        private static readonly Dictionary<string, string> EmptyOptions = [with(StringComparer.Ordinal)];
 
         /// <summary>The per-file options, which nothing under test reads.</summary>
         private static readonly FixedOptions NoOptions = new(EmptyOptions);

--- a/src/tests/ReactiveUI.Binding.AotValidation/AotViewModel.cs
+++ b/src/tests/ReactiveUI.Binding.AotValidation/AotViewModel.cs
@@ -67,6 +67,23 @@ public class AotViewModel : INotifyPropertyChanged, INotifyPropertyChanging
         }
     } = new();
 
+    /// <summary>Gets or sets the stream a WhenAnyObservable call switches to.</summary>
+    public IObservable<string>? Signal
+    {
+        get => field;
+        set
+        {
+            if (field == value)
+            {
+                return;
+            }
+
+            PropertyChanging?.Invoke(this, new(nameof(Signal)));
+            field = value;
+            PropertyChanged?.Invoke(this, new(nameof(Signal)));
+        }
+    }
+
     /// <summary>Gets or sets the command a stream of values is invoked against.</summary>
     public ICommand? Save
     {

--- a/src/tests/ReactiveUI.Binding.AotValidation/Program.cs
+++ b/src/tests/ReactiveUI.Binding.AotValidation/Program.cs
@@ -61,6 +61,8 @@ internal static class Program
         ValidateOneWayBind();
         ValidateBind();
         ValidateInvokeCommand();
+        ValidateWhenAny();
+        ValidateWhenAnyObservable();
 
         Report(string.Empty);
         Report($"AOT Validation: {_passed} passed, {_failed} failed");
@@ -187,6 +189,30 @@ internal static class Program
         viewModel.Name = ReplacementName;
         AssertEqual("InvokeCommand after set", ExpectedTwoExecutions, command.ExecuteCount);
         AssertEqual("InvokeCommand parameter after set", ReplacementName, command.LastParameter as string);
+    }
+
+    /// <summary>WhenAny reports the observed change, and its selector projects it.</summary>
+    private static void ValidateWhenAny()
+    {
+        var vm = new AotViewModel { Name = InitialName };
+        string? last = null;
+        using var sub = vm.WhenAny(x => x.Name, static c => c.Value).Subscribe(v => last = v);
+        AssertEqual("WhenAny initial", InitialName, last);
+        vm.Name = ReplacementName;
+        AssertEqual("WhenAny after set", ReplacementName, last);
+    }
+
+    /// <summary>WhenAnyObservable switches to the stream the observed property holds.</summary>
+    private static void ValidateWhenAnyObservable()
+    {
+        var stream = new System.Reactive.Subjects.Subject<string>();
+        var vm = new AotViewModel { Signal = stream };
+        string? last = null;
+        using var sub = vm.WhenAnyObservable(x => x.Signal!).Subscribe(v => last = v);
+        stream.OnNext(InitialName);
+        AssertEqual("WhenAnyObservable first value", InitialName, last);
+        stream.OnNext(ReplacementName);
+        AssertEqual("WhenAnyObservable second value", ReplacementName, last);
     }
 
     /// <summary>Compares an expected and actual value, recording a pass or failure to the console.</summary>

--- a/src/tests/ReactiveUI.Binding.AotValidation/ReactiveUI.Binding.AotValidation.csproj
+++ b/src/tests/ReactiveUI.Binding.AotValidation/ReactiveUI.Binding.AotValidation.csproj
@@ -2,12 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <PublishAot>true</PublishAot>
+    <TrimMode>full</TrimMode>
+    <InvariantGlobalization>true</InvariantGlobalization>
     <IsTestProject>false</IsTestProject>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+
+    <!-- The point of this project: an IL warning is a build failure, not a note in the log. -->
+    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2055;IL2067;IL2070;IL2072;IL2075;IL2091;IL3050</WarningsAsErrors>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BCG.DeepCommandPath#BindCommandDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BCG.DeepCommandPath#BindCommandDispatch.g.verified.cs
@@ -50,12 +50,22 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 return global::ReactiveUI.Primitives.Disposables.EmptyDisposable.Instance;
             }
 
-            var __commandObs_s0 = (global::System.IObservable<global::SharedScenarios.BindCommand.DeepCommandPath.ChildViewModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.BindCommand.DeepCommandPath.ChildViewModel>(
+            var __commandObs_s0Mechanism = (global::System.IObservable<global::SharedScenarios.BindCommand.DeepCommandPath.ChildViewModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.BindCommand.DeepCommandPath.ChildViewModel>(
                 viewModel,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.BindCommand.DeepCommandPath.MyViewModel)__o).Child,
                 false);
-
+            var __commandObs_s0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.BindCommand.DeepCommandPath.MyViewModel), "Child", 5, false);
+            var __commandObs_s0 = __commandObs_s0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.BindCommand.DeepCommandPath.ChildViewModel>)__commandObs_s0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.BindCommand.DeepCommandPath.ChildViewModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.BindCommand.DeepCommandPath.ChildViewModel>(
+                    __commandObs_s0Registration,
+                    viewModel,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.BindCommand.DeepCommandPath.MyViewModel, global::SharedScenarios.BindCommand.DeepCommandPath.ChildViewModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.BindCommand.DeepCommandPath.MyViewModel)__o).Child,
+                    false,
+                    true);
         var __commandObs_s1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.BindCommand.DeepCommandPath.ChildViewModel, global::System.Windows.Input.ICommand>(__commandObs_s0,
             __p1 => __p1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<global::System.Windows.Input.ICommand>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.CFPFallback#BindInteractionDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.CFPFallback#BindInteractionDispatch.g.verified.cs
@@ -43,12 +43,22 @@ namespace ReactiveUI.Binding
         {
             return serial;
         }
-
-        var interactionObs = new global::ReactiveUI.Binding.Observables.PropertyObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>(
+        var interactionObsMechanism = new global::ReactiveUI.Binding.Observables.PropertyObservable<global::ReactiveUI.Binding.Interaction<string, bool>>(
             viewModel,
             "Confirm",
             (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.BindInteraction.TaskHandler.MyViewModel)__o).Confirm,
             true);
+        var interactionObsRegistration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.BindInteraction.TaskHandler.MyViewModel), "Confirm", 5, false);
+        var interactionObs = interactionObsRegistration == null
+            ? (global::System.IObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>)interactionObsMechanism
+            : (global::System.IObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>(
+                interactionObsRegistration,
+                viewModel,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.BindInteraction.TaskHandler.MyViewModel, global::ReactiveUI.Binding.IInteraction<string, bool>>>)(__e => __e.Confirm)).Body,
+                "Confirm",
+                (object __o) => ((global::SharedScenarios.BindInteraction.TaskHandler.MyViewModel)__o).Confirm,
+                false,
+                true);
 
             var sub = global::ReactiveUI.Primitives.SubscribeExtensions.Subscribe(interactionObs, interaction =>
             {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.CFPFallback_DeepPropertyPath#BindInteractionDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.CFPFallback_DeepPropertyPath#BindInteractionDispatch.g.verified.cs
@@ -43,12 +43,22 @@ namespace ReactiveUI.Binding
         {
             return serial;
         }
-            var __interactionObs_s0 = (global::System.IObservable<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>(
+            var __interactionObs_s0Mechanism = (global::System.IObservable<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>(
                 viewModel,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.BindInteraction.DeepPropertyPath.MyViewModel)__o).Child,
                 false);
-
+            var __interactionObs_s0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.BindInteraction.DeepPropertyPath.MyViewModel), "Child", 5, false);
+            var __interactionObs_s0 = __interactionObs_s0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>)__interactionObs_s0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>(
+                    __interactionObs_s0Registration,
+                    viewModel,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.BindInteraction.DeepPropertyPath.MyViewModel, global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.BindInteraction.DeepPropertyPath.MyViewModel)__o).Child,
+                    false,
+                    true);
         var __interactionObs_s1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel, global::ReactiveUI.Binding.Interaction<string, bool>>(__interactionObs_s0,
             __p1 => __p1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<global::ReactiveUI.Binding.Interaction<string, bool>>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.CFPFallback_NonINPCViewModel#BindInteractionDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.CFPFallback_NonINPCViewModel#BindInteractionDispatch.g.verified.cs
@@ -43,8 +43,18 @@ namespace ReactiveUI.Binding
         {
             return serial;
         }
-
-        var interactionObs = new global::ReactiveUI.Binding.Observables.UnchangingPropertyObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>(viewModel.Confirm);
+        var interactionObsMechanism = new global::ReactiveUI.Binding.Observables.UnchangingPropertyObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>(viewModel.Confirm);
+        var interactionObsRegistration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.BindInteraction.NonINPCViewModel.MyViewModel), "Confirm", 0, false);
+        var interactionObs = interactionObsRegistration == null
+            ? (global::System.IObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>)interactionObsMechanism
+            : (global::System.IObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>(
+                interactionObsRegistration,
+                viewModel,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.BindInteraction.NonINPCViewModel.MyViewModel, global::ReactiveUI.Binding.IInteraction<string, bool>>>)(__e => __e.Confirm)).Body,
+                "Confirm",
+                (object __o) => ((global::SharedScenarios.BindInteraction.NonINPCViewModel.MyViewModel)__o).Confirm,
+                false,
+                true);
 
             var sub = global::ReactiveUI.Primitives.SubscribeExtensions.Subscribe(interactionObs, interaction =>
             {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.CFPFallback_ObservableHandler#BindInteractionDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.CFPFallback_ObservableHandler#BindInteractionDispatch.g.verified.cs
@@ -43,12 +43,22 @@ namespace ReactiveUI.Binding
         {
             return serial;
         }
-
-        var interactionObs = new global::ReactiveUI.Binding.Observables.PropertyObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>(
+        var interactionObsMechanism = new global::ReactiveUI.Binding.Observables.PropertyObservable<global::ReactiveUI.Binding.Interaction<string, bool>>(
             viewModel,
             "Confirm",
             (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.BindInteraction.ObservableHandler.MyViewModel)__o).Confirm,
             true);
+        var interactionObsRegistration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.BindInteraction.ObservableHandler.MyViewModel), "Confirm", 5, false);
+        var interactionObs = interactionObsRegistration == null
+            ? (global::System.IObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>)interactionObsMechanism
+            : (global::System.IObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>(
+                interactionObsRegistration,
+                viewModel,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.BindInteraction.ObservableHandler.MyViewModel, global::ReactiveUI.Binding.IInteraction<string, bool>>>)(__e => __e.Confirm)).Body,
+                "Confirm",
+                (object __o) => ((global::SharedScenarios.BindInteraction.ObservableHandler.MyViewModel)__o).Confirm,
+                false,
+                true);
 
             var sub = global::ReactiveUI.Primitives.SubscribeExtensions.Subscribe(interactionObs, interaction =>
             {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.DeepPropertyPath#BindInteractionDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.DeepPropertyPath#BindInteractionDispatch.g.verified.cs
@@ -44,12 +44,22 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
         {
             return serial;
         }
-            var __interactionObs_s0 = (global::System.IObservable<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>(
+            var __interactionObs_s0Mechanism = (global::System.IObservable<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>(
                 viewModel,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.BindInteraction.DeepPropertyPath.MyViewModel)__o).Child,
                 false);
-
+            var __interactionObs_s0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.BindInteraction.DeepPropertyPath.MyViewModel), "Child", 5, false);
+            var __interactionObs_s0 = __interactionObs_s0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>)__interactionObs_s0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>(
+                    __interactionObs_s0Registration,
+                    viewModel,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.BindInteraction.DeepPropertyPath.MyViewModel, global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.BindInteraction.DeepPropertyPath.MyViewModel)__o).Child,
+                    false,
+                    true);
         var __interactionObs_s1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.BindInteraction.DeepPropertyPath.ChildViewModel, global::ReactiveUI.Binding.Interaction<string, bool>>(__interactionObs_s0,
             __p1 => __p1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<global::ReactiveUI.Binding.Interaction<string, bool>>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.NonINPCViewModel#BindInteractionDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.NonINPCViewModel#BindInteractionDispatch.g.verified.cs
@@ -44,8 +44,18 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
         {
             return serial;
         }
-
-        var interactionObs = new global::ReactiveUI.Binding.Observables.UnchangingPropertyObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>(viewModel.Confirm);
+        var interactionObsMechanism = new global::ReactiveUI.Binding.Observables.UnchangingPropertyObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>(viewModel.Confirm);
+        var interactionObsRegistration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.BindInteraction.NonINPCViewModel.MyViewModel), "Confirm", 0, false);
+        var interactionObs = interactionObsRegistration == null
+            ? (global::System.IObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>)interactionObsMechanism
+            : (global::System.IObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>(
+                interactionObsRegistration,
+                viewModel,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.BindInteraction.NonINPCViewModel.MyViewModel, global::ReactiveUI.Binding.IInteraction<string, bool>>>)(__e => __e.Confirm)).Body,
+                "Confirm",
+                (object __o) => ((global::SharedScenarios.BindInteraction.NonINPCViewModel.MyViewModel)__o).Confirm,
+                false,
+                true);
 
             var sub = global::ReactiveUI.Primitives.SubscribeExtensions.Subscribe(interactionObs, interaction =>
             {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.ObservableHandler#BindInteractionDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.ObservableHandler#BindInteractionDispatch.g.verified.cs
@@ -44,12 +44,22 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
         {
             return serial;
         }
-
-        var interactionObs = new global::ReactiveUI.Binding.Observables.PropertyObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>(
+        var interactionObsMechanism = new global::ReactiveUI.Binding.Observables.PropertyObservable<global::ReactiveUI.Binding.Interaction<string, bool>>(
             viewModel,
             "Confirm",
             (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.BindInteraction.ObservableHandler.MyViewModel)__o).Confirm,
             true);
+        var interactionObsRegistration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.BindInteraction.ObservableHandler.MyViewModel), "Confirm", 5, false);
+        var interactionObs = interactionObsRegistration == null
+            ? (global::System.IObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>)interactionObsMechanism
+            : (global::System.IObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>(
+                interactionObsRegistration,
+                viewModel,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.BindInteraction.ObservableHandler.MyViewModel, global::ReactiveUI.Binding.IInteraction<string, bool>>>)(__e => __e.Confirm)).Body,
+                "Confirm",
+                (object __o) => ((global::SharedScenarios.BindInteraction.ObservableHandler.MyViewModel)__o).Confirm,
+                false,
+                true);
 
             var sub = global::ReactiveUI.Primitives.SubscribeExtensions.Subscribe(interactionObs, interaction =>
             {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.TaskHandler#BindInteractionDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BIG.TaskHandler#BindInteractionDispatch.g.verified.cs
@@ -44,12 +44,22 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
         {
             return serial;
         }
-
-        var interactionObs = new global::ReactiveUI.Binding.Observables.PropertyObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>(
+        var interactionObsMechanism = new global::ReactiveUI.Binding.Observables.PropertyObservable<global::ReactiveUI.Binding.Interaction<string, bool>>(
             viewModel,
             "Confirm",
             (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.BindInteraction.TaskHandler.MyViewModel)__o).Confirm,
             true);
+        var interactionObsRegistration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.BindInteraction.TaskHandler.MyViewModel), "Confirm", 5, false);
+        var interactionObs = interactionObsRegistration == null
+            ? (global::System.IObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>)interactionObsMechanism
+            : (global::System.IObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::ReactiveUI.Binding.IInteraction<string, bool>>(
+                interactionObsRegistration,
+                viewModel,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.BindInteraction.TaskHandler.MyViewModel, global::ReactiveUI.Binding.IInteraction<string, bool>>>)(__e => __e.Confirm)).Body,
+                "Confirm",
+                (object __o) => ((global::SharedScenarios.BindInteraction.TaskHandler.MyViewModel)__o).Confirm,
+                false,
+                true);
 
             var sub = global::ReactiveUI.Primitives.SubscribeExtensions.Subscribe(interactionObs, interaction =>
             {

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BindToGeneratorTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/BindToGeneratorTests.cs
@@ -13,6 +13,12 @@ public class BindToGeneratorTests
     /// <summary>The <c>BindToDispatch.g.cs</c> name these tests generate against.</summary>
     private const string BindToDispatchgcsName = "BindToDispatch.g.cs";
 
+    /// <summary>The attribute a generated member carries when only the runtime engine can serve it.</summary>
+    private const string RequiresUnreferencedCode = "RequiresUnreferencedCode";
+
+    /// <summary>The runtime engine a call site the compiler could not read is handed to.</summary>
+    private const string RuntimeBindingFallback = "RuntimeBindingFallback.BindTo";
+
     /// <summary>Verifies BindTo with a same-typed string observable and string property (direct assignment).</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
@@ -292,10 +298,10 @@ public class BindToGeneratorTests
         await result.HasGeneratedSource(BindToDispatchgcsName);
     }
 
-    /// <summary>A BindTo whose target property argument is not an inline lambda is skipped.</summary>
+    /// <summary>A target selector held in a variable names no path to read, so the runtime engine serves it.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task BindTo_TargetPropertyNotALambda_GeneratesNoDispatch()
+    public async Task TargetPropertyFromAVariable_GeneratesAnAnnotatedRuntimeDispatch()
     {
         const string source = """
                               using System;
@@ -314,16 +320,96 @@ public class BindToGeneratorTests
 
                                   public static class Scenario
                                   {
-                                      public static void Execute(IObservable<string> source, MyView view)
+                                      public static IDisposable Execute(IObservable<string> source, MyView view)
                                       {
                                           Expression<Func<MyView, string>> property = x => x.Caption;
-                                          source.BindTo(view, property);
+                                          return source.BindTo(view, property);
                                       }
                                   }
                               }
                               """;
 
         var result = TestHelper.RunGenerator(source, LanguageVersion.CSharp10);
+
+        await result.HasNoGeneratorDiagnostics();
+
+        var dispatch = result.GeneratedSources[BindToDispatchgcsName];
+        await Assert.That(dispatch).Contains(RequiresUnreferencedCode);
+        await Assert.That(dispatch).Contains(RuntimeBindingFallback);
+    }
+
+    /// <summary>A target selector whose body is no property path is served by the runtime engine, and says so.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task TargetPropertyWithoutAPropertyPath_GeneratesAnAnnotatedRuntimeDispatch()
+    {
+        const string source = """
+                              using System;
+                              using System.ComponentModel;
+                              using ReactiveUI.Binding;
+
+                              namespace TestApp
+                              {
+                                  public class MyView : INotifyPropertyChanged
+                                  {
+                                      public event PropertyChangedEventHandler? PropertyChanged;
+
+                                      public string Caption { get; set; } = "";
+
+                                      public string Resolve() => Caption;
+                                  }
+
+                                  public static class Scenario
+                                  {
+                                      public static IDisposable Execute(IObservable<string> source, MyView view)
+                                      {
+                                          return source.BindTo(view, x => x.Resolve());
+                                      }
+                                  }
+                              }
+                              """;
+
+        var result = TestHelper.RunGenerator(source, LanguageVersion.CSharp10);
+
+        await result.HasNoGeneratorDiagnostics();
+
+        var dispatch = result.GeneratedSources[BindToDispatchgcsName];
+        await Assert.That(dispatch).Contains(RequiresUnreferencedCode);
+        await Assert.That(dispatch).Contains(RuntimeBindingFallback);
+    }
+
+    /// <summary>A target selector producing a type no member can declare leaves the call to the stub.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task TargetPropertyProducingAnUndeclarableType_GeneratesNoDispatch()
+    {
+        const string source = """
+                              using System;
+                              using System.ComponentModel;
+                              using ReactiveUI.Binding;
+
+                              namespace TestApp
+                              {
+                                  public class MyView : INotifyPropertyChanged
+                                  {
+                                      public event PropertyChangedEventHandler? PropertyChanged;
+
+                                      public string[] Resolve() => new string[0];
+                                  }
+
+                                  public static class Scenario
+                                  {
+                                      public static IDisposable Execute(IObservable<string[]> source, MyView view)
+                                      {
+                                          return source.BindTo(view, x => x.Resolve());
+                                      }
+                                  }
+                              }
+                              """;
+
+        var result = TestHelper.RunGenerator(source, LanguageVersion.CSharp10);
+
+        await result.HasNoGeneratorDiagnostics();
         await result.DoesNotHaveGeneratedSource(BindToDispatchgcsName);
     }
 }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/CodeGeneration/ObservationCodeGeneratorHelperTests.MethodGeneration.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/CodeGeneration/ObservationCodeGeneratorHelperTests.MethodGeneration.cs
@@ -47,32 +47,48 @@ public partial class ObservationCodeGeneratorHelperTests
         await Assert.That(result).Contains("callerFilePath.EndsWith");
     }
 
-    /// <summary>Verifies GenerateRuntimeFallback throws rather than falling back to runtime reflection.</summary>
+    /// <summary>A call site the overload could not match reaches the stub rather than a throw.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task GenerateRuntimeFallback_GeneratesThrowNamingTheMethod()
+    public async Task GenerateRuntimeFallback_CallsTheStubTheOverloadDisplaces()
     {
         var sb = new StringBuilder();
+        var inv = ModelFactory.CreateInvocationInfo();
 
-        ObservationCodeGenerator.GenerateRuntimeFallback(sb, WhenChangedName);
+        ObservationCodeGenerator.GenerateRuntimeFallback(sb, inv, WhenChangedName, inv.PropertyPaths.Length, false);
 
         var result = sb.ToString();
-        await Assert.That(result).Contains(ThrowNewGlobalSystemInvalidOperationExceptionFragment);
-        await Assert.That(result).Contains(WhenChangedName);
+        await Assert.That(result).Contains($"{StubFallbackCallFragment}{WhenChangedName}");
+        await Assert.That(result).DoesNotContain(ThrowNewGlobalSystemInvalidOperationExceptionFragment);
+        await Assert.That(result).Contains("(objectToMonitor, property1);");
     }
 
-    /// <summary>Verifies the method prefix is interpolated into the message rather than hard-coded.</summary>
+    /// <summary>The stub the fallback names follows the API being generated.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task GenerateRuntimeFallback_WhenChanging_IncludesMethodPrefixInErrorMessage()
+    public async Task GenerateRuntimeFallback_WhenChanging_NamesTheWhenChangingStub()
     {
         var sb = new StringBuilder();
+        var inv = ModelFactory.CreateInvocationInfo();
 
-        ObservationCodeGenerator.GenerateRuntimeFallback(sb, WhenChangingName);
+        ObservationCodeGenerator.GenerateRuntimeFallback(sb, inv, WhenChangingName, inv.PropertyPaths.Length, false);
+
+        await Assert.That(sb.ToString()).Contains($"{StubFallbackCallFragment}{WhenChangingName}");
+    }
+
+    /// <summary>The projected type is stated last, after the observed ones, where the overload takes a selector.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task GenerateRuntimeFallback_WithSelector_StatesTheProjectedTypeLastAndForwardsIt()
+    {
+        var sb = new StringBuilder();
+        var inv = ModelFactory.CreateInvocationInfo();
+
+        ObservationCodeGenerator.GenerateRuntimeFallback(sb, inv, WhenChangedName, inv.PropertyPaths.Length, true);
 
         var result = sb.ToString();
-        await Assert.That(result).Contains(ThrowNewGlobalSystemInvalidOperationExceptionFragment);
-        await Assert.That(result).Contains(WhenChangingName);
+        await Assert.That(result).Contains($"{inv.ReturnTypeFullName}>(");
+        await Assert.That(result).Contains(", selector);");
     }
 
     /// <summary>Verifies GenerateObservationMethod with a deep chain and selector generates Switch and Select wrapping.</summary>

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/CodeGeneration/ObservationCodeGeneratorHelperTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/CodeGeneration/ObservationCodeGeneratorHelperTests.cs
@@ -106,6 +106,9 @@ public partial class ObservationCodeGeneratorHelperTests
     /// <summary>The <c>throw new global::System.InvalidOperationException</c> fragment these tests expect in the generated source.</summary>
     private const string ThrowNewGlobalSystemInvalidOperationExceptionFragment = "throw new global::System.InvalidOperationException";
 
+    /// <summary>The opening of the call a generated overload ends on, up to the API name.</summary>
+    private const string StubFallbackCallFragment = "return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.";
+
     /// <summary>Verifies GetSelectorType returns correct Func type for single-property invocation.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/TestHelper.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/Helpers/TestHelper.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -18,6 +19,9 @@ namespace ReactiveUI.Binding.SourceGenerators.Tests.Helpers;
 /// </summary>
 public static class TestHelper
 {
+    /// <summary>The transitive reference set each runtime flavour compiles against, keyed by flavour.</summary>
+    private static readonly ConcurrentDictionary<bool, ImmutableArray<MetadataReference>> FlavourReferences = new();
+
     /// <summary>
     /// Returns the C# language version used to exercise the <c>CallerFilePath</c> + <c>CallerLineNumber</c>
     /// dispatch fallback. The version is deliberately kept below C# 10 (where
@@ -110,33 +114,15 @@ public static class TestHelper
         IEnumerable<MetadataReference> references = Basic.Reference.Assemblies.Net80.References.All;
 #endif
 
-        // Add ReactiveUI and transitive assembly references.
-        // ReactiveUI is seeded by ReactiveObject rather than IReactiveObject: the two live in
-        // different assemblies, and the walk only follows references outward, so seeding from the
-        // interface would leave the assembly that declares ReactiveObject out of the compilation.
-        var runtimeSeeds = useReactiveRuntime
-            ? new[] { typeof(ReactiveUI.Binding.Reactive.ReactiveUIBindingExtensions).Assembly }
-            : new[]
-            {
-                typeof(ReactiveUIBindingExtensions).Assembly,
-                typeof(ReactiveUI.Primitives.Concurrency.ISequencer).Assembly,
-            };
-
-        var seedAssemblies = new[]
-        {
-            typeof(ReactiveObject).Assembly, typeof(IReactiveObject).Assembly,
-            typeof(System.Reactive.Linq.Observable).Assembly,
-        }.Concat(runtimeSeeds).ToArray();
-
         var allReferences = references
-            .Concat(GetTransitiveReferences(seedAssemblies))
+            .Concat(RuntimeReferences(useReactiveRuntime))
             .Concat(additionalReferences);
 
         return CSharpCompilation.Create(
             assemblyName,
             [syntaxTree],
             allReferences,
-            new(OutputKind.DynamicallyLinkedLibrary));
+            new(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextFor(parseOptions)));
     }
 
     /// <summary>The parse options a build produces from a language version, which is what the tests usually name.</summary>
@@ -529,6 +515,53 @@ public static class TestHelper
         .Replace("CombineLatest", "CL", StringComparison.Ordinal)
         .Replace("GeneratesElseIf", "GEI", StringComparison.Ordinal)
         .Replace("SameTypeSignature", "STS", StringComparison.Ordinal);
+
+    /// <summary>Names the runtime and transitive references a flavour compiles against, building the set once.</summary>
+    /// <param name="useReactiveRuntime">Whether to reference the System.Reactive flavour rather than the lean one.</param>
+    /// <returns>The shared reference set.</returns>
+    /// <remarks>
+    /// A <see cref="MetadataReference"/> carries its own copy of the assembly's metadata, and a compilation keeps
+    /// every reference it was given alive. Building the set per compilation therefore holds one metadata heap per
+    /// referenced assembly per test, which is what takes the suite past a CI runner's memory. The set is fixed for
+    /// a flavour, so it is built once and shared - the framework set is shared for the same reason.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ImmutableArray<MetadataReference> RuntimeReferences(bool useReactiveRuntime) =>
+        FlavourReferences.GetOrAdd(useReactiveRuntime, static flavour =>
+        {
+            // ReactiveUI is seeded by ReactiveObject rather than IReactiveObject: the two live in
+            // different assemblies, and the walk only follows references outward, so seeding from the
+            // interface would leave the assembly that declares ReactiveObject out of the compilation.
+            var runtimeSeeds = flavour
+                ? new[] { typeof(ReactiveUI.Binding.Reactive.ReactiveUIBindingExtensions).Assembly }
+                : new[]
+                {
+                    typeof(ReactiveUIBindingExtensions).Assembly,
+                    typeof(ReactiveUI.Primitives.Concurrency.ISequencer).Assembly,
+                };
+
+            var seedAssemblies = new[]
+            {
+                typeof(ReactiveObject).Assembly, typeof(IReactiveObject).Assembly,
+                typeof(System.Reactive.Linq.Observable).Assembly,
+            }.Concat(runtimeSeeds).ToArray();
+
+            return [.. GetTransitiveReferences(seedAssemblies)];
+        });
+
+    /// <summary>Chooses the nullable context a consumer's language version would give its own source.</summary>
+    /// <param name="parseOptions">The options the consumer's source is parsed with.</param>
+    /// <returns>The nullable context options for the compilation.</returns>
+    /// <remarks>
+    /// Annotations rather than warnings: a scenario written with <c>T?</c> needs an annotation context or every
+    /// annotation is reported, and turning the warnings on as well would report the scenario's own null-flow
+    /// instead of what the test is about. A version below C# 8 has no context to establish.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static NullableContextOptions NullableContextFor(CSharpParseOptions parseOptions) =>
+        parseOptions.LanguageVersion.MapSpecifiedToEffectiveVersion() >= LanguageVersion.CSharp8
+            ? NullableContextOptions.Annotations
+            : NullableContextOptions.Disable;
 
     /// <summary>
     /// Recursively walks assembly references from the seed assemblies to collect

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/ICG.DeepCommandPath#InvokeCommandDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/ICG.DeepCommandPath#InvokeCommandDispatch.g.verified.cs
@@ -43,12 +43,22 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
                 return global::ReactiveUI.Primitives.Disposables.EmptyDisposable.Instance;
             }
 
-            var __commandObs_s0 = (global::System.IObservable<global::SharedScenarios.InvokeCommand.DeepCommandPath.ChildViewModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.InvokeCommand.DeepCommandPath.ChildViewModel>(
+            var __commandObs_s0Mechanism = (global::System.IObservable<global::SharedScenarios.InvokeCommand.DeepCommandPath.ChildViewModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.InvokeCommand.DeepCommandPath.ChildViewModel>(
                 target,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.InvokeCommand.DeepCommandPath.MyViewModel)__o).Child,
                 false);
-
+            var __commandObs_s0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.InvokeCommand.DeepCommandPath.MyViewModel), "Child", 5, false);
+            var __commandObs_s0 = __commandObs_s0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.InvokeCommand.DeepCommandPath.ChildViewModel>)__commandObs_s0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.InvokeCommand.DeepCommandPath.ChildViewModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.InvokeCommand.DeepCommandPath.ChildViewModel>(
+                    __commandObs_s0Registration,
+                    target,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.InvokeCommand.DeepCommandPath.MyViewModel, global::SharedScenarios.InvokeCommand.DeepCommandPath.ChildViewModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.InvokeCommand.DeepCommandPath.MyViewModel)__o).Child,
+                    false,
+                    true);
         var __commandObs_s1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.InvokeCommand.DeepCommandPath.ChildViewModel, global::System.Windows.Input.ICommand>(__commandObs_s0,
             __p1 => __p1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<global::System.Windows.Input.ICommand>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/InterceptedCallSiteTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/InterceptedCallSiteTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using ReactiveUI.Binding.SourceGenerators.CodeGeneration;
 using ReactiveUI.Binding.SourceGenerators.Helpers;
 using ReactiveUI.Binding.SourceGenerators.Tests.Helpers;
 
@@ -34,6 +35,18 @@ public class InterceptedCallSiteTests
 
     /// <summary>The root namespace the scenarios build under.</summary>
     private const string RootNamespace = "TestApp";
+
+    /// <summary>The dispatch file a BindTo call site is claimed in.</summary>
+    private const string BindToDispatchFileName = "BindToDispatch.g.cs";
+
+    /// <summary>The dispatch file an InvokeCommand call site is claimed in.</summary>
+    private const string InvokeCommandDispatchFileName = "InvokeCommandDispatch.g.cs";
+
+    /// <summary>How many members carry the requirement when the claim carries it too: the claim and the worker.</summary>
+    private const int ClaimAndWorker = 2;
+
+    /// <summary>How many carry it when the overloads are what the build got: the worker alone.</summary>
+    private const int WorkerAlone = 1;
 
     /// <summary>The type the scenario exposes its binding through.</summary>
     private const string UsageTypeName = $"{RootNamespace}.Usage";
@@ -197,6 +210,50 @@ public class InterceptedCallSiteTests
                                             }
                                             """;
 
+    /// <summary>Call sites whose selectors name no property path, so only the runtime engine can serve them.</summary>
+    private const string RuntimeResolvedScenario = """
+                                                   using System;
+                                                   using System.ComponentModel;
+                                                   using System.Windows.Input;
+                                                   using ReactiveUI.Binding;
+
+                                                   namespace TestApp
+                                                   {
+                                                       public class Person : INotifyPropertyChanged
+                                                       {
+                                                           public event PropertyChangedEventHandler PropertyChanged;
+
+                                                           public ICommand Save { get; set; }
+
+                                                           public ICommand Resolve()
+                                                           {
+                                                               return Save;
+                                                           }
+                                                       }
+
+                                                       public class PersonView : INotifyPropertyChanged
+                                                       {
+                                                           public event PropertyChangedEventHandler PropertyChanged;
+
+                                                           public string Display { get; set; }
+
+                                                           public string Target()
+                                                           {
+                                                               return Display;
+                                                           }
+                                                       }
+
+                                                       public class Usage
+                                                       {
+                                                           public void Bind(Person person, PersonView view, IObservable<string> names)
+                                                           {
+                                                               names.BindTo(view, v => v.Target());
+                                                               names.InvokeCommand(person, x => x.Resolve());
+                                                           }
+                                                       }
+                                                   }
+                                                   """;
+
     /// <summary>The dispatch file each generated binding API emits.</summary>
     /// <remarks>
     /// Named rather than matched on a suffix, because the view locator emits one too and it claims no call
@@ -345,6 +402,31 @@ public class InterceptedCallSiteTests
         await Assert.That(observe!.Invoke(null, null)).IsEqualTo("changed");
 
         context.Unload();
+    }
+
+    /// <summary>
+    /// A claim that reaches the runtime engine carries the requirement on the claim itself, not only on the worker
+    /// behind it. The claim is what replaces the consumer's call, so it is the member their publish reports.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OptedInBuild_AnnotatesAClaimThatReachesTheRuntimeEngine()
+    {
+        var result = Generate(RuntimeResolvedScenario, LanguageVersion.CSharp10, optIn: true, RootNamespace);
+
+        await Assert.That(result.CompilationErrors).IsEmpty();
+
+        // The worker always carries it; a build that can claim the call site carries it there as well.
+        var expected = InterceptableLocationReader.IsSupported ? ClaimAndWorker : WorkerAlone;
+
+        await result.GeneratedSourceContainsCount(
+            BindToDispatchFileName,
+            GeneratedTypeNames.RequiresUnreferencedCodeAttribute,
+            expected);
+        await result.GeneratedSourceContainsCount(
+            InvokeCommandDispatchFileName,
+            GeneratedTypeNames.RequiresUnreferencedCodeAttribute,
+            expected);
     }
 
     /// <summary>The generated namespace is what the opt-in has to name.</summary>

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/InvokeCommandGeneratorTests.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/InvokeCommandGeneratorTests.cs
@@ -13,6 +13,12 @@ public class InvokeCommandGeneratorTests
     /// <summary>The <c>InvokeCommandDispatch.g.cs</c> name these tests generate against.</summary>
     private const string InvokeCommandDispatchgcsName = "InvokeCommandDispatch.g.cs";
 
+    /// <summary>The attribute a generated member carries when only the runtime engine can serve it.</summary>
+    private const string RequiresUnreferencedCode = "RequiresUnreferencedCode";
+
+    /// <summary>The runtime engine a call site the compiler could not read is handed to.</summary>
+    private const string RuntimeCommandFallback = "RuntimeCommandFallback.InvokeCommand";
+
     /// <summary>Verifies InvokeCommand observing a command property on the target.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
@@ -177,10 +183,10 @@ public class InvokeCommandGeneratorTests
         await result.DoesNotHaveGeneratedSource(InvokeCommandDispatchgcsName);
     }
 
-    /// <summary>A selector whose body is no property path leaves nothing to observe.</summary>
+    /// <summary>A selector whose body is no property path is served by the runtime engine, and says so.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task SelectorWithoutAPropertyPath_GeneratesNoDispatch()
+    public async Task SelectorWithoutAPropertyPath_GeneratesAnAnnotatedRuntimeDispatch()
     {
         const string source = """
                               using System;
@@ -213,7 +219,10 @@ public class InvokeCommandGeneratorTests
 
         await result.HasNoGeneratorDiagnostics();
         await result.CompilationSucceeds();
-        await result.DoesNotHaveGeneratedSource(InvokeCommandDispatchgcsName);
+
+        var dispatch = result.GeneratedSources[InvokeCommandDispatchgcsName];
+        await Assert.That(dispatch).Contains(RequiresUnreferencedCode);
+        await Assert.That(dispatch).Contains(RuntimeCommandFallback);
     }
 
     /// <summary>A receiver that is no stream of values has nothing to drive an execution.</summary>
@@ -255,10 +264,10 @@ public class InvokeCommandGeneratorTests
         await result.DoesNotHaveGeneratedSource(InvokeCommandDispatchgcsName);
     }
 
-    /// <summary>A selector held in a variable names no path to read, so nothing is generated for it.</summary>
+    /// <summary>A selector held in a variable names no path to read, so the runtime engine serves it.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task SelectorFromAVariable_GeneratesNoDispatch()
+    public async Task SelectorFromAVariable_GeneratesAnAnnotatedRuntimeDispatch()
     {
         const string source = """
                               using System;
@@ -290,7 +299,10 @@ public class InvokeCommandGeneratorTests
         var result = TestHelper.RunGenerator(source, LanguageVersion.CSharp10);
 
         await result.HasNoGeneratorDiagnostics();
-        await result.DoesNotHaveGeneratedSource(InvokeCommandDispatchgcsName);
+
+        var dispatch = result.GeneratedSources[InvokeCommandDispatchgcsName];
+        await Assert.That(dispatch).Contains(RequiresUnreferencedCode);
+        await Assert.That(dispatch).Contains(RuntimeCommandFallback);
     }
 
     /// <summary>Two call sites spelling the same selector share one generated worker.</summary>

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.MI_STS#WhenAnyDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.MI_STS#WhenAnyDispatch.g.verified.cs
@@ -30,7 +30,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAny_00002A522B790276(objectToMonitor, selector);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAny dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAny<global::SharedScenarios.WhenAny.MultipleInvocationsSameType.MyViewModel, string, string>(objectToMonitor, property1, selector);
         }
 
         private static global::System.IObservable<string> __WhenAny_00002A5206691BE8(global::SharedScenarios.WhenAny.MultipleInvocationsSameType.MyViewModel obj, global::System.Func<global::ReactiveUI.Binding.IObservedChange<global::SharedScenarios.WhenAny.MultipleInvocationsSameType.MyViewModel, string>, string> selector)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.MP_2P#WhenAnyDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.MP_2P#WhenAnyDispatch.g.verified.cs
@@ -29,7 +29,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAny_7FFFD022211E67B0(objectToMonitor, selector);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAny dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAny<global::SharedScenarios.WhenAny.MultiPropertyTwoProperties.MyViewModel, string, string, string>(objectToMonitor, property1, property2, selector);
         }
 
         private static global::System.IObservable<string> __WhenAny_7FFFD022211E67B0(global::SharedScenarios.WhenAny.MultiPropertyTwoProperties.MyViewModel obj, global::System.Func<global::ReactiveUI.Binding.IObservedChange<global::SharedScenarios.WhenAny.MultiPropertyTwoProperties.MyViewModel, string>, global::ReactiveUI.Binding.IObservedChange<global::SharedScenarios.WhenAny.MultiPropertyTwoProperties.MyViewModel, string>, string> selector)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.MP_DC#WhenAnyDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.MP_DC#WhenAnyDispatch.g.verified.cs
@@ -29,17 +29,27 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAny_7FFFD8112D4F4829(objectToMonitor, selector);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAny dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAny<global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ParentViewModel, string, string, string>(objectToMonitor, property1, property2, selector);
         }
 
         private static global::System.IObservable<string> __WhenAny_7FFFD8112D4F4829(global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ParentViewModel obj, global::System.Func<global::ReactiveUI.Binding.IObservedChange<global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ParentViewModel, string>, global::ReactiveUI.Binding.IObservedChange<global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ParentViewModel, string>, string> selector)
         {
-            var __propObs0_s0 = (global::System.IObservable<global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ChildModel>(
+            var __propObs0_s0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ChildModel>(
                 obj,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ParentViewModel)__o).Child,
                 false);
-
+            var __propObs0_s0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ParentViewModel), "Child", 5, false);
+            var __propObs0_s0 = __propObs0_s0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ChildModel>)__propObs0_s0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ChildModel>(
+                    __propObs0_s0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ParentViewModel, global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ChildModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ParentViewModel)__o).Child,
+                    false,
+                    true);
         var __propObs0_s1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenAny.MultiPropertyDeepChain.ChildModel, string>(__propObs0_s0,
             __propObs0_p1 => __propObs0_p1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.SP_DC#WhenAnyDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.SP_DC#WhenAnyDispatch.g.verified.cs
@@ -26,17 +26,27 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAny_0000044C01973E8C(objectToMonitor, selector);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAny dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAny<global::SharedScenarios.WhenAny.DeepPropertyChain.ParentViewModel, string, string>(objectToMonitor, property1, selector);
         }
 
         private static global::System.IObservable<string> __WhenAny_0000044C01973E8C(global::SharedScenarios.WhenAny.DeepPropertyChain.ParentViewModel obj, global::System.Func<global::ReactiveUI.Binding.IObservedChange<global::SharedScenarios.WhenAny.DeepPropertyChain.ParentViewModel, string>, string> selector)
         {
-            var __propObs0_s0 = (global::System.IObservable<global::SharedScenarios.WhenAny.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAny.DeepPropertyChain.ChildModel>(
+            var __propObs0_s0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenAny.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAny.DeepPropertyChain.ChildModel>(
                 obj,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAny.DeepPropertyChain.ParentViewModel)__o).Child,
                 false);
-
+            var __propObs0_s0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenAny.DeepPropertyChain.ParentViewModel), "Child", 5, false);
+            var __propObs0_s0 = __propObs0_s0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenAny.DeepPropertyChain.ChildModel>)__propObs0_s0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenAny.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenAny.DeepPropertyChain.ChildModel>(
+                    __propObs0_s0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenAny.DeepPropertyChain.ParentViewModel, global::SharedScenarios.WhenAny.DeepPropertyChain.ChildModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.WhenAny.DeepPropertyChain.ParentViewModel)__o).Child,
+                    false,
+                    true);
         var __propObs0_s1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenAny.DeepPropertyChain.ChildModel, string>(__propObs0_s0,
             __propObs0_p1 => __propObs0_p1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.SP_INPC#WhenAnyDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.SP_INPC#WhenAnyDispatch.g.verified.cs
@@ -26,7 +26,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAny_00002E2F49F124B9(objectToMonitor, selector);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAny dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAny<global::SharedScenarios.WhenAny.SinglePropertyINPC.MyViewModel, string, string>(objectToMonitor, property1, selector);
         }
 
         private static global::System.IObservable<string> __WhenAny_00002E2F49F124B9(global::SharedScenarios.WhenAny.SinglePropertyINPC.MyViewModel obj, global::System.Func<global::ReactiveUI.Binding.IObservedChange<global::SharedScenarios.WhenAny.SinglePropertyINPC.MyViewModel, string>, string> selector)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.SP_INPC_CFP#WhenAnyDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAG.SP_INPC_CFP#WhenAnyDispatch.g.verified.cs
@@ -24,7 +24,7 @@ namespace ReactiveUI.Binding
             {
                 return __WhenAny_00002E2F49F124B9(objectToMonitor, selector);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAny dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAny<global::SharedScenarios.WhenAny.SinglePropertyINPC.MyViewModel, string, string>(objectToMonitor, property1, selector);
         }
 
         private static global::System.IObservable<string> __WhenAny_00002E2F49F124B9(global::SharedScenarios.WhenAny.SinglePropertyINPC.MyViewModel obj, global::System.Func<global::ReactiveUI.Binding.IObservedChange<global::SharedScenarios.WhenAny.SinglePropertyINPC.MyViewModel, string>, string> selector)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.2O_DC_CL#WhenAnyObservableDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.2O_DC_CL#WhenAnyObservableDispatch.g.verified.cs
@@ -29,17 +29,27 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyObservable_7FFFF799BE8759BB(objectToMonitor, selector);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyObservable dispatch matched. This indicates a source generator caching issue.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyObservable(objectToMonitor, obs1, obs2, selector);
         }
 
         private static global::System.IObservable<string> __WhenAnyObservable_7FFFF799BE8759BB(global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ParentViewModel obj, global::System.Func<int, string, string> selector)
         {
-            var __obsProperty0_s0 = (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>(
+            var __obsProperty0_s0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>(
                 obj,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ParentViewModel)__o).Child,
                 false);
-
+            var __obsProperty0_s0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ParentViewModel), "Child", 5, false);
+            var __obsProperty0_s0 = __obsProperty0_s0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>)__obsProperty0_s0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>(
+                    __obsProperty0_s0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ParentViewModel, global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ParentViewModel)__o).Child,
+                    false,
+                    true);
         var __obsProperty0_s1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel, global::System.IObservable<int>>(__obsProperty0_s0,
             __obsProperty0_p1 => __obsProperty0_p1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<global::System.IObservable<int>>(
@@ -61,12 +71,22 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             var __switched0 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::System.IObservable<int>, int>(__obsProperty0,
                 __obs => __obs ?? (global::System.IObservable<int>)global::ReactiveUI.Primitives.Advanced.ImmutableEmptySignal<int>.Instance);
 
-            var __obsProperty1_s0 = (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>(
+            var __obsProperty1_s0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>(
                 obj,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ParentViewModel)__o).Child,
                 false);
-
+            var __obsProperty1_s0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ParentViewModel), "Child", 5, false);
+            var __obsProperty1_s0 = __obsProperty1_s0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>)__obsProperty1_s0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>(
+                    __obsProperty1_s0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ParentViewModel, global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ParentViewModel)__o).Child,
+                    false,
+                    true);
         var __obsProperty1_s1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenAnyObservable.DeepObservableCombineLatest.ChildModel, global::System.IObservable<string>>(__obsProperty1_s0,
             __obsProperty1_p1 => __obsProperty1_p1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<global::System.IObservable<string>>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.2O_DC_Merge#WhenAnyObservableDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.2O_DC_Merge#WhenAnyObservableDispatch.g.verified.cs
@@ -28,17 +28,27 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyObservable_000031E1E650E394(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyObservable dispatch matched. This indicates a source generator caching issue.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyObservable(objectToMonitor, obs1, obs2);
         }
 
         private static global::System.IObservable<string> __WhenAnyObservable_000031E1E650E394(global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ParentViewModel obj)
         {
-            var __obsProperty0_s0 = (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>(
+            var __obsProperty0_s0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>(
                 obj,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ParentViewModel)__o).Child,
                 false);
-
+            var __obsProperty0_s0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ParentViewModel), "Child", 5, false);
+            var __obsProperty0_s0 = __obsProperty0_s0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>)__obsProperty0_s0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>(
+                    __obsProperty0_s0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ParentViewModel, global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ParentViewModel)__o).Child,
+                    false,
+                    true);
         var __obsProperty0_s1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel, global::System.IObservable<string>>(__obsProperty0_s0,
             __obsProperty0_p1 => __obsProperty0_p1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<global::System.IObservable<string>>(
@@ -60,12 +70,22 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             var __switched0 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::System.IObservable<string>, string>(__obsProperty0,
                 __obs => __obs ?? (global::System.IObservable<string>)global::ReactiveUI.Primitives.Advanced.ImmutableEmptySignal<string>.Instance);
 
-            var __obsProperty1_s0 = (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>(
+            var __obsProperty1_s0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>(
                 obj,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ParentViewModel)__o).Child,
                 false);
-
+            var __obsProperty1_s0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ParentViewModel), "Child", 5, false);
+            var __obsProperty1_s0 = __obsProperty1_s0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>)__obsProperty1_s0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>(
+                    __obsProperty1_s0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ParentViewModel, global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ParentViewModel)__o).Child,
+                    false,
+                    true);
         var __obsProperty1_s1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenAnyObservable.DeepObservableMerge.ChildModel, global::System.IObservable<string>>(__obsProperty1_s0,
             __obsProperty1_p1 => __obsProperty1_p1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<global::System.IObservable<string>>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.2O_Merge#WhenAnyObservableDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.2O_Merge#WhenAnyObservableDispatch.g.verified.cs
@@ -28,7 +28,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyObservable_000004E8406EC0BF(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyObservable dispatch matched. This indicates a source generator caching issue.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyObservable(objectToMonitor, obs1, obs2);
         }
 
         private static global::System.IObservable<string> __WhenAnyObservable_000004E8406EC0BF(global::SharedScenarios.WhenAnyObservable.TwoObservablesMerge.MyViewModel obj)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.2O_WS#WhenAnyObservableDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.2O_WS#WhenAnyObservableDispatch.g.verified.cs
@@ -29,7 +29,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyObservable_7FFFE3651E3C40DF(objectToMonitor, selector);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyObservable dispatch matched. This indicates a source generator caching issue.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyObservable(objectToMonitor, obs1, obs2, selector);
         }
 
         private static global::System.IObservable<string> __WhenAnyObservable_7FFFE3651E3C40DF(global::SharedScenarios.WhenAnyObservable.TwoObservablesWithSelector.MyViewModel obj, global::System.Func<int, string, string> selector)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.MI_STS#WhenAnyObservableDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.MI_STS#WhenAnyObservableDispatch.g.verified.cs
@@ -29,7 +29,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyObservable_7FFFC6DF47F56865(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyObservable dispatch matched. This indicates a source generator caching issue.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyObservable(objectToMonitor, obs1);
         }
 
         private static global::System.IObservable<string> __WhenAnyObservable_7FFFC6DF44F563AC(global::SharedScenarios.WhenAnyObservable.MultipleInvocationsSameType.MyViewModel obj)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.SingleObservable#WhenAnyObservableDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.SingleObservable#WhenAnyObservableDispatch.g.verified.cs
@@ -25,7 +25,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyObservable_7FFFCD9779338746(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyObservable dispatch matched. This indicates a source generator caching issue.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyObservable(objectToMonitor, obs1);
         }
 
         private static global::System.IObservable<string> __WhenAnyObservable_7FFFCD9779338746(global::SharedScenarios.WhenAnyObservable.SingleObservable.MyViewModel obj)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.SingleObservable_CFP#WhenAnyObservableDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.SingleObservable_CFP#WhenAnyObservableDispatch.g.verified.cs
@@ -23,7 +23,7 @@ namespace ReactiveUI.Binding
             {
                 return __WhenAnyObservable_7FFFCD9779338746(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyObservable dispatch matched. This indicates a source generator caching issue.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyObservable(objectToMonitor, obs1);
         }
 
         private static global::System.IObservable<string> __WhenAnyObservable_7FFFCD9779338746(global::SharedScenarios.WhenAnyObservable.SingleObservable.MyViewModel obj)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.SingleObservable_DC#WhenAnyObservableDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAOG.SingleObservable_DC#WhenAnyObservableDispatch.g.verified.cs
@@ -25,17 +25,27 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyObservable_7FFFD9447DB2EDB8(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyObservable dispatch matched. This indicates a source generator caching issue.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyObservable(objectToMonitor, obs1);
         }
 
         private static global::System.IObservable<string> __WhenAnyObservable_7FFFD9447DB2EDB8(global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ParentViewModel obj)
         {
-            var __obsProperty_s0 = (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ChildModel>(
+            var __obsProperty_s0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ChildModel>(
                 obj,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ParentViewModel)__o).Child,
                 false);
-
+            var __obsProperty_s0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ParentViewModel), "Child", 5, false);
+            var __obsProperty_s0 = __obsProperty_s0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ChildModel>)__obsProperty_s0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ChildModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ChildModel>(
+                    __obsProperty_s0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ParentViewModel, global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ChildModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ParentViewModel)__o).Child,
+                    false,
+                    true);
         var __obsProperty_s1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenAnyObservable.DeepObservableSwitch.ChildModel, global::System.IObservable<string>>(__obsProperty_s0,
             __obsProperty_p1 => __obsProperty_p1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<global::System.IObservable<string>>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.DPC#WhenAnyValueDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.DPC#WhenAnyValueDispatch.g.verified.cs
@@ -25,17 +25,27 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyValue_000009AD7646CA30(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyValue dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyValue<global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ParentViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenAnyValue_000009AD7646CA30(global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ParentViewModel obj)
         {
-            var __obs0 = (global::System.IObservable<global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ChildModel>(
+            var __obs0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ChildModel>(
                 obj,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ParentViewModel)__o).Child,
                 false);
-
+            var __obs0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ParentViewModel), "Child", 5, false);
+            var __obs0 = __obs0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ChildModel>)__obs0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ChildModel>(
+                    __obs0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ParentViewModel, global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ChildModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ParentViewModel)__o).Child,
+                    false,
+                    true);
         var __obs1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenAnyValue.DeepPropertyChain.ChildModel, string>(__obs0,
             __parent1 => __parent1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.MP_2P#WhenAnyValueDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.MP_2P#WhenAnyValueDispatch.g.verified.cs
@@ -28,7 +28,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyValue_0000038CCDEFA447(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyValue dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyValue<global::SharedScenarios.WhenAnyValue.MultiPropertyTwoProperties.MyViewModel, string, int>(objectToMonitor, property1, property2);
         }
 
         private static global::System.IObservable<global::ReactiveUI.Binding.PropertyValues<string, int>> __WhenAnyValue_0000038CCDEFA447(global::SharedScenarios.WhenAnyValue.MultiPropertyTwoProperties.MyViewModel obj)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.MP_3P#WhenAnyValueDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.MP_3P#WhenAnyValueDispatch.g.verified.cs
@@ -31,7 +31,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyValue_7FFFD35E67D97FB8(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyValue dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyValue<global::SharedScenarios.WhenAnyValue.MultiPropertyThreeProperties.MyViewModel, string, int, double>(objectToMonitor, property1, property2, property3);
         }
 
         private static global::System.IObservable<global::ReactiveUI.Binding.PropertyValues<string, int, double>> __WhenAnyValue_7FFFD35E67D97FB8(global::SharedScenarios.WhenAnyValue.MultiPropertyThreeProperties.MyViewModel obj)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.MP_FiveProperties#WhenAnyValueDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.MP_FiveProperties#WhenAnyValueDispatch.g.verified.cs
@@ -37,7 +37,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyValue_00003486AFD4FA6C(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyValue dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyValue<global::SharedScenarios.WhenAnyValue.MultiPropertyFiveProperties.MyViewModel, string, int, double, bool, string>(objectToMonitor, property1, property2, property3, property4, property5);
         }
 
         private static global::System.IObservable<global::ReactiveUI.Binding.PropertyValues<string, int, double, bool, string>> __WhenAnyValue_00003486AFD4FA6C(global::SharedScenarios.WhenAnyValue.MultiPropertyFiveProperties.MyViewModel obj)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.MP_TwelveProperties#WhenAnyValueDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.MP_TwelveProperties#WhenAnyValueDispatch.g.verified.cs
@@ -58,7 +58,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyValue_7FFFC43E653A6144(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyValue dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyValue<global::SharedScenarios.WhenAnyValue.MultiPropertyTwelveProperties.WhenAnyFixture, string, string, string, string, string, string, string, string, string, string, string, string>(objectToMonitor, property1, property2, property3, property4, property5, property6, property7, property8, property9, property10, property11, property12);
         }
 
         private static global::System.IObservable<global::ReactiveUI.Binding.PropertyValues<string, string, string, string, string, string, string, string, string, string, string, string>> __WhenAnyValue_7FFFC43E653A6144(global::SharedScenarios.WhenAnyValue.MultiPropertyTwelveProperties.WhenAnyFixture obj)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.MP_WS#WhenAnyValueDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.MP_WS#WhenAnyValueDispatch.g.verified.cs
@@ -29,7 +29,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyValue_00000ABCF94E0289(objectToMonitor, selector);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyValue dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyValue<global::SharedScenarios.WhenAnyValue.MultiPropertyWithSelector.MyViewModel, string, string, string>(objectToMonitor, property1, property2, selector);
         }
 
         private static global::System.IObservable<string> __WhenAnyValue_00000ABCF94E0289(global::SharedScenarios.WhenAnyValue.MultiPropertyWithSelector.MyViewModel obj, global::System.Func<string, string, string> selector)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.NullableProperties#WhenAnyValueDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.NullableProperties#WhenAnyValueDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyValue_00001B08EE215D76(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyValue dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyValue<global::SharedScenarios.WhenAnyValue.NullableProperties.MyViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenAnyValue_00001B08EE215D76(global::SharedScenarios.WhenAnyValue.NullableProperties.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "NullableName", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyValue.NullableProperties.MyViewModel)__o).NullableName, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenAnyValue.NullableProperties.MyViewModel, string>>)(__e => __e.NullableName)).Body,
+                "NullableName",
+                false,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenAnyValue.NullableProperties.MyViewModel)__o).NullableName,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "NullableName", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyValue.NullableProperties.MyViewModel)__o).NullableName, true));
         }
 
         /// <summary>
@@ -49,12 +56,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyValue_00001B08D596E358(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyValue dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyValue<global::SharedScenarios.WhenAnyValue.NullableProperties.MyViewModel, int?>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<int?> __WhenAnyValue_00001B08D596E358(global::SharedScenarios.WhenAnyValue.NullableProperties.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<int?>(obj, "NullableAge", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyValue.NullableProperties.MyViewModel)__o).NullableAge, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<int?>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenAnyValue.NullableProperties.MyViewModel, int?>>)(__e => __e.NullableAge)).Body,
+                "NullableAge",
+                false,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenAnyValue.NullableProperties.MyViewModel)__o).NullableAge,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<int?>(obj, "NullableAge", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyValue.NullableProperties.MyViewModel)__o).NullableAge, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.SP_INPC#WhenAnyValueDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.SP_INPC#WhenAnyValueDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenAnyValue_0000263492582AFF(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyValue dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyValue<global::SharedScenarios.WhenAnyValue.SinglePropertyINPC.MyViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenAnyValue_0000263492582AFF(global::SharedScenarios.WhenAnyValue.SinglePropertyINPC.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Name", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyValue.SinglePropertyINPC.MyViewModel)__o).Name, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenAnyValue.SinglePropertyINPC.MyViewModel, string>>)(__e => __e.Name)).Body,
+                "Name",
+                false,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenAnyValue.SinglePropertyINPC.MyViewModel)__o).Name,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Name", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyValue.SinglePropertyINPC.MyViewModel)__o).Name, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.SP_INPC_CFP#WhenAnyValueDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WAVG.SP_INPC_CFP#WhenAnyValueDispatch.g.verified.cs
@@ -23,12 +23,19 @@ namespace ReactiveUI.Binding
             {
                 return __WhenAnyValue_0000263492582AFF(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenAnyValue dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenAnyValue<global::SharedScenarios.WhenAnyValue.SinglePropertyINPC.MyViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenAnyValue_0000263492582AFF(global::SharedScenarios.WhenAnyValue.SinglePropertyINPC.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Name", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyValue.SinglePropertyINPC.MyViewModel)__o).Name, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenAnyValue.SinglePropertyINPC.MyViewModel, string>>)(__e => __e.Name)).Body,
+                "Name",
+                false,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenAnyValue.SinglePropertyINPC.MyViewModel)__o).Name,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Name", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenAnyValue.SinglePropertyINPC.MyViewModel)__o).Name, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.4LDC#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.4LDC#WhenChangedDispatch.g.verified.cs
@@ -25,17 +25,27 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_0000130742850C0E(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level1, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanged_0000130742850C0E(global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level1 obj)
         {
-            var __obs0 = (global::System.IObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level2>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level2>(
+            var __obs0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level2>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level2>(
                 obj,
                 "Model",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level1)__o).Model,
                 false);
-
+            var __obs0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level1), "Model", 5, false);
+            var __obs0 = __obs0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level2>)__obs0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level2>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level2>(
+                    __obs0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level1, global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level2>>)(__e => __e.Model)).Body,
+                    "Model",
+                    (object __o) => ((global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level1)__o).Model,
+                    false,
+                    true);
         var __obs1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level2, global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level3>(__obs0,
             __parent1 => __parent1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<global::SharedScenarios.WhenChanged.FourLevelDeepChain.Level3>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.AndroidView_Property#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.AndroidView_Property#WhenChangedDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_7FFFE0F8FBCE6526(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::TestApp.MyAndroidView, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanged_7FFFE0F8FBCE6526(global::TestApp.MyAndroidView obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Text", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::TestApp.MyAndroidView)__o).Text, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::TestApp.MyAndroidView, string>>)(__e => __e.Text)).Body,
+                "Text",
+                false,
+                5,
+                (object __o) => ((global::TestApp.MyAndroidView)__o).Text,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Text", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::TestApp.MyAndroidView)__o).Text, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.DPC#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.DPC#WhenChangedDispatch.g.verified.cs
@@ -25,17 +25,27 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_7FFFCA2DD50C8513(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.DeepPropertyChain.ParentViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanged_7FFFCA2DD50C8513(global::SharedScenarios.WhenChanged.DeepPropertyChain.ParentViewModel obj)
         {
-            var __obs0 = (global::System.IObservable<global::SharedScenarios.WhenChanged.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenChanged.DeepPropertyChain.ChildModel>(
+            var __obs0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenChanged.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenChanged.DeepPropertyChain.ChildModel>(
                 obj,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.DeepPropertyChain.ParentViewModel)__o).Child,
                 false);
-
+            var __obs0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenChanged.DeepPropertyChain.ParentViewModel), "Child", 5, false);
+            var __obs0 = __obs0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenChanged.DeepPropertyChain.ChildModel>)__obs0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenChanged.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenChanged.DeepPropertyChain.ChildModel>(
+                    __obs0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanged.DeepPropertyChain.ParentViewModel, global::SharedScenarios.WhenChanged.DeepPropertyChain.ChildModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.WhenChanged.DeepPropertyChain.ParentViewModel)__o).Child,
+                    false,
+                    true);
         var __obs1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenChanged.DeepPropertyChain.ChildModel, string>(__obs0,
             __parent1 => __parent1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.IntProperty#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.IntProperty#WhenChangedDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_7FFFEF8ACA05A8AD(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.IntProperty.MyViewModel, int>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<int> __WhenChanged_7FFFEF8ACA05A8AD(global::SharedScenarios.WhenChanged.IntProperty.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<int>(obj, "Count", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.IntProperty.MyViewModel)__o).Count, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<int>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanged.IntProperty.MyViewModel, int>>)(__e => __e.Count)).Body,
+                "Count",
+                false,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenChanged.IntProperty.MyViewModel)__o).Count,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<int>(obj, "Count", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.IntProperty.MyViewModel)__o).Count, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.KVO_NSObject_Property#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.KVO_NSObject_Property#WhenChangedDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_000018C06482B4BD(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::TestApp.MyAppleView, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanged_000018C06482B4BD(global::TestApp.MyAppleView obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Text", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::TestApp.MyAppleView)__o).Text, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::TestApp.MyAppleView, string>>)(__e => __e.Text)).Body,
+                "Text",
+                false,
+                5,
+                (object __o) => ((global::TestApp.MyAppleView)__o).Text,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Text", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::TestApp.MyAppleView)__o).Text, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.MI_SameViewModel#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.MI_SameViewModel#WhenChangedDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_7FFFDB8E16EAA670(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanged_7FFFDB8E16EAA670(global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Name", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel)__o).Name, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel, string>>)(__e => __e.Name)).Body,
+                "Name",
+                false,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel)__o).Name,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Name", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel)__o).Name, true));
         }
 
         /// <summary>
@@ -49,12 +56,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_7FFFDB8E19F31E38(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel, int>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<int> __WhenChanged_7FFFDB8E19F31E38(global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<int>(obj, "Age", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel)__o).Age, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<int>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel, int>>)(__e => __e.Age)).Body,
+                "Age",
+                false,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel)__o).Age,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<int>(obj, "Age", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel)__o).Age, true));
         }
 
         /// <summary>
@@ -73,12 +87,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_7FFFDB8D81A702DF(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel, double>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<double> __WhenChanged_7FFFDB8D81A702DF(global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<double>(obj, "Score", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel)__o).Score, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<double>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel, double>>)(__e => __e.Score)).Body,
+                "Score",
+                false,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel)__o).Score,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<double>(obj, "Score", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.MultipleInvocationsSameViewModel.MyViewModel)__o).Score, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.MP_2P#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.MP_2P#WhenChangedDispatch.g.verified.cs
@@ -28,7 +28,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_7FFFFC6CDD42386A(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.MultiPropertyTwoProperties.MyViewModel, string, int>(objectToMonitor, property1, property2);
         }
 
         private static global::System.IObservable<global::ReactiveUI.Binding.PropertyValues<string, int>> __WhenChanged_7FFFFC6CDD42386A(global::SharedScenarios.WhenChanged.MultiPropertyTwoProperties.MyViewModel obj)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.MP_3P#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.MP_3P#WhenChangedDispatch.g.verified.cs
@@ -31,7 +31,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_000035AA2B4CCE33(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.MultiPropertyThreeProperties.MyViewModel, string, int, double>(objectToMonitor, property1, property2, property3);
         }
 
         private static global::System.IObservable<global::ReactiveUI.Binding.PropertyValues<string, int, double>> __WhenChanged_000035AA2B4CCE33(global::SharedScenarios.WhenChanged.MultiPropertyThreeProperties.MyViewModel obj)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.MP_WDC#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.MP_WDC#WhenChangedDispatch.g.verified.cs
@@ -29,17 +29,27 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_7FFFD8A9CF83ACC3(objectToMonitor, selector);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.MyViewModel, string, string, string>(objectToMonitor, property1, property2, selector);
         }
 
         private static global::System.IObservable<string> __WhenChanged_7FFFD8A9CF83ACC3(global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.MyViewModel obj, global::System.Func<string, string, string> selector)
         {
-            var __propObs0_s0 = (global::System.IObservable<global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.AddressModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.AddressModel>(
+            var __propObs0_s0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.AddressModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.AddressModel>(
                 obj,
                 "Address",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.MyViewModel)__o).Address,
                 false);
-
+            var __propObs0_s0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.MyViewModel), "Address", 5, false);
+            var __propObs0_s0 = __propObs0_s0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.AddressModel>)__propObs0_s0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.AddressModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.AddressModel>(
+                    __propObs0_s0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.MyViewModel, global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.AddressModel>>)(__e => __e.Address)).Body,
+                    "Address",
+                    (object __o) => ((global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.MyViewModel)__o).Address,
+                    false,
+                    true);
         var __propObs0_s1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenChanged.MultiPropertyWithDeepChains.AddressModel, string>(__propObs0_s0,
             __propObs0_p1 => __propObs0_p1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.MP_WS#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.MP_WS#WhenChangedDispatch.g.verified.cs
@@ -29,7 +29,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_00002EE07F183006(objectToMonitor, selector);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.MultiPropertyWithSelector.MyViewModel, string, string, string>(objectToMonitor, property1, property2, selector);
         }
 
         private static global::System.IObservable<string> __WhenChanged_00002EE07F183006(global::SharedScenarios.WhenChanged.MultiPropertyWithSelector.MyViewModel obj, global::System.Func<string, string, string> selector)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.MultipleViewModels#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.MultipleViewModels#WhenChangedDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_000013C2FFE01BC5(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.MultipleViewModels.ViewModel1, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanged_000013C2FFE01BC5(global::SharedScenarios.WhenChanged.MultipleViewModels.ViewModel1 obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Name", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.MultipleViewModels.ViewModel1)__o).Name, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanged.MultipleViewModels.ViewModel1, string>>)(__e => __e.Name)).Body,
+                "Name",
+                false,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenChanged.MultipleViewModels.ViewModel1)__o).Name,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Name", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.MultipleViewModels.ViewModel1)__o).Name, true));
         }
 
         /// <summary>
@@ -49,12 +56,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_00001520715BEC78(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.MultipleViewModels.ViewModel2, int>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<int> __WhenChanged_00001520715BEC78(global::SharedScenarios.WhenChanged.MultipleViewModels.ViewModel2 obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<int>(obj, "Count", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.MultipleViewModels.ViewModel2)__o).Count, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<int>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanged.MultipleViewModels.ViewModel2, int>>)(__e => __e.Count)).Body,
+                "Count",
+                false,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenChanged.MultipleViewModels.ViewModel2)__o).Count,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<int>(obj, "Count", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.MultipleViewModels.ViewModel2)__o).Count, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.NullForgivingDC#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.NullForgivingDC#WhenChangedDispatch.g.verified.cs
@@ -25,17 +25,27 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_7FFFCA7893201375(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ParentViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanged_7FFFCA7893201375(global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ParentViewModel obj)
         {
-            var __obs0 = (global::System.IObservable<global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ChildModel>(
+            var __obs0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyObservable<global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ChildModel>(
                 obj,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ParentViewModel)__o).Child,
                 false);
-
+            var __obs0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ParentViewModel), "Child", 5, false);
+            var __obs0 = __obs0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ChildModel>)__obs0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ChildModel>(
+                    __obs0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ParentViewModel, global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ChildModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ParentViewModel)__o).Child,
+                    false,
+                    true);
         var __obs1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenChanged.NullForgivingDeepChain.ChildModel, string>(__obs0,
             __parent1 => __parent1 != null
                 ? global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.NullableProperty#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.NullableProperty#WhenChangedDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_7FFFF613BD504637(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.NullableProperty.MyViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanged_7FFFF613BD504637(global::SharedScenarios.WhenChanged.NullableProperty.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "NullableName", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.NullableProperty.MyViewModel)__o).NullableName, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanged.NullableProperty.MyViewModel, string>>)(__e => __e.NullableName)).Body,
+                "NullableName",
+                false,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenChanged.NullableProperty.MyViewModel)__o).NullableName,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "NullableName", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.NullableProperty.MyViewModel)__o).NullableName, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.SP_INPC#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.SP_INPC#WhenChangedDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_7FFFD2E8D6FC818E(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.SinglePropertyINPC.MyViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanged_7FFFD2E8D6FC818E(global::SharedScenarios.WhenChanged.SinglePropertyINPC.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Name", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.SinglePropertyINPC.MyViewModel)__o).Name, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanged.SinglePropertyINPC.MyViewModel, string>>)(__e => __e.Name)).Body,
+                "Name",
+                false,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenChanged.SinglePropertyINPC.MyViewModel)__o).Name,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Name", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.SinglePropertyINPC.MyViewModel)__o).Name, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.SP_INPC_CFP#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.SP_INPC_CFP#WhenChangedDispatch.g.verified.cs
@@ -23,12 +23,19 @@ namespace ReactiveUI.Binding
             {
                 return __WhenChanged_7FFFD2E8D6FC818E(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.SinglePropertyINPC.MyViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanged_7FFFD2E8D6FC818E(global::SharedScenarios.WhenChanged.SinglePropertyINPC.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Name", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.SinglePropertyINPC.MyViewModel)__o).Name, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanged.SinglePropertyINPC.MyViewModel, string>>)(__e => __e.Name)).Body,
+                "Name",
+                false,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenChanged.SinglePropertyINPC.MyViewModel)__o).Name,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Name", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.SinglePropertyINPC.MyViewModel)__o).Name, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.SP_ReactiveObject#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.SP_ReactiveObject#WhenChangedDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_0000039705C7F4BC(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::SharedScenarios.WhenChanged.SinglePropertyReactiveObject.MyViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanged_0000039705C7F4BC(global::SharedScenarios.WhenChanged.SinglePropertyReactiveObject.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Name", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.SinglePropertyReactiveObject.MyViewModel)__o).Name, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanged.SinglePropertyReactiveObject.MyViewModel, string>>)(__e => __e.Name)).Body,
+                "Name",
+                false,
+                10,
+                (object __o) => ((global::SharedScenarios.WhenChanged.SinglePropertyReactiveObject.MyViewModel)__o).Name,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Name", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::SharedScenarios.WhenChanged.SinglePropertyReactiveObject.MyViewModel)__o).Name, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.WinFormsComponent_Property#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.WinFormsComponent_Property#WhenChangedDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_0000245FAC302C0E(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::TestApp.MyWinFormsControl, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanged_0000245FAC302C0E(global::TestApp.MyWinFormsControl obj)
         {
-            return new global::ReactiveUI.Binding.Observables.EventObservable<string>(__h => ((global::TestApp.MyWinFormsControl)obj).TextChanged += __h, __h => ((global::TestApp.MyWinFormsControl)obj).TextChanged -= __h, () => ((global::TestApp.MyWinFormsControl)obj).Text, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::TestApp.MyWinFormsControl, string>>)(__e => __e.Text)).Body,
+                "Text",
+                false,
+                8,
+                (object __o) => ((global::TestApp.MyWinFormsControl)__o).Text,
+                new global::ReactiveUI.Binding.Observables.EventObservable<string>(__h => ((global::TestApp.MyWinFormsControl)obj).TextChanged += __h, __h => ((global::TestApp.MyWinFormsControl)obj).TextChanged -= __h, () => ((global::TestApp.MyWinFormsControl)obj).Text, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.WinUIDependencyObject_Property#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.WinUIDependencyObject_Property#WhenChangedDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_7FFFDEC5A322381F(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::TestApp.MyWinUIControl, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanged_7FFFDEC5A322381F(global::TestApp.MyWinUIControl obj)
         {
-            return new __WinUIDPObservable<string>((global::Microsoft.UI.Xaml.DependencyObject)obj, global::TestApp.MyWinUIControl.TextProperty, (global::Microsoft.UI.Xaml.DependencyObject __o) => ((global::TestApp.MyWinUIControl)__o).Text, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::TestApp.MyWinUIControl, string>>)(__e => __e.Text)).Body,
+                "Text",
+                false,
+                6,
+                (object __o) => ((global::TestApp.MyWinUIControl)__o).Text,
+                new __WinUIDPObservable<string>((global::Microsoft.UI.Xaml.DependencyObject)obj, global::TestApp.MyWinUIControl.TextProperty, (global::Microsoft.UI.Xaml.DependencyObject __o) => ((global::TestApp.MyWinUIControl)__o).Text, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.WpfDependencyObject_Property#WhenChangedDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCG.WpfDependencyObject_Property#WhenChangedDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanged_7FFFDFDB348EEE2E(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanged dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanged<global::TestApp.MyWpfControl, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanged_7FFFDFDB348EEE2E(global::TestApp.MyWpfControl obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Text", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::TestApp.MyWpfControl)__o).Text, true);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::TestApp.MyWpfControl, string>>)(__e => __e.Text)).Body,
+                "Text",
+                false,
+                5,
+                (object __o) => ((global::TestApp.MyWpfControl)__o).Text,
+                new global::ReactiveUI.Binding.Observables.PropertyObservable<string>(obj, "Text", (global::System.ComponentModel.INotifyPropertyChanged __o) => ((global::TestApp.MyWpfControl)__o).Text, true));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.4LDC#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.4LDC#WhenChangingDispatch.g.verified.cs
@@ -25,16 +25,26 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanging_00001C315F48E7DF(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanging dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanging<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level1, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanging_00001C315F48E7DF(global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level1 obj)
         {
-            var __obs0 = (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>(
+            var __obs0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>(
                 (global::System.ComponentModel.INotifyPropertyChanging)obj,
                 "Model",
                 (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level1)__o).Model);
-
+            var __obs0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level1), "Model", 5, true);
+            var __obs0 = __obs0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>)__obs0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>(
+                    __obs0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level1, global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>>)(__e => __e.Model)).Body,
+                    "Model",
+                    (object __o) => ((global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level1)__o).Model,
+                    true,
+                    true);
         var __obs1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2, global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>(__obs0,
             __parent1 => __parent1 != null
                 ? (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.4LDC_CFP#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.4LDC_CFP#WhenChangingDispatch.g.verified.cs
@@ -23,16 +23,26 @@ namespace ReactiveUI.Binding
             {
                 return __WhenChanging_00001C315F48E7DF(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanging dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanging<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level1, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanging_00001C315F48E7DF(global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level1 obj)
         {
-            var __obs0 = (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>(
+            var __obs0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>(
                 (global::System.ComponentModel.INotifyPropertyChanging)obj,
                 "Model",
                 (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level1)__o).Model);
-
+            var __obs0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level1), "Model", 5, true);
+            var __obs0 = __obs0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>)__obs0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>(
+                    __obs0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level1, global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2>>)(__e => __e.Model)).Body,
+                    "Model",
+                    (object __o) => ((global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level1)__o).Model,
+                    true,
+                    true);
         var __obs1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level2, global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>(__obs0,
             __parent1 => __parent1 != null
                 ? (global::System.IObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<global::SharedScenarios.WhenChanging.FourLevelDeepChain.Level3>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.DPC#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.DPC#WhenChangingDispatch.g.verified.cs
@@ -25,16 +25,26 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanging_7FFFF85E7720B498(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanging dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanging<global::SharedScenarios.WhenChanging.DeepPropertyChain.ParentViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanging_7FFFF85E7720B498(global::SharedScenarios.WhenChanging.DeepPropertyChain.ParentViewModel obj)
         {
-            var __obs0 = (global::System.IObservable<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>(
+            var __obs0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>(
                 (global::System.ComponentModel.INotifyPropertyChanging)obj,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.DeepPropertyChain.ParentViewModel)__o).Child);
-
+            var __obs0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenChanging.DeepPropertyChain.ParentViewModel), "Child", 5, true);
+            var __obs0 = __obs0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>)__obs0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>(
+                    __obs0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanging.DeepPropertyChain.ParentViewModel, global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.WhenChanging.DeepPropertyChain.ParentViewModel)__o).Child,
+                    true,
+                    true);
         var __obs1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel, string>(__obs0,
             __parent1 => __parent1 != null
                 ? (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<string>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.DPC_CFP#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.DPC_CFP#WhenChangingDispatch.g.verified.cs
@@ -23,16 +23,26 @@ namespace ReactiveUI.Binding
             {
                 return __WhenChanging_7FFFF85E7720B498(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanging dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanging<global::SharedScenarios.WhenChanging.DeepPropertyChain.ParentViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanging_7FFFF85E7720B498(global::SharedScenarios.WhenChanging.DeepPropertyChain.ParentViewModel obj)
         {
-            var __obs0 = (global::System.IObservable<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>(
+            var __obs0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>(
                 (global::System.ComponentModel.INotifyPropertyChanging)obj,
                 "Child",
                 (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.DeepPropertyChain.ParentViewModel)__o).Child);
-
+            var __obs0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenChanging.DeepPropertyChain.ParentViewModel), "Child", 5, true);
+            var __obs0 = __obs0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>)__obs0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>(
+                    __obs0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanging.DeepPropertyChain.ParentViewModel, global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel>>)(__e => __e.Child)).Body,
+                    "Child",
+                    (object __o) => ((global::SharedScenarios.WhenChanging.DeepPropertyChain.ParentViewModel)__o).Child,
+                    true,
+                    true);
         var __obs1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenChanging.DeepPropertyChain.ChildModel, string>(__obs0,
             __parent1 => __parent1 != null
                 ? (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<string>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.INPChangingOnly_Property#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.INPChangingOnly_Property#WhenChangingDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanging_7FFFE1C28268960F(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanging dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanging<global::TestApp.MyChangingViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanging_7FFFE1C28268960F(global::TestApp.MyChangingViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<string>((global::System.ComponentModel.INotifyPropertyChanging)obj, "Name", (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::TestApp.MyChangingViewModel)__o).Name);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::TestApp.MyChangingViewModel, string>>)(__e => __e.Name)).Body,
+                "Name",
+                true,
+                5,
+                (object __o) => ((global::TestApp.MyChangingViewModel)__o).Name,
+                new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<string>((global::System.ComponentModel.INotifyPropertyChanging)obj, "Name", (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::TestApp.MyChangingViewModel)__o).Name));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.MP_2P#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.MP_2P#WhenChangingDispatch.g.verified.cs
@@ -28,7 +28,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanging_000011A95039C09F(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanging dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanging<global::SharedScenarios.WhenChanging.MultiPropertyTwoProperties.MyViewModel, string, int>(objectToMonitor, property1, property2);
         }
 
         private static global::System.IObservable<global::ReactiveUI.Binding.PropertyValues<string, int>> __WhenChanging_000011A95039C09F(global::SharedScenarios.WhenChanging.MultiPropertyTwoProperties.MyViewModel obj)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.MP_2P_CFP#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.MP_2P_CFP#WhenChangingDispatch.g.verified.cs
@@ -25,7 +25,7 @@ namespace ReactiveUI.Binding
             {
                 return __WhenChanging_000011A95039C09F(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanging dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanging<global::SharedScenarios.WhenChanging.MultiPropertyTwoProperties.MyViewModel, string, int>(objectToMonitor, property1, property2);
         }
 
         private static global::System.IObservable<global::ReactiveUI.Binding.PropertyValues<string, int>> __WhenChanging_000011A95039C09F(global::SharedScenarios.WhenChanging.MultiPropertyTwoProperties.MyViewModel obj)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.MP_3P#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.MP_3P#WhenChangingDispatch.g.verified.cs
@@ -31,7 +31,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanging_7FFFF53EB8A56F90(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanging dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanging<global::SharedScenarios.WhenChanging.MultiPropertyThreeProperties.MyViewModel, string, int, double>(objectToMonitor, property1, property2, property3);
         }
 
         private static global::System.IObservable<global::ReactiveUI.Binding.PropertyValues<string, int, double>> __WhenChanging_7FFFF53EB8A56F90(global::SharedScenarios.WhenChanging.MultiPropertyThreeProperties.MyViewModel obj)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.MP_WDC#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.MP_WDC#WhenChangingDispatch.g.verified.cs
@@ -29,16 +29,26 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanging_7FFFFF97E6DC4D84(objectToMonitor, selector);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanging dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanging<global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.MyViewModel, string, string, string>(objectToMonitor, property1, property2, selector);
         }
 
         private static global::System.IObservable<string> __WhenChanging_7FFFFF97E6DC4D84(global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.MyViewModel obj, global::System.Func<string, string, string> selector)
         {
-            var __propObs0_s0 = (global::System.IObservable<global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.AddressModel>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.AddressModel>(
+            var __propObs0_s0Mechanism = (global::System.IObservable<global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.AddressModel>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.AddressModel>(
                 (global::System.ComponentModel.INotifyPropertyChanging)obj,
                 "Address",
                 (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.MyViewModel)__o).Address);
-
+            var __propObs0_s0Registration = global::ReactiveUI.Binding.Fallback.ObservationAffinityChecker.FindHigherAffinityPlugin(typeof(global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.MyViewModel), "Address", 5, true);
+            var __propObs0_s0 = __propObs0_s0Registration == null
+                ? (global::System.IObservable<global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.AddressModel>)__propObs0_s0Mechanism
+                : (global::System.IObservable<global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.AddressModel>)new global::ReactiveUI.Binding.Observables.PluginPropertyObservable<global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.AddressModel>(
+                    __propObs0_s0Registration,
+                    obj,
+                    ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.MyViewModel, global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.AddressModel>>)(__e => __e.Address)).Body,
+                    "Address",
+                    (object __o) => ((global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.MyViewModel)__o).Address,
+                    true,
+                    true);
         var __propObs0_s1 = new global::ReactiveUI.Primitives.Advanced.SwitchMapSignal<global::SharedScenarios.WhenChanging.MultiPropertyWithDeepChains.AddressModel, string>(__propObs0_s0,
             __propObs0_p1 => __propObs0_p1 != null
                 ? (global::System.IObservable<string>)new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<string>(

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.MP_WS#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.MP_WS#WhenChangingDispatch.g.verified.cs
@@ -29,7 +29,7 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanging_00001B25E45F4801(objectToMonitor, selector);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanging dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanging<global::SharedScenarios.WhenChanging.MultiPropertyWithSelector.MyViewModel, string, string, string>(objectToMonitor, property1, property2, selector);
         }
 
         private static global::System.IObservable<string> __WhenChanging_00001B25E45F4801(global::SharedScenarios.WhenChanging.MultiPropertyWithSelector.MyViewModel obj, global::System.Func<string, string, string> selector)

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.ReactiveObject_Changing_Property#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.ReactiveObject_Changing_Property#WhenChangingDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanging_7FFFD5A9BCD06EB3(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanging dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanging<global::TestApp.MyReactiveViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanging_7FFFD5A9BCD06EB3(global::TestApp.MyReactiveViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<string>((global::System.ComponentModel.INotifyPropertyChanging)obj, "Name", (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::TestApp.MyReactiveViewModel)__o).Name);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::TestApp.MyReactiveViewModel, string>>)(__e => __e.Name)).Body,
+                "Name",
+                true,
+                10,
+                (object __o) => ((global::TestApp.MyReactiveViewModel)__o).Name,
+                new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<string>((global::System.ComponentModel.INotifyPropertyChanging)obj, "Name", (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::TestApp.MyReactiveViewModel)__o).Name));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.SP_INPC#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.SP_INPC#WhenChangingDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanging_7FFFD2B6A9CCF5C7(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanging dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanging<global::SharedScenarios.WhenChanging.SinglePropertyINPC.MyViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanging_7FFFD2B6A9CCF5C7(global::SharedScenarios.WhenChanging.SinglePropertyINPC.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<string>((global::System.ComponentModel.INotifyPropertyChanging)obj, "Name", (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.SinglePropertyINPC.MyViewModel)__o).Name);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanging.SinglePropertyINPC.MyViewModel, string>>)(__e => __e.Name)).Body,
+                "Name",
+                true,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenChanging.SinglePropertyINPC.MyViewModel)__o).Name,
+                new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<string>((global::System.ComponentModel.INotifyPropertyChanging)obj, "Name", (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.SinglePropertyINPC.MyViewModel)__o).Name));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.SP_INPC_CFP#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.SP_INPC_CFP#WhenChangingDispatch.g.verified.cs
@@ -23,12 +23,19 @@ namespace ReactiveUI.Binding
             {
                 return __WhenChanging_7FFFD2B6A9CCF5C7(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanging dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanging<global::SharedScenarios.WhenChanging.SinglePropertyINPC.MyViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanging_7FFFD2B6A9CCF5C7(global::SharedScenarios.WhenChanging.SinglePropertyINPC.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<string>((global::System.ComponentModel.INotifyPropertyChanging)obj, "Name", (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.SinglePropertyINPC.MyViewModel)__o).Name);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanging.SinglePropertyINPC.MyViewModel, string>>)(__e => __e.Name)).Body,
+                "Name",
+                true,
+                5,
+                (object __o) => ((global::SharedScenarios.WhenChanging.SinglePropertyINPC.MyViewModel)__o).Name,
+                new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<string>((global::System.ComponentModel.INotifyPropertyChanging)obj, "Name", (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.SinglePropertyINPC.MyViewModel)__o).Name));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.SP_ReactiveObject#WhenChangingDispatch.g.verified.cs
+++ b/src/tests/ReactiveUI.Binding.SourceGenerators.Tests/WCnG.SP_ReactiveObject#WhenChangingDispatch.g.verified.cs
@@ -25,12 +25,19 @@ namespace ReactiveUI.Binding.Generated.TestAssembly
             {
                 return __WhenChanging_7FFFCA92B45AE4E5(objectToMonitor);
             }
-            throw new global::System.InvalidOperationException("No generated WhenChanging dispatch matched. Ensure the expression is an inline lambda for compile-time optimization.");
+            return global::ReactiveUI.Binding.ReactiveUIBindingExtensions.WhenChanging<global::SharedScenarios.WhenChanging.SinglePropertyReactiveObject.MyViewModel, string>(objectToMonitor, property1);
         }
 
         private static global::System.IObservable<string> __WhenChanging_7FFFCA92B45AE4E5(global::SharedScenarios.WhenChanging.SinglePropertyReactiveObject.MyViewModel obj)
         {
-            return new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<string>((global::System.ComponentModel.INotifyPropertyChanging)obj, "Name", (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.SinglePropertyReactiveObject.MyViewModel)__o).Name);
+            return global::ReactiveUI.Binding.Observables.PluginObservationSource.Choose<string>(
+                obj,
+                ((global::System.Linq.Expressions.Expression<global::System.Func<global::SharedScenarios.WhenChanging.SinglePropertyReactiveObject.MyViewModel, string>>)(__e => __e.Name)).Body,
+                "Name",
+                true,
+                10,
+                (object __o) => ((global::SharedScenarios.WhenChanging.SinglePropertyReactiveObject.MyViewModel)__o).Name,
+                new global::ReactiveUI.Binding.Observables.PropertyChangingObservable<string>((global::System.ComponentModel.INotifyPropertyChanging)obj, "Name", (global::System.ComponentModel.INotifyPropertyChanging __o) => ((global::SharedScenarios.WhenChanging.SinglePropertyReactiveObject.MyViewModel)__o).Name));
         }
 
     }

--- a/src/tests/ReactiveUI.Binding.Tests/Fallback/RuntimeBindingConverterTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Fallback/RuntimeBindingConverterTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Binding.Fallback;
+using ReactiveUI.Binding.Tests.TestModels;
+
+namespace ReactiveUI.Binding.Tests.Fallback;
+
+/// <summary>Covers the conversion a generated binding routes a value through before it writes.</summary>
+/// <remarks>
+/// A refused conversion is the case that matters: the generated binding skips the assignment for that
+/// emission rather than writing a default, so the failure has to be reported rather than absorbed.
+/// </remarks>
+public class RuntimeBindingConverterTests
+{
+    /// <summary>The value handed to the conversion.</summary>
+    private const string SourceValue = "41";
+
+    /// <summary>The value a successful conversion produces.</summary>
+    private const int ConvertedValue = 41;
+
+    /// <summary>An explicit converter takes precedence over the registry.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task TryConvert_WithAConverterOverride_ProducesTheConvertedValue()
+    {
+        var converter = new StubBindingTypeConverter(
+            typeof(string),
+            typeof(int),
+            static (_, _) => new(true, ConvertedValue));
+
+        var converted = RuntimeBindingConverter.TryConvert<string, int>(
+            SourceValue,
+            null,
+            converter,
+            out var result);
+
+        await Assert.That(converted).IsTrue();
+        await Assert.That(result).IsEqualTo(ConvertedValue);
+    }
+
+    /// <summary>An explicit converter that refuses the value fails the conversion.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task TryConvert_WhenTheConverterOverrideRefuses_Fails()
+    {
+        var converter = new StubBindingTypeConverter(
+            typeof(string),
+            typeof(int),
+            static (_, _) => new(false, null));
+
+        var converted = RuntimeBindingConverter.TryConvert<string, int>(
+            SourceValue,
+            null,
+            converter,
+            out var result);
+
+        await Assert.That(converted).IsFalse();
+        await Assert.That(result).IsEqualTo(0);
+    }
+
+    /// <summary>An explicit converter producing a value of another type fails the conversion.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task TryConvert_WhenTheConverterOverrideProducesAnotherType_Fails()
+    {
+        var converter = new StubBindingTypeConverter(
+            typeof(string),
+            typeof(int),
+            static (_, _) => new(true, SourceValue));
+
+        var converted = RuntimeBindingConverter.TryConvert<string, int>(
+            SourceValue,
+            null,
+            converter,
+            out var result);
+
+        await Assert.That(converted).IsFalse();
+        await Assert.That(result).IsEqualTo(0);
+    }
+
+    /// <summary>The registry resolves the conversion when no explicit converter is supplied.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task TryConvert_WithoutAConverterOverride_ResolvesFromTheRegistry()
+    {
+        var converted = RuntimeBindingConverter.TryConvert<string, int>(
+            SourceValue,
+            null,
+            null,
+            out var result);
+
+        await Assert.That(converted).IsTrue();
+        await Assert.That(result).IsEqualTo(ConvertedValue);
+    }
+
+    /// <summary>A type pair the registry cannot bridge fails the conversion.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task TryConvert_WhenNoConverterReachesTheTypePair_Fails()
+    {
+        var converted = RuntimeBindingConverter.TryConvert<TestViewModel, int>(
+            new(),
+            null,
+            null,
+            out var result);
+
+        await Assert.That(converted).IsFalse();
+        await Assert.That(result).IsEqualTo(0);
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Fallback/RuntimeBindingFallbackTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Fallback/RuntimeBindingFallbackTests.cs
@@ -425,6 +425,27 @@ public class RuntimeBindingFallbackTests
         await Assert.That(action).ThrowsExactly<ArgumentNullException>();
     }
 
+    /// <summary>Verifies that a null target leaves the source unsubscribed rather than faulting.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTo_NullTarget_LeavesTheSourceUnsubscribed()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+
+        var source = new ManualObservable<string>();
+
+        using var binding = RuntimeBindingFallback.BindTo<string, TestViewModel, string>(
+            source,
+            null,
+            x => x.Name,
+            null,
+            null,
+            null,
+            BindingExpression);
+
+        await Assert.That(source.Observer).IsNull();
+    }
+
     /// <summary>A view with one observable property, for the view-first binding tests.</summary>
     private sealed class BindingTestView : IViewFor, INotifyPropertyChanged
     {

--- a/src/tests/ReactiveUI.Binding.Tests/Fallback/RuntimeCommandBindingFallbackTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Fallback/RuntimeCommandBindingFallbackTests.cs
@@ -38,4 +38,56 @@ public class RuntimeCommandBindingFallbackTests
 
         await Assert.That(parameters.Observer).IsNull();
     }
+
+    /// <summary>A control no registered binder reaches leaves the command unbound rather than faulting.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommand_WithAControlNoBinderReaches_BindsNothing()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        Locator.CurrentMutable.RegisterConstant<ICreatesCommandBinding>(new ClickCommandBinder());
+        var command = new RecordingStubCommand();
+        var viewModel = new DispatchStubViewModel { Run = command };
+
+        using var binding = RuntimeCommandBindingFallback.BindCommand<
+            DispatchStubView,
+            DispatchStubViewModel,
+            ICommand,
+            UnclaimedStubControl>(
+            new(),
+            viewModel,
+            x => x.Run,
+            x => x.Surface,
+            new ManualObservable<object?>(),
+            null,
+            BindingExpression);
+
+        await Assert.That(command.LastParameter).IsNull();
+    }
+
+    /// <summary>Naming an event does not find a binder for a control no binder reaches either.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommand_WithANamedEventAndAControlNoBinderReaches_BindsNothing()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        Locator.CurrentMutable.RegisterConstant<ICreatesCommandBinding>(new ClickCommandBinder());
+        var command = new RecordingStubCommand();
+        var viewModel = new DispatchStubViewModel { Run = command };
+
+        using var binding = RuntimeCommandBindingFallback.BindCommand<
+            DispatchStubView,
+            DispatchStubViewModel,
+            ICommand,
+            UnclaimedStubControl>(
+            new(),
+            viewModel,
+            x => x.Run,
+            x => x.Surface,
+            new ManualObservable<object?>(),
+            nameof(DispatchStubControl.Click),
+            BindingExpression);
+
+        await Assert.That(command.LastParameter).IsNull();
+    }
 }

--- a/src/tests/ReactiveUI.Binding.Tests/Fallback/RuntimeCommandBindingFallbackTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Fallback/RuntimeCommandBindingFallbackTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows.Input;
+using ReactiveUI.Binding.Fallback;
+using ReactiveUI.Binding.Tests.TestModels;
+
+namespace ReactiveUI.Binding.Tests.Fallback;
+
+/// <summary>Covers the command binding a call site the generator could not read falls back to.</summary>
+public class RuntimeCommandBindingFallbackTests
+{
+    /// <summary>The expression text reported when the observation faults.</summary>
+    private const string BindingExpression = "x => x.Run";
+
+    /// <summary>A null view model holds no command to bind, so the parameter stream stays unsubscribed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommand_WithNoViewModel_BindsNothing()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        Locator.CurrentMutable.RegisterConstant<ICreatesCommandBinding>(new ClickCommandBinder());
+        var parameters = new ManualObservable<object?>();
+
+        using var binding = RuntimeCommandBindingFallback.BindCommand<
+            DispatchStubView,
+            DispatchStubViewModel,
+            ICommand,
+            DispatchStubControl>(
+            new(),
+            null,
+            x => x.Run,
+            x => x.Control,
+            parameters,
+            null,
+            BindingExpression);
+
+        await Assert.That(parameters.Observer).IsNull();
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Fallback/RuntimeInteractionFallbackTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Fallback/RuntimeInteractionFallbackTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Binding.Fallback;
+using ReactiveUI.Binding.Tests.TestModels;
+
+namespace ReactiveUI.Binding.Tests.Fallback;
+
+/// <summary>Covers the interaction registration a call site the generator could not read falls back to.</summary>
+public class RuntimeInteractionFallbackTests
+{
+    /// <summary>The expression text reported when the observation faults.</summary>
+    private const string BindingExpression = "x => x.Confirm";
+
+    /// <summary>A null view model holds no interaction, so the handler is never registered.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindInteraction_WithNoViewModel_RegistersNothing()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        var registrations = 0;
+
+        using var binding = RuntimeInteractionFallback.BindInteraction<DispatchStubViewModel, string, bool>(
+            null,
+            x => x.Confirm,
+            _ =>
+            {
+                registrations++;
+                return new UnregisteredHandler();
+            },
+            BindingExpression);
+
+        await Assert.That(registrations).IsEqualTo(0);
+    }
+
+    /// <summary>Stands in for the registration a handler would hand back.</summary>
+    private sealed class UnregisteredHandler : IDisposable
+    {
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Fallback/RuntimeInteractionFallbackTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Fallback/RuntimeInteractionFallbackTests.cs
@@ -34,6 +34,28 @@ public class RuntimeInteractionFallbackTests
         await Assert.That(registrations).IsEqualTo(0);
     }
 
+    /// <summary>A property holding no interaction registers nothing, and does not fault the observation.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindInteraction_WhenThePropertyHoldsNoInteraction_RegistersNothing()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        var registrations = 0;
+        var viewModel = new DispatchStubViewModel { Confirm = null! };
+
+        using var binding = RuntimeInteractionFallback.BindInteraction(
+            viewModel,
+            x => x.Confirm,
+            _ =>
+            {
+                registrations++;
+                return new UnregisteredHandler();
+            },
+            BindingExpression);
+
+        await Assert.That(registrations).IsEqualTo(0);
+    }
+
     /// <summary>Stands in for the registration a handler would hand back.</summary>
     private sealed class UnregisteredHandler : IDisposable
     {

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/BindingDispatchStubTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/BindingDispatchStubTests.cs
@@ -518,6 +518,53 @@ public class BindingDispatchStubTests
         await Assert.That(command.LastParameter).IsEqualTo(ReverseValue);
     }
 
+    /// <summary>A command binding named against an event reaches the command through that event.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommandUnsafe_WithANamedEvent_ExecutesThroughThatEvent()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        Locator.CurrentMutable.RegisterConstant<ICreatesCommandBinding>(new ClickCommandBinder());
+        var command = new RecordingStubCommand();
+        _viewModel.Run = command;
+
+        using var binding = ReactiveUIBindingExtensions.BindCommandUnsafe(
+            _view,
+            _viewModel,
+            x => x.Run,
+            x => x.Control,
+            _source,
+            nameof(DispatchStubControl.Click));
+
+        _source.Observer?.OnNext(BoundValue);
+        _view.Control.PerformClick();
+
+        await Assert.That(command.LastParameter).IsEqualTo(BoundValue);
+    }
+
+    /// <summary>A command binding with no view model has no parameter property to observe.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommandUnsafe_WithAParameterPropertyAndNoViewModel_BindsNothing()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        Locator.CurrentMutable.RegisterConstant<ICreatesCommandBinding>(new ClickCommandBinder());
+        var command = new RecordingStubCommand();
+        _viewModel.Run = command;
+
+        using var binding = ReactiveUIBindingExtensions.BindCommandUnsafe(
+            _view,
+            (DispatchStubViewModel?)null,
+            x => x.Run,
+            x => x.Control,
+            x => x.Parameter,
+            null);
+
+        _view.Control.PerformClick();
+
+        await Assert.That(command.LastParameter).IsNull();
+    }
+
     /// <summary>WhenAny refuses a call no generated dispatch claimed.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/BindingDispatchStubTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/BindingDispatchStubTests.cs
@@ -25,6 +25,16 @@ public class BindingDispatchStubTests
     /// <summary>The value written on the target side of a two-way binding.</summary>
     private const string ReverseValue = "reversed";
 
+    /// <summary>The overload a refused BindTo points the caller at.</summary>
+    private const string BindToTwin = "BindToUnsafe";
+
+    /// <summary>The overload a refused command binding points the caller at.</summary>
+    private const string BindCommandTwin = "BindCommandUnsafe";
+
+    /// <summary>The converter a BindTo overload names, so the call reaches the overload taking one.</summary>
+    private static readonly IBindingTypeConverter PassThrough =
+        new StubBindingTypeConverter(typeof(string), typeof(string), static (from, _) => new(true, from));
+
     /// <summary>The source of a binding.</summary>
     private readonly DispatchStubViewModel _viewModel = new();
 
@@ -423,7 +433,7 @@ public class BindingDispatchStubTests
     public Task BindTo_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
         AssertRefusedNaming(
             () => ReactiveUIBindingExtensions.BindTo(_source, _view, x => x.Caption),
-            "BindToUnsafe");
+            BindToTwin);
 
     /// <summary>BindCommand refuses a call no generated dispatch claimed.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
@@ -432,7 +442,7 @@ public class BindingDispatchStubTests
     public Task BindCommand_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
         AssertRefusedNaming(
             () => ReactiveUIBindingExtensions.BindCommand(_view, _viewModel, x => x.Run, x => x.Control),
-            "BindCommandUnsafe");
+            BindCommandTwin);
 
     /// <summary>BindInteraction refuses a call no generated dispatch claimed.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
@@ -460,12 +470,15 @@ public class BindingDispatchStubTests
             () => ReactiveUIBindingExtensions.InvokeCommand(_source, _viewModel, x => x.Run),
             "InvokeCommandUnsafe");
 
-    /// <summary>A command binding offers the value its parameter stream produces to the command.</summary>
+    /// <summary>A command binding executes with the value its parameter stream produced.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task BindCommandUnsafe_WithAParameterStream_OffersTheValueProduced()
+    public async Task BindCommandUnsafe_WithAParameterStream_ExecutesWithTheValueProduced()
     {
         RuntimeObservationFallbackTests.EnsureInitialized();
+        Locator.CurrentMutable.RegisterConstant<ICreatesCommandBinding>(new ClickCommandBinder());
+        var command = new RecordingStubCommand();
+        _viewModel.Run = command;
 
         using var binding = ReactiveUIBindingExtensions.BindCommandUnsafe(
             _view,
@@ -476,16 +489,21 @@ public class BindingDispatchStubTests
             null);
 
         _source.Observer?.OnNext(BoundValue);
+        _view.Control.PerformClick();
 
-        await Assert.That(binding).IsNotNull();
+        await Assert.That(command.LastParameter).IsEqualTo(BoundValue);
     }
 
-    /// <summary>A command binding offers the value its parameter property holds to the command.</summary>
+    /// <summary>A command binding executes with the value its parameter property holds.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task BindCommandUnsafe_WithAParameterProperty_OffersTheValueHeld()
+    public async Task BindCommandUnsafe_WithAParameterProperty_ExecutesWithTheValueHeld()
     {
         RuntimeObservationFallbackTests.EnsureInitialized();
+        Locator.CurrentMutable.RegisterConstant<ICreatesCommandBinding>(new ClickCommandBinder());
+        var command = new RecordingStubCommand();
+        _viewModel.Run = command;
+        _viewModel.Parameter = ReverseValue;
 
         using var binding = ReactiveUIBindingExtensions.BindCommandUnsafe(
             _view,
@@ -495,9 +513,9 @@ public class BindingDispatchStubTests
             x => x.Parameter,
             null);
 
-        _viewModel.Parameter = ReverseValue;
+        _view.Control.PerformClick();
 
-        await Assert.That(binding).IsNotNull();
+        await Assert.That(command.LastParameter).IsEqualTo(ReverseValue);
     }
 
     /// <summary>WhenAny refuses a call no generated dispatch claimed.</summary>
@@ -517,6 +535,136 @@ public class BindingDispatchStubTests
         AssertRefusedNaming(
             () => ReactiveUIBindingExtensions.WhenAnyObservable(_viewModel, x => x.Signal!),
             "WhenAnyObservableUnsafe");
+
+    /// <summary>The converting one-way overload refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindOneWayWithConversion_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.BindOneWay(
+                _viewModel,
+                _view,
+                x => x.Caption,
+                x => x.Caption,
+                static value => value + ReverseValue),
+            "BindOneWayUnsafe");
+
+    /// <summary>The converting two-way overload refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindTwoWayWithConversions_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.BindTwoWay(
+                _viewModel,
+                _view,
+                x => x.Caption,
+                x => x.Caption,
+                static value => value + ReverseValue,
+                static value => value + BoundValue),
+            "BindTwoWayUnsafe");
+
+    /// <summary>The selecting view binding refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task OneWayBindWithSelector_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.OneWayBind(
+                _view,
+                _viewModel,
+                x => x.Caption,
+                x => x.Caption,
+                static value => value + ReverseValue),
+            "OneWayBindUnsafe");
+
+    /// <summary>The converting view binding refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindWithConverters_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.Bind(
+                _view,
+                _viewModel,
+                x => x.Caption,
+                x => x.Caption,
+                static value => value + ReverseValue,
+                static value => value + BoundValue),
+            "BindUnsafe");
+
+    /// <summary>BindTo with a conversion hint refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    /// <remarks>
+    /// The hint is named rather than positional: it is typed <c>object</c>, so a string passed positionally
+    /// binds to the plain overload's captured expression text instead.
+    /// </remarks>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindToWithConversionHint_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.BindTo(_source, _view, x => x.Caption, conversionHint: BoundValue),
+            BindToTwin);
+
+    /// <summary>BindTo with a converter refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindToWithConverterOverride_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.BindTo(_source, _view, x => x.Caption, PassThrough),
+            BindToTwin);
+
+    /// <summary>BindTo with a hint and a converter refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindToWithHintAndConverter_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.BindTo(_source, _view, x => x.Caption, BoundValue, PassThrough),
+            BindToTwin);
+
+    /// <summary>A command binding taking a parameter stream refuses a call no dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindCommandWithParameterStream_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.BindCommand(
+                _view,
+                _viewModel,
+                x => x.Run,
+                x => x.Control,
+                _source),
+            BindCommandTwin);
+
+    /// <summary>A command binding taking a parameter property refuses a call no dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindCommandWithParameterProperty_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.BindCommand(
+                _view,
+                _viewModel,
+                x => x.Run,
+                x => x.Control,
+                x => x.Parameter),
+            BindCommandTwin);
+
+    /// <summary>An interaction binding handling with a stream refuses a call no dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindInteractionWithObservableHandler_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.BindInteraction(
+                _view,
+                _viewModel,
+                x => x.Confirm,
+                context => _source),
+            "BindInteractionUnsafe");
 
     /// <summary>Asserts that a call refuses and points the caller at the overload that resolves it.</summary>
     /// <param name="call">The call expected to refuse.</param>

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/BindingDispatchStubTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/BindingDispatchStubTests.cs
@@ -2,19 +2,29 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
+using ReactiveUI.Binding.Tests.Fallback;
 using ReactiveUI.Binding.Tests.TestModels;
 
 namespace ReactiveUI.Binding.Tests.Mixins;
 
 /// <summary>Covers the binding overloads that exist only to be replaced by a generated one.</summary>
 /// <remarks>
-/// Unlike the observation surface, a binding has no runtime fallback: resolving one needs the two lambdas at
-/// compile time. Each overload here therefore refuses the call rather than binding something. They are reached
-/// on the declaring class rather than as extension methods, because written as an extension call the generated
-/// dispatch wins overload resolution and the refusal never happens.
+/// A generated overload wins overload resolution for every call site of its types, including the ones whose
+/// lambdas it could not read. The unsuffixed overload it displaces therefore refuses, naming the
+/// <c>Unsafe</c> twin that resolves the expression by reflection, so nothing a consumer calls by its plain
+/// name carries <c>RequiresUnreferencedCode</c>. Both halves are reached on the declaring class rather than as
+/// extension methods, because written as an extension call a generated dispatch wins and the stub is never
+/// entered.
 /// </remarks>
 public class BindingDispatchStubTests
 {
+    /// <summary>The value the source carries into the binding.</summary>
+    private const string BoundValue = "bound";
+
+    /// <summary>The value written on the target side of a two-way binding.</summary>
+    private const string ReverseValue = "reversed";
+
     /// <summary>The source of a binding.</summary>
     private readonly DispatchStubViewModel _viewModel = new();
 
@@ -24,198 +34,498 @@ public class BindingDispatchStubTests
     /// <summary>The stream a BindTo call writes from.</summary>
     private readonly ManualObservable<string> _source = new();
 
-    /// <summary>A one-way binding with no generated overload refuses the call.</summary>
+    /// <summary>A one-way binding with no generated overload runs through the runtime engine.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task BindOneWay_WithNoGeneratedOverload_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.BindOneWay(
+    public async Task BindOneWay_WithNoGeneratedOverload_BindsThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        _viewModel.Caption = BoundValue;
+
+        using var binding = ReactiveUIBindingExtensions.BindOneWayUnsafe(
+            _viewModel,
+            _view,
+            x => x.Caption,
+            x => x.Caption);
+
+        await Assert.That(_view.Caption).IsEqualTo(BoundValue);
+    }
+
+    /// <summary>A converting one-way binding with no generated overload runs through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindOneWay_ConvertingWithNoGeneratedOverload_BindsThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        _viewModel.Caption = BoundValue;
+
+        using var binding = ReactiveUIBindingExtensions.BindOneWayUnsafe(
+            _viewModel,
+            _view,
+            x => x.Caption,
+            x => x.Caption,
+            static value => value);
+
+        await Assert.That(_view.Caption).IsEqualTo(BoundValue);
+    }
+
+    /// <summary>A two-way binding with no generated overload drives both sides through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTwoWay_WithNoGeneratedOverload_BindsBothSidesThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        _viewModel.Caption = BoundValue;
+
+        using var binding = ReactiveUIBindingExtensions.BindTwoWayUnsafe(
+            _viewModel,
+            _view,
+            x => x.Caption,
+            x => x.Caption);
+
+        var afterBind = _view.Caption;
+        _view.Caption = ReverseValue;
+
+        await Assert.That(afterBind).IsEqualTo(BoundValue);
+        await Assert.That(_viewModel.Caption).IsEqualTo(ReverseValue);
+    }
+
+    /// <summary>A converting two-way binding with no generated overload runs through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTwoWay_ConvertingWithNoGeneratedOverload_BindsThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        _viewModel.Caption = BoundValue;
+
+        using var binding = ReactiveUIBindingExtensions.BindTwoWayUnsafe(
+            _viewModel,
+            _view,
+            x => x.Caption,
+            x => x.Caption,
+            static value => value,
+            static value => value);
+
+        await Assert.That(_view.Caption).IsEqualTo(BoundValue);
+    }
+
+    /// <summary>The view-first spelling of a one-way binding runs through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OneWayBind_WithNoGeneratedOverload_BindsThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        _viewModel.Caption = BoundValue;
+
+        using var binding = ReactiveUIBindingExtensions.OneWayBindUnsafe(
+            _view,
+            _viewModel,
+            x => x.Caption,
+            x => x.Caption);
+
+        await Assert.That(_view.Caption).IsEqualTo(BoundValue);
+    }
+
+    /// <summary>The converting view-first spelling of a one-way binding runs through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OneWayBind_ConvertingWithNoGeneratedOverload_BindsThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        _viewModel.Caption = BoundValue;
+
+        using var binding = ReactiveUIBindingExtensions.OneWayBindUnsafe(
+            _view,
+            _viewModel,
+            x => x.Caption,
+            x => x.Caption,
+            static value => value);
+
+        await Assert.That(_view.Caption).IsEqualTo(BoundValue);
+    }
+
+    /// <summary>The view-first spelling of a two-way binding runs through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Bind_WithNoGeneratedOverload_BindsBothSidesThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        _viewModel.Caption = BoundValue;
+
+        using var binding = ReactiveUIBindingExtensions.BindUnsafe(
+            _view,
+            _viewModel,
+            x => x.Caption,
+            x => x.Caption);
+
+        var afterBind = _view.Caption;
+        _view.Caption = ReverseValue;
+
+        await Assert.That(afterBind).IsEqualTo(BoundValue);
+        await Assert.That(_viewModel.Caption).IsEqualTo(ReverseValue);
+    }
+
+    /// <summary>The converting view-first spelling of a two-way binding runs through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Bind_ConvertingWithNoGeneratedOverload_BindsThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        _viewModel.Caption = BoundValue;
+
+        using var binding = ReactiveUIBindingExtensions.BindUnsafe(
+            _view,
+            _viewModel,
+            x => x.Caption,
+            x => x.Caption,
+            static value => value,
+            static value => value);
+
+        await Assert.That(_view.Caption).IsEqualTo(BoundValue);
+    }
+
+    /// <summary>Writing a stream into a property with no generated overload runs through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTo_WithNoGeneratedOverload_WritesThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+
+        using var binding = ReactiveUIBindingExtensions.BindToUnsafe(_source, _view, x => x.Caption);
+        _source.Observer!.OnNext(BoundValue);
+
+        await Assert.That(_view.Caption).IsEqualTo(BoundValue);
+    }
+
+    /// <summary>Writing a stream into a property with a conversion hint runs through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTo_WithAConversionHint_WritesThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+
+        using var binding = ReactiveUIBindingExtensions.BindToUnsafe(_source, _view, x => x.Caption, conversionHint: null);
+        _source.Observer!.OnNext(BoundValue);
+
+        await Assert.That(_view.Caption).IsEqualTo(BoundValue);
+    }
+
+    /// <summary>Writing a stream into a property with a converter runs through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTo_WithAConverter_WritesThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+
+        using var binding = ReactiveUIBindingExtensions.BindToUnsafe(_source, _view, x => x.Caption, converterOverride: null);
+        _source.Observer!.OnNext(BoundValue);
+
+        await Assert.That(_view.Caption).IsEqualTo(BoundValue);
+    }
+
+    /// <summary>Writing a stream into a property with both a hint and a converter runs through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTo_WithAConversionHintAndAConverter_WritesThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+
+        using var binding = ReactiveUIBindingExtensions.BindToUnsafe(
+            _source,
+            _view,
+            x => x.Caption,
+            conversionHint: null,
+            converterOverride: null);
+        _source.Observer!.OnNext(BoundValue);
+
+        await Assert.That(_view.Caption).IsEqualTo(BoundValue);
+    }
+
+    /// <summary>A command binding with no generated overload runs through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommand_WithNoGeneratedOverload_BindsThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+
+        using var binding = ReactiveUIBindingExtensions.BindCommandUnsafe(
+            _view,
+            _viewModel,
+            x => x.Run,
+            x => x.Control,
+            null);
+
+        await Assert.That(binding).IsNotNull();
+    }
+
+    /// <summary>A command binding taking its parameter from a stream runs through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommand_WithAParameterStream_BindsThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+
+        using var binding = ReactiveUIBindingExtensions.BindCommandUnsafe(
+            _view,
+            _viewModel,
+            x => x.Run,
+            x => x.Control,
+            _source,
+            null);
+
+        await Assert.That(binding).IsNotNull();
+    }
+
+    /// <summary>A command binding taking its parameter from a property runs through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommand_WithAParameterProperty_BindsThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+
+        using var binding = ReactiveUIBindingExtensions.BindCommandUnsafe(
+            _view,
+            _viewModel,
+            x => x.Run,
+            x => x.Control,
+            x => x.Parameter,
+            null);
+
+        await Assert.That(binding).IsNotNull();
+    }
+
+    /// <summary>An interaction binding handled asynchronously reaches the handler through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindInteraction_WithAnAsynchronousHandler_RegistersThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        _viewModel.Confirm = new Interaction<string, bool>();
+
+        using var binding = ReactiveUIBindingExtensions.BindInteractionUnsafe(
+            _view,
+            _viewModel,
+            x => x.Confirm,
+            static context =>
+            {
+                context.SetOutput(true);
+                return Task.CompletedTask;
+            });
+
+        var handled = await _viewModel.Confirm.Handle(BoundValue);
+
+        await Assert.That(handled).IsTrue();
+    }
+
+    /// <summary>An interaction binding handled by a stream reaches the handler through the runtime engine.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindInteraction_WithAStreamHandler_RegistersThroughTheRuntimeEngine()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        _viewModel.Confirm = new Interaction<string, bool>();
+
+        using var binding = ReactiveUIBindingExtensions.BindInteractionUnsafe(
+            _view,
+            _viewModel,
+            x => x.Confirm,
+            static IObservable<string> (context) =>
+            {
+                context.SetOutput(true);
+                return ReactiveUI.Primitives.Signals.Signal.Empty<string>();
+            });
+
+        var handled = await _viewModel.Confirm.Handle(BoundValue);
+
+        await Assert.That(handled).IsTrue();
+    }
+
+    /// <summary>WhenChanged refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.WhenChanged(_viewModel, x => x.Caption),
+            "WhenChangedUnsafe");
+
+    /// <summary>WhenChanging refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.WhenChanging(_viewModel, x => x.Caption),
+            "WhenChangingUnsafe");
+
+    /// <summary>WhenAnyValue refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.WhenAnyValue(_viewModel, x => x.Caption),
+            "WhenAnyValueUnsafe");
+
+    /// <summary>The multi-property selector overload refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChangedWithSelector_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.WhenChanged(
                 _viewModel,
-                _view,
-                x => x.Caption,
-                x => x.Caption))
-            .ThrowsExactly<InvalidOperationException>();
-
-    /// <summary>A converting one-way binding with no generated overload refuses the call.</summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task BindOneWay_ConvertingWithNoGeneratedOverload_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.BindOneWay(
-                _viewModel,
-                _view,
                 x => x.Caption,
                 x => x.Caption,
-                static value => value))
-            .ThrowsExactly<InvalidOperationException>();
+                static (first, second) => first + second),
+            "WhenChangedUnsafe");
 
-    /// <summary>A two-way binding with no generated overload refuses the call.</summary>
+    /// <summary>BindOneWay refuses a call no generated dispatch claimed.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task BindTwoWay_WithNoGeneratedOverload_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.BindTwoWay(
-                _viewModel,
-                _view,
-                x => x.Caption,
-                x => x.Caption))
-            .ThrowsExactly<InvalidOperationException>();
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindOneWay_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.BindOneWay(_viewModel, _view, x => x.Caption, x => x.Caption),
+            "BindOneWayUnsafe");
 
-    /// <summary>A converting two-way binding with no generated overload refuses the call.</summary>
+    /// <summary>BindTwoWay refuses a call no generated dispatch claimed.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task BindTwoWay_ConvertingWithNoGeneratedOverload_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.BindTwoWay(
-                _viewModel,
-                _view,
-                x => x.Caption,
-                x => x.Caption,
-                static value => value,
-                static value => value))
-            .ThrowsExactly<InvalidOperationException>();
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindTwoWay_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.BindTwoWay(_viewModel, _view, x => x.Caption, x => x.Caption),
+            "BindTwoWayUnsafe");
 
-    /// <summary>The view-first spelling of a one-way binding refuses the call.</summary>
+    /// <summary>OneWayBind refuses a call no generated dispatch claimed.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task OneWayBind_WithNoGeneratedOverload_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.OneWayBind(
-                _view,
-                _viewModel,
-                x => x.Caption,
-                x => x.Caption))
-            .ThrowsExactly<InvalidOperationException>();
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task OneWayBind_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.OneWayBind(_view, _viewModel, x => x.Caption, x => x.Caption),
+            "OneWayBindUnsafe");
 
-    /// <summary>The converting view-first spelling of a one-way binding refuses the call.</summary>
+    /// <summary>Bind refuses a call no generated dispatch claimed.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task OneWayBind_ConvertingWithNoGeneratedOverload_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.OneWayBind(
-                _view,
-                _viewModel,
-                x => x.Caption,
-                x => x.Caption,
-                static value => value))
-            .ThrowsExactly<InvalidOperationException>();
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task Bind_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.Bind(_view, _viewModel, x => x.Caption, x => x.Caption),
+            "BindUnsafe");
 
-    /// <summary>The view-first spelling of a two-way binding refuses the call.</summary>
+    /// <summary>BindTo refuses a call no generated dispatch claimed.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task Bind_WithNoGeneratedOverload_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.Bind(
-                _view,
-                _viewModel,
-                x => x.Caption,
-                x => x.Caption))
-            .ThrowsExactly<InvalidOperationException>();
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindTo_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.BindTo(_source, _view, x => x.Caption),
+            "BindToUnsafe");
 
-    /// <summary>The converting view-first spelling of a two-way binding refuses the call.</summary>
+    /// <summary>BindCommand refuses a call no generated dispatch claimed.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task Bind_ConvertingWithNoGeneratedOverload_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.Bind(
-                _view,
-                _viewModel,
-                x => x.Caption,
-                x => x.Caption,
-                static value => value,
-                static value => value))
-            .ThrowsExactly<InvalidOperationException>();
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindCommand_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.BindCommand(_view, _viewModel, x => x.Run, x => x.Control),
+            "BindCommandUnsafe");
 
-    /// <summary>Writing a stream into a property with no generated overload refuses the call.</summary>
+    /// <summary>BindInteraction refuses a call no generated dispatch claimed.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task BindTo_WithNoGeneratedOverload_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.BindTo(
-                _source,
-                _view,
-                x => x.Caption))
-            .ThrowsExactly<InvalidOperationException>();
-
-    /// <summary>Writing a stream into a property with a conversion hint refuses the call.</summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task BindTo_WithAConversionHint_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.BindTo(
-                _source,
-                _view,
-                x => x.Caption,
-                conversionHint: null))
-            .ThrowsExactly<InvalidOperationException>();
-
-    /// <summary>Writing a stream into a property with a converter refuses the call.</summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task BindTo_WithAConverter_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.BindTo(
-                _source,
-                _view,
-                x => x.Caption,
-                converterOverride: null))
-            .ThrowsExactly<InvalidOperationException>();
-
-    /// <summary>Writing a stream into a property with both a hint and a converter refuses the call.</summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task BindTo_WithAConversionHintAndAConverter_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.BindTo(
-                _source,
-                _view,
-                x => x.Caption,
-                conversionHint: null,
-                converterOverride: null))
-            .ThrowsExactly<InvalidOperationException>();
-
-    /// <summary>A command binding with no generated overload refuses the call.</summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task BindCommand_WithNoGeneratedOverload_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.BindCommand(
-                _view,
-                _viewModel,
-                x => x.Run,
-                x => x.Control))
-            .ThrowsExactly<InvalidOperationException>();
-
-    /// <summary>A command binding taking its parameter from a stream refuses the call.</summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task BindCommand_WithAParameterStream_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.BindCommand(
-                _view,
-                _viewModel,
-                x => x.Run,
-                x => x.Control,
-                _source))
-            .ThrowsExactly<InvalidOperationException>();
-
-    /// <summary>A command binding taking its parameter from a property refuses the call.</summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task BindCommand_WithAParameterProperty_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.BindCommand(
-                _view,
-                _viewModel,
-                x => x.Run,
-                x => x.Control,
-                x => x.Parameter))
-            .ThrowsExactly<InvalidOperationException>();
-
-    /// <summary>An interaction binding handled asynchronously refuses the call.</summary>
-    /// <returns>A task representing the asynchronous test operation.</returns>
-    [Test]
-    public async Task BindInteraction_WithAnAsynchronousHandler_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.BindInteraction(
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindInteraction_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.BindInteraction(
                 _view,
                 _viewModel,
                 x => x.Confirm,
-                static context => Task.CompletedTask))
-            .ThrowsExactly<InvalidOperationException>();
+                static context =>
+                {
+                    context.SetOutput(true);
+                    return Task.CompletedTask;
+                }),
+            "BindInteractionUnsafe");
 
-    /// <summary>An interaction binding handled by a stream refuses the call.</summary>
+    /// <summary>InvokeCommand refuses a call no generated dispatch claimed.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task BindInteraction_WithAStreamHandler_ThrowsInvalidOperationException() =>
-        await Assert.That(() => ReactiveUIBindingExtensions.BindInteraction(
-                _view,
-                _viewModel,
-                x => x.Confirm,
-                static IObservable<string> (context) => new ManualObservable<string>()))
-            .ThrowsExactly<InvalidOperationException>();
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task InvokeCommand_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.InvokeCommand(_source, _viewModel, x => x.Run),
+            "InvokeCommandUnsafe");
+
+    /// <summary>A command binding offers the value its parameter stream produces to the command.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommandUnsafe_WithAParameterStream_OffersTheValueProduced()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+
+        using var binding = ReactiveUIBindingExtensions.BindCommandUnsafe(
+            _view,
+            _viewModel,
+            x => x.Run,
+            x => x.Control,
+            _source,
+            null);
+
+        _source.Observer?.OnNext(BoundValue);
+
+        await Assert.That(binding).IsNotNull();
+    }
+
+    /// <summary>A command binding offers the value its parameter property holds to the command.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommandUnsafe_WithAParameterProperty_OffersTheValueHeld()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+
+        using var binding = ReactiveUIBindingExtensions.BindCommandUnsafe(
+            _view,
+            _viewModel,
+            x => x.Run,
+            x => x.Control,
+            x => x.Parameter,
+            null);
+
+        _viewModel.Parameter = ReverseValue;
+
+        await Assert.That(binding).IsNotNull();
+    }
+
+    /// <summary>WhenAny refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAny_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.WhenAny(_viewModel, x => x.Caption, static c => c.Value),
+            "WhenAnyUnsafe");
+
+    /// <summary>WhenAnyObservable refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefusedNaming(
+            () => ReactiveUIBindingExtensions.WhenAnyObservable(_viewModel, x => x.Signal!),
+            "WhenAnyObservableUnsafe");
+
+    /// <summary>Asserts that a call refuses and points the caller at the overload that resolves it.</summary>
+    /// <param name="call">The call expected to refuse.</param>
+    /// <param name="twin">The name the message has to offer.</param>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    private static async Task AssertRefusedNaming(Func<object?> call, string twin)
+    {
+        var error = await Assert.That(call).Throws<InvalidOperationException>();
+
+        await Assert.That(error!.Message).Contains(twin);
+    }
 }

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/InvokeCommandTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/InvokeCommandTests.cs
@@ -60,7 +60,7 @@ public class InvokeCommandTests
         var viewModel = new DispatchStubViewModel { Run = command };
         var values = new Subject<string>();
 
-        using var invocation = values.InvokeCommand(viewModel, x => x.Run);
+        using var invocation = values.InvokeCommandUnsafe(viewModel, x => x.Run);
 
         values.OnNext(FirstValue);
 
@@ -77,7 +77,7 @@ public class InvokeCommandTests
 
         var values = new Subject<string>();
 
-        using var invocation = values.InvokeCommand((DispatchStubViewModel?)null, x => x.Run);
+        using var invocation = values.InvokeCommandUnsafe((DispatchStubViewModel?)null, x => x.Run);
 
         values.OnNext(FirstValue);
 
@@ -89,7 +89,7 @@ public class InvokeCommandTests
     [Test]
     public async Task InvokeCommand_NullSelector_Throws() =>
         await Assert.That(static () =>
-                new Subject<string>().InvokeCommand(new DispatchStubViewModel(), null!))
+                new Subject<string>().InvokeCommandUnsafe(new DispatchStubViewModel(), null!))
             .Throws<ArgumentNullException>();
 
     /// <summary>A null sequence is rejected rather than deferred to the first value.</summary>
@@ -97,6 +97,6 @@ public class InvokeCommandTests
     [Test]
     public async Task InvokeCommand_NullSource_Throws() =>
         await Assert.That(static () =>
-                ((IObservable<string>)null!).InvokeCommand(new DispatchStubViewModel(), x => x.Run))
+                ((IObservable<string>)null!).InvokeCommandUnsafe(new DispatchStubViewModel(), x => x.Run))
             .Throws<ArgumentNullException>();
 }

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/RefusalAssertions.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/RefusalAssertions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Binding.Tests.Mixins;
+
+/// <summary>The assertion every overload's refusal is checked with.</summary>
+/// <remarks>
+/// A refusal is only useful if it tells the caller what to do instead, so the message is checked as well as
+/// the exception. Shared because each API declares one refusal per arity and they all carry the same contract.
+/// </remarks>
+internal static class RefusalAssertions
+{
+    /// <summary>Asserts that a call refuses and names the overload that resolves the expression.</summary>
+    /// <param name="call">The call expected to refuse.</param>
+    /// <param name="twin">The name the message has to offer.</param>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    internal static async Task AssertRefused(Func<object?> call, string twin)
+    {
+        var error = await Assert.That(call).Throws<InvalidOperationException>();
+
+        await Assert.That(error!.Message).Contains(twin);
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/SchedulerUnsafeBindingTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/SchedulerUnsafeBindingTests.cs
@@ -1,0 +1,438 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using ReactiveUI.Binding.Tests.Fallback;
+using ReactiveUI.Binding.Tests.TestModels;
+using ReactiveUI.Primitives.Concurrency;
+
+namespace ReactiveUI.Binding.Tests.Mixins;
+
+/// <summary>Covers every scheduler overload that resolves its expression by reflection.</summary>
+/// <remarks>
+/// The scheduler surface is the one place where the converter-taking overloads had no caller, so each shape is
+/// exercised here rather than left to the shapes a consumer happens to reach for. The file the methods live in
+/// sits inside a type marked <c>ExcludeFromCodeCoverage</c>, so these assertions are the only record that the
+/// overloads work.
+/// </remarks>
+[NotInParallel]
+public class SchedulerUnsafeBindingTests
+{
+    /// <summary>The value carried across a binding.</summary>
+    private const string BoundValue = "bound";
+
+    /// <summary>The value written back on the target side of a two-way binding.</summary>
+    private const string ReverseValue = "reversed";
+
+    /// <summary>The scheduler these overloads exist to take, left unset so writes stay on the calling thread.</summary>
+    private const ISequencer? OnThisThread = null;
+
+    /// <summary>A one-way scheduled binding carries the source value to the target.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindOneWayUnsafe_CarriesTheSourceValue()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        var source = new DispatchStubViewModel { Caption = BoundValue };
+        var target = new DispatchStubView();
+
+        using var binding = source.BindOneWayUnsafe(target, s => s.Caption, t => t.Caption, OnThisThread);
+
+        await Assert.That(target.Caption).IsEqualTo(BoundValue);
+    }
+
+    /// <summary>A one-way scheduled binding applies the conversion it is given.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindOneWayUnsafe_WithAConversion_AppliesIt()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        var source = new DispatchStubViewModel { Caption = BoundValue };
+        var target = new DispatchStubView();
+
+        using var binding = source.BindOneWayUnsafe(
+            target,
+            s => s.Caption,
+            t => t.Caption,
+            static value => $"{value}!",
+            OnThisThread);
+
+        await Assert.That(target.Caption).IsEqualTo($"{BoundValue}!");
+    }
+
+    /// <summary>A one-way scheduled binding applies the converter it is given.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindOneWayUnsafe_WithAConverter_AppliesIt()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        var source = new DispatchStubViewModel { Caption = BoundValue };
+        var target = new DispatchStubView();
+
+        using var binding = source.BindOneWayUnsafe(
+            target,
+            s => s.Caption,
+            t => t.Caption,
+            new SuffixConverter(),
+            OnThisThread,
+            null);
+
+        await Assert.That(target.Caption).IsEqualTo($"{BoundValue}{SuffixConverter.Suffix}");
+    }
+
+    /// <summary>A two-way scheduled binding carries a value in both directions.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTwoWayUnsafe_CarriesBothDirections()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        var source = new DispatchStubViewModel { Caption = BoundValue };
+        var target = new DispatchStubView();
+
+        using var binding = source.BindTwoWayUnsafe(target, s => s.Caption, t => t.Caption, OnThisThread);
+        var afterBind = target.Caption;
+        target.Caption = ReverseValue;
+
+        await Assert.That(afterBind).IsEqualTo(BoundValue);
+        await Assert.That(source.Caption).IsEqualTo(ReverseValue);
+    }
+
+    /// <summary>A two-way scheduled binding applies the conversions it is given.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTwoWayUnsafe_WithConversions_AppliesThem()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        var source = new DispatchStubViewModel { Caption = BoundValue };
+        var target = new DispatchStubView();
+
+        using var binding = source.BindTwoWayUnsafe(
+            target,
+            s => s.Caption,
+            t => t.Caption,
+            static value => value,
+            static value => value,
+            OnThisThread);
+
+        await Assert.That(target.Caption).IsEqualTo(BoundValue);
+    }
+
+    /// <summary>A two-way scheduled binding applies the converters it is given.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindTwoWayUnsafe_WithConverters_AppliesThem()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        var source = new DispatchStubViewModel { Caption = BoundValue };
+        var target = new DispatchStubView();
+
+        using var binding = source.BindTwoWayUnsafe(
+            target,
+            s => s.Caption,
+            t => t.Caption,
+            new SuffixConverter(),
+            new SuffixConverter(),
+            OnThisThread,
+            null);
+
+        await Assert.That(target.Caption).IsEqualTo($"{BoundValue}{SuffixConverter.Suffix}");
+    }
+
+    /// <summary>A view-first scheduled one-way binding projects through its selector.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OneWayBindUnsafe_WithASelector_ProjectsThroughIt()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        var viewModel = new DispatchStubViewModel { Caption = BoundValue };
+        var view = new DispatchStubView { ViewModel = viewModel };
+
+        using var binding = view.OneWayBindUnsafe(
+            viewModel,
+            vm => vm.Caption,
+            v => v.Caption,
+            static value => $"{value}!",
+            OnThisThread);
+
+        await Assert.That(view.Caption).IsEqualTo($"{BoundValue}!");
+    }
+
+    /// <summary>A view-first scheduled one-way binding applies the converter it is given.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task OneWayBindUnsafe_WithAConverter_AppliesIt()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        var viewModel = new DispatchStubViewModel { Caption = BoundValue };
+        var view = new DispatchStubView { ViewModel = viewModel };
+
+        using var binding = view.OneWayBindUnsafe(
+            viewModel,
+            vm => vm.Caption,
+            v => v.Caption,
+            new SuffixConverter(),
+            OnThisThread,
+            null);
+
+        await Assert.That(view.Caption).IsEqualTo($"{BoundValue}{SuffixConverter.Suffix}");
+    }
+
+    /// <summary>A view-first scheduled two-way binding carries a value in both directions.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindUnsafe_CarriesBothDirections()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        var viewModel = new DispatchStubViewModel { Caption = BoundValue };
+        var view = new DispatchStubView { ViewModel = viewModel };
+
+        using var binding = view.BindUnsafe(
+            viewModel,
+            vm => vm.Caption,
+            v => v.Caption,
+            static value => value,
+            static value => value,
+            OnThisThread);
+
+        var afterBind = view.Caption;
+        view.Caption = ReverseValue;
+
+        await Assert.That(afterBind).IsEqualTo(BoundValue);
+        await Assert.That(viewModel.Caption).IsEqualTo(ReverseValue);
+    }
+
+    /// <summary>A view-first scheduled two-way binding applies the converters it is given.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindUnsafe_WithConverters_AppliesThem()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        var viewModel = new DispatchStubViewModel { Caption = BoundValue };
+        var view = new DispatchStubView { ViewModel = viewModel };
+
+        using var binding = view.BindUnsafe(
+            viewModel,
+            vm => vm.Caption,
+            v => v.Caption,
+            new SuffixConverter(),
+            new SuffixConverter(),
+            OnThisThread,
+            null);
+
+        await Assert.That(view.Caption).IsEqualTo($"{BoundValue}{SuffixConverter.Suffix}");
+    }
+
+    /// <summary>A view-first scheduled two-way binding converts a write from the view side too.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    /// <remarks>
+    /// The pair round-trips: the forward converter appends the marker and the reverse one strips it, so the
+    /// binding settles. A pair that changed the value on both passes would feed each write back through the
+    /// other side forever.
+    /// </remarks>
+    [Test]
+    public async Task BindUnsafe_WithConverters_ConvertsTheViewWrite()
+    {
+        RuntimeObservationFallbackTests.EnsureInitialized();
+        var viewModel = new DispatchStubViewModel { Caption = BoundValue };
+        var view = new DispatchStubView { ViewModel = viewModel };
+
+        using var binding = view.BindUnsafe(
+            viewModel,
+            vm => vm.Caption,
+            v => v.Caption,
+            new SuffixConverter(),
+            new StripSuffixConverter(),
+            OnThisThread,
+            null);
+
+        view.Caption = $"{ReverseValue}{SuffixConverter.Suffix}";
+
+        await Assert.That(viewModel.Caption).IsEqualTo(ReverseValue);
+    }
+
+    /// <summary>BindOneWay refuses a scheduled call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindOneWay_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new DispatchStubViewModel().BindOneWay(
+            new DispatchStubView(),
+            s => s.Caption,
+            t => t.Caption,
+            ImmediateSequencer.Instance));
+
+    /// <summary>BindOneWay with a conversion refuses a scheduled call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindOneWay_ConvertingWithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new DispatchStubViewModel().BindOneWay(
+            new DispatchStubView(),
+            s => s.Caption,
+            t => t.Caption,
+            static value => value,
+            ImmediateSequencer.Instance));
+
+    /// <summary>BindOneWay with a converter refuses a scheduled call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindOneWay_WithAConverterAndNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new DispatchStubViewModel().BindOneWay(
+            new DispatchStubView(),
+            s => s.Caption,
+            t => t.Caption,
+            new SuffixConverter(),
+            ImmediateSequencer.Instance));
+
+    /// <summary>BindTwoWay refuses a scheduled call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindTwoWay_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new DispatchStubViewModel().BindTwoWay(
+            new DispatchStubView(),
+            s => s.Caption,
+            t => t.Caption,
+            ImmediateSequencer.Instance));
+
+    /// <summary>BindTwoWay with conversions refuses a scheduled call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindTwoWay_ConvertingWithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new DispatchStubViewModel().BindTwoWay(
+            new DispatchStubView(),
+            s => s.Caption,
+            t => t.Caption,
+            static value => value,
+            static value => value,
+            ImmediateSequencer.Instance));
+
+    /// <summary>BindTwoWay with converters refuses a scheduled call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindTwoWay_WithConvertersAndNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new DispatchStubViewModel().BindTwoWay(
+            new DispatchStubView(),
+            s => s.Caption,
+            t => t.Caption,
+            new SuffixConverter(),
+            new SuffixConverter(),
+            ImmediateSequencer.Instance));
+
+    /// <summary>OneWayBind with a selector refuses a scheduled call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task OneWayBind_WithASelectorAndNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new DispatchStubView().OneWayBind(
+            new DispatchStubViewModel(),
+            vm => vm.Caption,
+            v => v.Caption,
+            static value => value,
+            ImmediateSequencer.Instance));
+
+    /// <summary>OneWayBind with a converter refuses a scheduled call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task OneWayBind_WithAConverterAndNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new DispatchStubView().OneWayBind(
+            new DispatchStubViewModel(),
+            vm => vm.Caption,
+            v => v.Caption,
+            new SuffixConverter(),
+            ImmediateSequencer.Instance));
+
+    /// <summary>Bind with conversions refuses a scheduled call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task Bind_WithConversionsAndNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new DispatchStubView().Bind(
+            new DispatchStubViewModel(),
+            vm => vm.Caption,
+            v => v.Caption,
+            static value => value,
+            static value => value,
+            ImmediateSequencer.Instance));
+
+    /// <summary>Bind with converters refuses a scheduled call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task Bind_WithConvertersAndNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new DispatchStubView().Bind(
+            new DispatchStubViewModel(),
+            vm => vm.Caption,
+            v => v.Caption,
+            new SuffixConverter(),
+            new SuffixConverter(),
+            ImmediateSequencer.Instance));
+
+    /// <summary>Asserts that a scheduled call refuses and names the overload that resolves it.</summary>
+    /// <param name="call">The call expected to refuse.</param>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    private static async Task AssertRefused(Func<object?> call)
+    {
+        var error = await Assert.That(call).Throws<InvalidOperationException>();
+
+        await Assert.That(error!.Message).Contains("Unsafe");
+    }
+
+    /// <summary>The reverse of <see cref="SuffixConverter"/>, so a two-way pair round-trips and settles.</summary>
+    private sealed class StripSuffixConverter : IBindingTypeConverter
+    {
+        /// <summary>An affinity high enough to outrank every registered converter.</summary>
+        private const int WinningAffinity = 100;
+
+        /// <inheritdoc/>
+        public Type FromType => typeof(string);
+
+        /// <inheritdoc/>
+        public Type ToType => typeof(string);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetAffinityForObjects() => WinningAffinity;
+
+        /// <inheritdoc/>
+        public bool TryConvertTyped(object? from, object? conversionHint, out object? result)
+        {
+            result = from is string text && text.EndsWith(SuffixConverter.Suffix, StringComparison.Ordinal)
+                ? text[..^SuffixConverter.Suffix.Length]
+                : from;
+            return true;
+        }
+    }
+
+    /// <summary>A converter that appends a marker, so a test can see that it ran.</summary>
+    private sealed class SuffixConverter : IBindingTypeConverter
+    {
+        /// <summary>The marker a converted value carries.</summary>
+        internal const string Suffix = "-converted";
+
+        /// <summary>An affinity high enough to outrank every registered converter.</summary>
+        private const int WinningAffinity = 100;
+
+        /// <inheritdoc/>
+        public Type FromType => typeof(string);
+
+        /// <inheritdoc/>
+        public Type ToType => typeof(string);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetAffinityForObjects() => WinningAffinity;
+
+        /// <inheritdoc/>
+        public bool TryConvertTyped(object? from, object? conversionHint, out object? result)
+        {
+            result = from is string text ? $"{text}{Suffix}" : from;
+            return true;
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyObservableRefusalTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyObservableRefusalTests.cs
@@ -1,0 +1,393 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using ReactiveUI.Binding.Tests.TestModels;
+
+namespace ReactiveUI.Binding.Tests.Mixins;
+
+/// <summary>Covers every WhenAnyObservable overload refusing a call no generated dispatch claimed.</summary>
+/// <remarks>
+/// A generated overload wins overload resolution for every call site of its types, so the overload it
+/// displaces refuses rather than reaching for reflection behind the caller's back. Each arity declares its own
+/// refusal, and the message it carries is how a caller learns which overload resolves the expression instead.
+/// </remarks>
+public class WhenAnyObservableRefusalTests
+{
+    /// <summary>The overload each refusal points the caller at.</summary>
+    private const string Twin = "WhenAnyObservableUnsafe";
+
+    /// <summary>Arity 3 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity3WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                static (v1, v2, v3) => v1),
+            Twin);
+
+    /// <summary>Arity 4 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity4WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                static (v1, v2, v3, v4) => v1),
+            Twin);
+
+    /// <summary>Arity 5 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity5WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                static (v1, v2, v3, v4, v5) => v1),
+            Twin);
+
+    /// <summary>Arity 6 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity6WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                static (v1, v2, v3, v4, v5, v6) => v1),
+            Twin);
+
+    /// <summary>Arity 7 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity7WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                static (v1, v2, v3, v4, v5, v6, v7) => v1),
+            Twin);
+
+    /// <summary>Arity 8 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity8WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                static (v1, v2, v3, v4, v5, v6, v7, v8) => v1),
+            Twin);
+
+    /// <summary>Arity 9 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity9WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9) => v1),
+            Twin);
+
+    /// <summary>Arity 10 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity10WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) => v1),
+            Twin);
+
+    /// <summary>Arity 11 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity11WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) => v1),
+            Twin);
+
+    /// <summary>Arity 12 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity12WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) => v1),
+            Twin);
+
+    /// <summary>Arity 1 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity1_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal),
+            Twin);
+
+    /// <summary>Arity 2 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity2_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal),
+            Twin);
+
+    /// <summary>Arity 3 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity3_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal),
+            Twin);
+
+    /// <summary>Arity 4 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity4_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal),
+            Twin);
+
+    /// <summary>Arity 5 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity5_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal),
+            Twin);
+
+    /// <summary>Arity 6 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity6_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal),
+            Twin);
+
+    /// <summary>Arity 7 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity7_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal),
+            Twin);
+
+    /// <summary>Arity 8 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity8_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal),
+            Twin);
+
+    /// <summary>Arity 9 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity9_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal),
+            Twin);
+
+    /// <summary>Arity 10 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity10_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal),
+            Twin);
+
+    /// <summary>Arity 11 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity11_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal),
+            Twin);
+
+    /// <summary>Arity 12 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity12_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal,
+                x => x.Signal),
+            Twin);
+
+    /// <summary>Arity 2 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyObservable_Arity2WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyObservable(
+                x => x.Signal,
+                x => x.Signal,
+                static (v1, v2) => v1),
+            Twin);
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyObservableWideArityTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyObservableWideArityTests.cs
@@ -31,7 +31,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1)
             .Subscribe(seen.Add);
@@ -56,7 +56,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2)
@@ -82,7 +82,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -109,7 +109,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -137,7 +137,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -166,7 +166,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -196,7 +196,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -227,7 +227,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -259,7 +259,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -292,7 +292,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -326,7 +326,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -361,7 +361,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -397,7 +397,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -424,7 +424,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -452,7 +452,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -481,7 +481,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -511,7 +511,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -542,7 +542,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -574,7 +574,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -607,7 +607,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -641,7 +641,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -676,7 +676,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,
@@ -712,7 +712,7 @@ public class WhenAnyObservableWideArityTests
         var streams = fixture.FillStreams();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservable(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyObservableUnsafe(
                 fixture,
                 x => x.Stream1,
                 x => x.Stream2,

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyRefusalTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyRefusalTests.cs
@@ -1,0 +1,218 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using ReactiveUI.Binding.Tests.TestModels;
+
+namespace ReactiveUI.Binding.Tests.Mixins;
+
+/// <summary>Covers every WhenAny overload refusing a call no generated dispatch claimed.</summary>
+/// <remarks>
+/// A generated overload wins overload resolution for every call site of its types, so the overload it
+/// displaces refuses rather than reaching for reflection behind the caller's back. Each arity declares its own
+/// refusal, and the message it carries is how a caller learns which overload resolves the expression instead.
+/// </remarks>
+public class WhenAnyRefusalTests
+{
+    /// <summary>The overload each refusal points the caller at.</summary>
+    private const string Twin = "WhenAnyUnsafe";
+
+    /// <summary>Arity 1 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAny_Arity1WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAny(
+                x => x.Caption,
+                static (v1) => v1.Value),
+            Twin);
+
+    /// <summary>Arity 2 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAny_Arity2WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAny(
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2) => v1.Value),
+            Twin);
+
+    /// <summary>Arity 3 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAny_Arity3WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAny(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3) => v1.Value),
+            Twin);
+
+    /// <summary>Arity 4 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAny_Arity4WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAny(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4) => v1.Value),
+            Twin);
+
+    /// <summary>Arity 5 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAny_Arity5WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAny(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5) => v1.Value),
+            Twin);
+
+    /// <summary>Arity 6 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAny_Arity6WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAny(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6) => v1.Value),
+            Twin);
+
+    /// <summary>Arity 7 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAny_Arity7WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAny(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7) => v1.Value),
+            Twin);
+
+    /// <summary>Arity 8 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAny_Arity8WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAny(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8) => v1.Value),
+            Twin);
+
+    /// <summary>Arity 9 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAny_Arity9WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAny(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9) => v1.Value),
+            Twin);
+
+    /// <summary>Arity 10 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAny_Arity10WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAny(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) => v1.Value),
+            Twin);
+
+    /// <summary>Arity 11 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAny_Arity11WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAny(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) => v1.Value),
+            Twin);
+
+    /// <summary>Arity 12 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAny_Arity12WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAny(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) => v1.Value),
+            Twin);
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyValueRefusalTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyValueRefusalTests.cs
@@ -1,0 +1,600 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using ReactiveUI.Binding.Tests.TestModels;
+
+namespace ReactiveUI.Binding.Tests.Mixins;
+
+/// <summary>Covers every WhenAnyValue overload refusing a call no generated dispatch claimed.</summary>
+/// <remarks>
+/// A generated overload wins overload resolution for every call site of its types, so the overload it
+/// displaces refuses rather than reaching for reflection behind the caller's back. Each arity declares its own
+/// refusal, and the message it carries is how a caller learns which overload resolves the expression instead.
+/// <para>
+/// A one-argument selector is typed explicitly. Left to inference it is indistinguishable from a second
+/// property expression, and the call does not compile.
+/// </para>
+/// </remarks>
+public class WhenAnyValueRefusalTests
+{
+    /// <summary>The overload each refusal points the caller at.</summary>
+    private const string Twin = "WhenAnyValueUnsafe";
+
+    /// <summary>Arity 1 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity1WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                static (string v1) => v1),
+            Twin);
+
+    /// <summary>Arity 2 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity2WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2) => v1),
+            Twin);
+
+    /// <summary>Arity 3 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity3WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3) => v1),
+            Twin);
+
+    /// <summary>Arity 4 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity4WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4) => v1),
+            Twin);
+
+    /// <summary>Arity 5 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity5WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5) => v1),
+            Twin);
+
+    /// <summary>Arity 6 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity6WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6) => v1),
+            Twin);
+
+    /// <summary>Arity 7 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity7WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7) => v1),
+            Twin);
+
+    /// <summary>Arity 8 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity8WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8) => v1),
+            Twin);
+
+    /// <summary>Arity 9 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity9WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9) => v1),
+            Twin);
+
+    /// <summary>Arity 10 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity10WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) => v1),
+            Twin);
+
+    /// <summary>Arity 11 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity11WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) => v1),
+            Twin);
+
+    /// <summary>Arity 12 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity12WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) => v1),
+            Twin);
+
+    /// <summary>Arity 13 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity13WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) => v1),
+            Twin);
+
+    /// <summary>Arity 14 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity14WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) => v1),
+            Twin);
+
+    /// <summary>Arity 15 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity15WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) => v1),
+            Twin);
+
+    /// <summary>Arity 16 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity16WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) => v1),
+            Twin);
+
+    /// <summary>Arity 1 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity1_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 2 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity2_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 3 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity3_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 4 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity4_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 5 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity5_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 6 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity6_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 7 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity7_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 8 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity8_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 9 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity9_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 10 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity10_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 11 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity11_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 12 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity12_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 13 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity13_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 14 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity14_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 15 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity15_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 16 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenAnyValue_Arity16_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenAnyValue(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyValueWideArityTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyValueWideArityTests.cs
@@ -30,7 +30,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1)
             .Subscribe(seen.Add);
@@ -48,7 +48,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2)
@@ -67,7 +67,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -87,7 +87,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -108,7 +108,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -130,7 +130,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -153,7 +153,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -177,7 +177,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -202,7 +202,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -228,7 +228,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -255,7 +255,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -283,7 +283,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -312,7 +312,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -342,7 +342,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -373,7 +373,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -405,7 +405,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -438,7 +438,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 static (string v1) => v1)
@@ -457,7 +457,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -477,7 +477,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -498,7 +498,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -520,7 +520,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -543,7 +543,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -567,7 +567,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -592,7 +592,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -618,7 +618,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -645,7 +645,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -673,7 +673,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -702,7 +702,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -732,7 +732,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -763,7 +763,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -795,7 +795,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -828,7 +828,7 @@ public class WhenAnyValueWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAnyValue(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyValueUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyWideArityTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenAnyWideArityTests.cs
@@ -30,7 +30,7 @@ public class WhenAnyWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyUnsafe(
                 fixture,
                 x => x.Value1,
                 static c1 => c1.Value)
@@ -49,7 +49,7 @@ public class WhenAnyWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -69,7 +69,7 @@ public class WhenAnyWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -90,7 +90,7 @@ public class WhenAnyWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -112,7 +112,7 @@ public class WhenAnyWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -135,7 +135,7 @@ public class WhenAnyWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -159,7 +159,7 @@ public class WhenAnyWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -184,7 +184,7 @@ public class WhenAnyWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -210,7 +210,7 @@ public class WhenAnyWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -237,7 +237,7 @@ public class WhenAnyWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -265,7 +265,7 @@ public class WhenAnyWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -294,7 +294,7 @@ public class WhenAnyWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenAny(
+        using var subscription = ReactiveUIBindingExtensions.WhenAnyUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenChangedRefusalTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenChangedRefusalTests.cs
@@ -1,0 +1,585 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using ReactiveUI.Binding.Tests.TestModels;
+
+namespace ReactiveUI.Binding.Tests.Mixins;
+
+/// <summary>Covers every WhenChanged overload refusing a call no generated dispatch claimed.</summary>
+/// <remarks>
+/// A generated overload wins overload resolution for every call site of its types, so the overload it
+/// displaces refuses rather than reaching for reflection behind the caller's back. Each arity declares its own
+/// refusal, and the message it carries is how a caller learns which overload resolves the expression instead.
+/// </remarks>
+public class WhenChangedRefusalTests
+{
+    /// <summary>The overload each refusal points the caller at.</summary>
+    private const string Twin = "WhenChangedUnsafe";
+
+    /// <summary>Arity 2 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity2WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2) => v1),
+            Twin);
+
+    /// <summary>Arity 3 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity3WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3) => v1),
+            Twin);
+
+    /// <summary>Arity 4 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity4WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4) => v1),
+            Twin);
+
+    /// <summary>Arity 5 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity5WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5) => v1),
+            Twin);
+
+    /// <summary>Arity 6 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity6WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6) => v1),
+            Twin);
+
+    /// <summary>Arity 7 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity7WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7) => v1),
+            Twin);
+
+    /// <summary>Arity 8 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity8WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8) => v1),
+            Twin);
+
+    /// <summary>Arity 9 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity9WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9) => v1),
+            Twin);
+
+    /// <summary>Arity 10 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity10WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) => v1),
+            Twin);
+
+    /// <summary>Arity 11 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity11WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) => v1),
+            Twin);
+
+    /// <summary>Arity 12 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity12WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) => v1),
+            Twin);
+
+    /// <summary>Arity 13 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity13WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) => v1),
+            Twin);
+
+    /// <summary>Arity 14 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity14WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) => v1),
+            Twin);
+
+    /// <summary>Arity 15 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity15WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) => v1),
+            Twin);
+
+    /// <summary>Arity 16 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity16WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) => v1),
+            Twin);
+
+    /// <summary>Arity 1 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity1_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 2 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity2_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 3 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity3_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 4 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity4_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 5 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity5_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 6 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity6_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 7 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity7_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 8 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity8_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 9 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity9_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 10 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity10_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 11 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity11_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 12 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity12_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 13 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity13_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 14 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity14_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 15 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity15_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 16 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanged_Arity16_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanged(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenChangedWideArityTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenChangedWideArityTests.cs
@@ -30,7 +30,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1)
             .Subscribe(seen.Add);
@@ -48,7 +48,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2)
@@ -67,7 +67,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -87,7 +87,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -108,7 +108,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -130,7 +130,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -153,7 +153,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -177,7 +177,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -202,7 +202,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -228,7 +228,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -255,7 +255,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -283,7 +283,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -312,7 +312,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -342,7 +342,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -373,7 +373,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -405,7 +405,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -438,7 +438,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -458,7 +458,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -479,7 +479,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -501,7 +501,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -524,7 +524,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -548,7 +548,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -573,7 +573,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -599,7 +599,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -626,7 +626,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -654,7 +654,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -683,7 +683,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -713,7 +713,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -744,7 +744,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -776,7 +776,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -809,7 +809,7 @@ public class WhenChangedWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanged(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangedUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenChangingRefusalTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenChangingRefusalTests.cs
@@ -1,0 +1,585 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using ReactiveUI.Binding.Tests.TestModels;
+
+namespace ReactiveUI.Binding.Tests.Mixins;
+
+/// <summary>Covers every WhenChanging overload refusing a call no generated dispatch claimed.</summary>
+/// <remarks>
+/// A generated overload wins overload resolution for every call site of its types, so the overload it
+/// displaces refuses rather than reaching for reflection behind the caller's back. Each arity declares its own
+/// refusal, and the message it carries is how a caller learns which overload resolves the expression instead.
+/// </remarks>
+public class WhenChangingRefusalTests
+{
+    /// <summary>The overload each refusal points the caller at.</summary>
+    private const string Twin = "WhenChangingUnsafe";
+
+    /// <summary>Arity 2 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity2WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2) => v1),
+            Twin);
+
+    /// <summary>Arity 3 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity3WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3) => v1),
+            Twin);
+
+    /// <summary>Arity 4 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity4WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4) => v1),
+            Twin);
+
+    /// <summary>Arity 5 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity5WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5) => v1),
+            Twin);
+
+    /// <summary>Arity 6 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity6WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6) => v1),
+            Twin);
+
+    /// <summary>Arity 7 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity7WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7) => v1),
+            Twin);
+
+    /// <summary>Arity 8 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity8WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8) => v1),
+            Twin);
+
+    /// <summary>Arity 9 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity9WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9) => v1),
+            Twin);
+
+    /// <summary>Arity 10 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity10WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) => v1),
+            Twin);
+
+    /// <summary>Arity 11 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity11WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) => v1),
+            Twin);
+
+    /// <summary>Arity 12 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity12WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) => v1),
+            Twin);
+
+    /// <summary>Arity 13 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity13WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) => v1),
+            Twin);
+
+    /// <summary>Arity 14 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity14WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) => v1),
+            Twin);
+
+    /// <summary>Arity 15 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity15WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) => v1),
+            Twin);
+
+    /// <summary>Arity 16 with a selector refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity16WithSelector_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                static (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) => v1),
+            Twin);
+
+    /// <summary>Arity 1 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity1_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 2 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity2_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 3 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity3_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 4 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity4_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 5 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity5_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 6 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity6_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 7 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity7_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 8 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity8_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 9 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity9_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 10 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity10_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 11 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity11_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 12 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity12_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 13 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity13_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 14 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity14_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 15 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity15_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+
+    /// <summary>Arity 16 refuses and names the twin.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task WhenChanging_Arity16_NamesTheUnsafeTwin() =>
+        RefusalAssertions.AssertRefused(
+            static () => new DispatchStubViewModel().WhenChanging(
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption,
+                x => x.Caption),
+            Twin);
+}

--- a/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenChangingWideArityTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Mixins/WhenChangingWideArityTests.cs
@@ -30,7 +30,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1)
             .Subscribe(seen.Add);
@@ -50,7 +50,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2)
@@ -71,7 +71,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -93,7 +93,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -116,7 +116,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -140,7 +140,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -165,7 +165,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -191,7 +191,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -218,7 +218,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -246,7 +246,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -275,7 +275,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -305,7 +305,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -336,7 +336,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -368,7 +368,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -401,7 +401,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -435,7 +435,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -470,7 +470,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -492,7 +492,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -515,7 +515,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -539,7 +539,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -564,7 +564,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -590,7 +590,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -617,7 +617,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -645,7 +645,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -674,7 +674,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -704,7 +704,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -735,7 +735,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -767,7 +767,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -800,7 +800,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -834,7 +834,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,
@@ -869,7 +869,7 @@ public class WhenChangingWideArityTests
         var fixture = new WideArityFixture();
         var seen = new List<string>();
 
-        using var subscription = ReactiveUIBindingExtensions.WhenChanging(
+        using var subscription = ReactiveUIBindingExtensions.WhenChangingUnsafe(
                 fixture,
                 x => x.Value1,
                 x => x.Value2,

--- a/src/tests/ReactiveUI.Binding.Tests/Reactive/ReactiveSchedulerExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/Reactive/ReactiveSchedulerExtensionsTests.cs
@@ -4,78 +4,185 @@
 
 using System.ComponentModel;
 using System.Reactive.Concurrency;
+using System.Runtime.CompilerServices;
 using ReactiveUI.Binding.Reactive;
 
 namespace ReactiveUI.Binding.Tests.Reactive;
 
-/// <summary>
-///     Tests for the System.Reactive flavour of <see cref="ReactiveSchedulerExtensions"/>, which takes
-///     an <see cref="IScheduler"/>. All extension methods are CallerInfo stubs that throw
-///     InvalidOperationException unless a source generator provides the implementation.
-/// </summary>
+/// <summary>Covers the System.Reactive flavour of the scheduler overloads, which take an <see cref="IScheduler"/>.</summary>
+/// <remarks>
+/// Each overload is split in two: the unsuffixed member resolves at compile time and throws when no generated
+/// dispatch claimed the call site, and the <c>Unsafe</c> twin walks the chain by reflection. What is checked here
+/// is the refusal and the message that names the twin, because that message is how a consumer learns which
+/// overload to call. The twins' behaviour is covered against the lean flavour, which compiles the same source.
+/// </remarks>
 public class ReactiveSchedulerExtensionsTests
 {
-    /// <summary>Verifies that BindOneWay throws InvalidOperationException (no generated binding).</summary>
+    /// <summary>BindOneWay refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public void BindOneWay_ThrowsInvalidOperationException()
-    {
-        var source = new TestModel();
-        var target = new TestModel();
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindOneWay_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new TestModel().BindOneWay(
+            new TestModel(),
+            s => s.Name,
+            t => t.Name,
+            ImmediateScheduler.Instance));
 
-        _ = Assert.Throws<InvalidOperationException>(() =>
-            source.BindOneWay(
-                target,
-                s => s.Name,
-                t => t.Name,
-                (IScheduler?)null));
+    /// <summary>BindOneWay with a conversion refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindOneWay_ConvertingWithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new TestModel().BindOneWay(
+            new TestModel(),
+            s => s.Name,
+            t => t.Name,
+            static v => v,
+            ImmediateScheduler.Instance));
+
+    /// <summary>BindTwoWay refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindTwoWay_WithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new TestModel().BindTwoWay(
+            new TestModel(),
+            s => s.Name,
+            t => t.Name,
+            ImmediateScheduler.Instance));
+
+    /// <summary>BindTwoWay with conversions refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindTwoWay_ConvertingWithNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new TestModel().BindTwoWay(
+            new TestModel(),
+            s => s.Name,
+            t => t.Name,
+            static v => v,
+            static v => v,
+            ImmediateScheduler.Instance));
+
+    /// <summary>BindOneWay with a converter refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindOneWay_WithAConverterAndNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new TestModel().BindOneWay(
+            new TestModel(),
+            s => s.Name,
+            t => t.Name,
+            new PassThroughConverter(),
+            ImmediateScheduler.Instance));
+
+    /// <summary>BindTwoWay with converters refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task BindTwoWay_WithConvertersAndNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new TestModel().BindTwoWay(
+            new TestModel(),
+            s => s.Name,
+            t => t.Name,
+            new PassThroughConverter(),
+            new PassThroughConverter(),
+            ImmediateScheduler.Instance));
+
+    /// <summary>OneWayBind with a selector refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task OneWayBind_WithASelectorAndNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new TestView().OneWayBind(
+            new TestModel(),
+            vm => vm.Name,
+            v => v.Caption,
+            static value => value,
+            ImmediateScheduler.Instance));
+
+    /// <summary>OneWayBind with a converter refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task OneWayBind_WithAConverterAndNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new TestView().OneWayBind(
+            new TestModel(),
+            vm => vm.Name,
+            v => v.Caption,
+            new PassThroughConverter(),
+            ImmediateScheduler.Instance));
+
+    /// <summary>Bind with conversions refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task Bind_WithConversionsAndNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new TestView().Bind(
+            new TestModel(),
+            vm => vm.Name,
+            v => v.Caption,
+            static value => value,
+            static value => value,
+            ImmediateScheduler.Instance));
+
+    /// <summary>Bind with converters refuses a call no generated dispatch claimed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task Bind_WithConvertersAndNoGeneratedOverload_NamesTheUnsafeTwin() =>
+        AssertRefused(static () => new TestView().Bind(
+            new TestModel(),
+            vm => vm.Name,
+            v => v.Caption,
+            new PassThroughConverter(),
+            new PassThroughConverter(),
+            ImmediateScheduler.Instance));
+
+    /// <summary>Asserts that a call refuses and names the overload that resolves it.</summary>
+    /// <param name="call">The call expected to refuse.</param>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    private static async Task AssertRefused(Func<object?> call)
+    {
+        var error = await Assert.That(call).Throws<InvalidOperationException>();
+
+        await Assert.That(error!.Message).Contains("Unsafe");
     }
 
-    /// <summary>Verifies that BindOneWay with conversion throws InvalidOperationException (no generated binding).</summary>
-    [Test]
-    public void BindOneWay_WithConversion_ThrowsInvalidOperationException()
+    /// <summary>A converter these overloads take, which never converts because the call refuses first.</summary>
+    private sealed class PassThroughConverter : ReactiveUI.Binding.Reactive.IBindingTypeConverter
     {
-        var source = new TestModel();
-        var target = new TestModel();
+        /// <summary>The affinity a converter returns when it is the only candidate.</summary>
+        private const int SoleCandidateAffinity = 2;
 
-        _ = Assert.Throws<InvalidOperationException>(() =>
-            source.BindOneWay(
-                target,
-                s => s.Name,
-                t => t.Name,
-                static v => v,
-                (IScheduler?)null));
+        /// <inheritdoc/>
+        public Type FromType => typeof(string);
+
+        /// <inheritdoc/>
+        public Type ToType => typeof(string);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetAffinityForObjects() => SoleCandidateAffinity;
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryConvertTyped(object? from, object? conversionHint, out object? result)
+        {
+            result = from;
+            return true;
+        }
     }
 
-    /// <summary>Verifies that BindTwoWay throws InvalidOperationException (no generated binding).</summary>
-    [Test]
-    public void BindTwoWay_ThrowsInvalidOperationException()
+    /// <summary>A view the view-first scheduler overloads name.</summary>
+    private sealed class TestView : ReactiveUI.Binding.Reactive.IViewFor
     {
-        var source = new TestModel();
-        var target = new TestModel();
+        /// <inheritdoc/>
+        public object? ViewModel { get; set; }
 
-        _ = Assert.Throws<InvalidOperationException>(() =>
-            source.BindTwoWay(
-                target,
-                s => s.Name,
-                t => t.Name,
-                (IScheduler?)null));
-    }
-
-    /// <summary>Verifies that BindTwoWay with conversion throws InvalidOperationException (no generated binding).</summary>
-    [Test]
-    public void BindTwoWay_WithConversion_ThrowsInvalidOperationException()
-    {
-        var source = new TestModel();
-        var target = new TestModel();
-
-        _ = Assert.Throws<InvalidOperationException>(() =>
-            source.BindTwoWay(
-                target,
-                s => s.Name,
-                t => t.Name,
-                static v => v,
-                static v => v,
-                (IScheduler?)null));
+        /// <summary>Gets or sets the bound caption.</summary>
+        public string? Caption { get; set; }
     }
 
     /// <summary>A simple test model implementing <see cref="INotifyPropertyChanged"/>.</summary>

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/ClickCommandBinder.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/ClickCommandBinder.cs
@@ -1,0 +1,106 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+
+namespace ReactiveUI.Binding.Tests.TestModels;
+
+/// <summary>Binds a command to <see cref="DispatchStubControl.Click"/>, tracking the latest parameter.</summary>
+/// <remarks>
+/// The runtime library ships no command binder of its own, so a binding built through the runtime path has
+/// nothing to subscribe its parameter stream with. Registering this one is what lets a test drive a command
+/// execution and see the parameter that reached it.
+/// </remarks>
+public class ClickCommandBinder : ICreatesCommandBinding
+{
+    /// <summary>The affinity returned for a control this binder knows how to reach.</summary>
+    private const int SupportedAffinity = 100;
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int GetAffinityForObject<T>(bool hasEventTarget) =>
+        typeof(T) == typeof(DispatchStubControl) ? SupportedAffinity : 0;
+
+    /// <inheritdoc/>
+    public IDisposable? BindCommandToObject<T>(ICommand? command, T? target, IObservable<object?> commandParameter)
+        where T : class
+    {
+        if (command is null || target is not DispatchStubControl control)
+        {
+            return null;
+        }
+
+        object? latest = null;
+        var parameters = commandParameter.Subscribe(new LatestParameter(value => latest = value));
+
+        EventHandler onClick = (_, _) =>
+        {
+            if (!command.CanExecute(latest))
+            {
+                return;
+            }
+
+            command.Execute(latest);
+        };
+
+        control.Click += onClick;
+
+        return new UnbindOnDispose(() =>
+        {
+            control.Click -= onClick;
+            parameters.Dispose();
+        });
+    }
+
+    /// <inheritdoc/>
+    [SuppressMessage("Design", "SST1452:Unused type parameter", Justification = "type parameter is dictated by the interface / specified explicitly by the caller")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public IDisposable? BindCommandToObject<T, TEventArgs>(
+        ICommand? command,
+        T? target,
+        IObservable<object?> commandParameter,
+        string eventName)
+        where T : class => BindCommandToObject(command, target, commandParameter);
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public IDisposable? BindCommandToObject<T, TEventArgs>(
+        ICommand? command,
+        T? target,
+        IObservable<object?> commandParameter,
+        Action<EventHandler<TEventArgs>> addHandler,
+        Action<EventHandler<TEventArgs>> removeHandler)
+        where T : class
+        where TEventArgs : EventArgs => BindCommandToObject(command, target, commandParameter);
+
+    /// <summary>Records the most recent value a parameter stream produced.</summary>
+    /// <param name="onValue">Receives each value.</param>
+    private sealed class LatestParameter(Action<object?> onValue) : IObserver<object?>
+    {
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void OnNext(object? value) => onValue(value);
+    }
+
+    /// <summary>Runs an action when disposed.</summary>
+    /// <param name="unbind">The action that undoes the binding.</param>
+    private sealed class UnbindOnDispose(Action unbind) : IDisposable
+    {
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose() => unbind();
+    }
+}

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/DispatchStubControl.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/DispatchStubControl.cs
@@ -2,11 +2,20 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
+
 namespace ReactiveUI.Binding.Tests.TestModels;
 
-/// <summary>A control a command binding names, carrying nothing beyond a property to bind against.</summary>
+/// <summary>A control a command binding names, carrying a property to bind against and the default event.</summary>
 public class DispatchStubControl
 {
+    /// <summary>Raised to execute a bound command. This is the event the default command binder looks for.</summary>
+    public event EventHandler? Click;
+
     /// <summary>Gets or sets the control's text.</summary>
     public string Text { get; set; } = "a";
+
+    /// <summary>Raises <see cref="Click"/>, executing whichever command is bound to it.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void PerformClick() => Click?.Invoke(this, EventArgs.Empty);
 }

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/DispatchStubView.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/DispatchStubView.cs
@@ -18,6 +18,9 @@ public class DispatchStubView : IViewFor, INotifyPropertyChanged
     /// <summary>Gets the control a command binding names.</summary>
     public DispatchStubControl Control { get; } = new();
 
+    /// <summary>Gets the control that no registered command binder reaches.</summary>
+    public UnclaimedStubControl Surface { get; } = new();
+
     /// <summary>Gets or sets the bound text.</summary>
     public string Caption
     {

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/DispatchStubViewModel.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/DispatchStubViewModel.cs
@@ -44,4 +44,7 @@ public class DispatchStubViewModel : INotifyPropertyChanged
 
     /// <summary>Gets or sets the interaction an interaction binding names.</summary>
     public IInteraction<string, bool> Confirm { get; set; } = null!;
+
+    /// <summary>Gets or sets the stream a WhenAnyObservable call names.</summary>
+    public IObservable<string>? Signal { get; set; }
 }

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/RecordingStubCommand.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/RecordingStubCommand.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+
+namespace ReactiveUI.Binding.Tests.TestModels;
+
+/// <summary>A command that records the parameter it was executed with.</summary>
+public class RecordingStubCommand : ICommand
+{
+    /// <inheritdoc/>
+    /// <remarks>The command is always available, so nothing raises this. A binder still subscribes to it.</remarks>
+    public event EventHandler? CanExecuteChanged
+    {
+        add { }
+        remove { }
+    }
+
+    /// <summary>Gets the parameter the most recent execution carried.</summary>
+    public object? LastParameter { get; private set; }
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool CanExecute(object? parameter) => true;
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Execute(object? parameter) => LastParameter = parameter;
+}

--- a/src/tests/ReactiveUI.Binding.Tests/TestModels/UnclaimedStubControl.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/TestModels/UnclaimedStubControl.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Binding.Tests.TestModels;
+
+/// <summary>A control no registered command binder reaches.</summary>
+/// <remarks>
+/// The runtime library ships no command binder of its own, so a control nothing claims is what a command
+/// binding meets when the host registered no binder that fits. The binding resolves to nothing rather than
+/// faulting, and this control is how that outcome is reached without unregistering anything global.
+/// </remarks>
+public class UnclaimedStubControl
+{
+    /// <summary>Gets or sets the control's text.</summary>
+    public string Text { get; set; } = "a";
+}

--- a/src/tests/ReactiveUI.Binding.Tests/WhenAny/WhenAnyObservableTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/WhenAny/WhenAnyObservableTests.cs
@@ -46,7 +46,7 @@ public class WhenAnyObservableTests
         var values = new List<int>();
 
         // Command1 is null, should not throw
-        using var sub = vm.WhenAnyObservable(x => x.Command1)
+        using var sub = vm.WhenAnyObservableUnsafe(x => x.Command1)
             .Subscribe(values.Add);
 
         // Set it to a real observable
@@ -71,7 +71,7 @@ public class WhenAnyObservableTests
         var vm = new TestWhenAnyObsViewModel { Command1 = subject1, Command2 = subject2 };
         var values = new List<int>();
 
-        using var sub = vm.WhenAnyObservable(x => x.Command1, x => x.Command2)
+        using var sub = vm.WhenAnyObservableUnsafe(x => x.Command1, x => x.Command2)
             .Subscribe(values.Add);
 
         subject1.OnNext(1);
@@ -95,7 +95,7 @@ public class WhenAnyObservableTests
         var vm = new TestWhenAnyObsViewModel { Command1 = subject1, Command2 = subject2, Command3 = subject3 };
         var values = new List<int>();
 
-        using var sub = vm.WhenAnyObservable(x => x.Command1, x => x.Command2, x => x.Command3)
+        using var sub = vm.WhenAnyObservableUnsafe(x => x.Command1, x => x.Command2, x => x.Command3)
             .Subscribe(values.Add);
 
         subject1.OnNext(FirstCombineValue);
@@ -115,7 +115,7 @@ public class WhenAnyObservableTests
         var vm = new TestWhenAnyObsViewModel();
         var values = new List<int>();
 
-        using var sub = vm.WhenAnyObservable(x => x.Changes)
+        using var sub = vm.WhenAnyObservableUnsafe(x => x.Changes)
             .Subscribe(values.Add);
 
         // Initially null, should not emit

--- a/src/tests/ReactiveUI.Binding.Tests/WhenAny/WhenAnyTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/WhenAny/WhenAnyTests.cs
@@ -23,7 +23,7 @@ public class WhenAnyTests
         var fixture = new TestFixture { IsNotNullString = "Initial" };
         var values = new List<string>();
 
-        using var sub = fixture.WhenAny(
+        using var sub = fixture.WhenAnyUnsafe(
                 x => x.IsNotNullString,
                 static change => change.Value)
             .Subscribe(values.Add);
@@ -47,7 +47,7 @@ public class WhenAnyTests
         var fixture = new TestFixture { IsNotNullString = "Hello", IsOnlyOneWord = "World" };
         var values = new List<string>();
 
-        using var sub = fixture.WhenAny(
+        using var sub = fixture.WhenAnyUnsafe(
                 x => x.IsNotNullString,
                 x => x.IsOnlyOneWord,
                 static (c1, c2) => $"{c1.Value} {c2.Value}")
@@ -67,7 +67,7 @@ public class WhenAnyTests
         var fixture = new TestFixture { IsNotNullString = "PreExisting" };
         var values = new List<string>();
 
-        using var sub = fixture.WhenAny(
+        using var sub = fixture.WhenAnyUnsafe(
                 x => x.IsNotNullString,
                 static change => change.Value)
             .Subscribe(values.Add);
@@ -86,7 +86,7 @@ public class WhenAnyTests
         var obj = new NonReactiveINotifyPropertyChangedObject { InpcProperty = "Start" };
         var values = new List<string>();
 
-        using var sub = obj.WhenAny(
+        using var sub = obj.WhenAnyUnsafe(
                 x => x.InpcProperty,
                 static change => change.Value)
             .Subscribe(values.Add);
@@ -109,7 +109,7 @@ public class WhenAnyTests
         var fixture = new TestFixture { IsNotNullString = "Test" };
         IObservedChange<TestFixture, string>? captured = null;
 
-        using var sub = fixture.WhenAny(
+        using var sub = fixture.WhenAnyUnsafe(
                 x => x.IsNotNullString,
                 static change => change)
             .Subscribe(c => captured = c);

--- a/src/tests/ReactiveUI.Binding.Tests/WhenAny/WhenAnyValueMultiPropertyTests.cs
+++ b/src/tests/ReactiveUI.Binding.Tests/WhenAny/WhenAnyValueMultiPropertyTests.cs
@@ -29,7 +29,7 @@ public class WhenAnyValueMultiPropertyTests
         var fixture = new WhenAnyTestFixture { Value1 = "A" };
         var values = new List<string>();
 
-        using var sub = fixture.WhenAnyValue(x => x.Value1)
+        using var sub = fixture.WhenAnyValueUnsafe(x => x.Value1)
             .Subscribe(values.Add);
 
         await Assert.That(values.Count).IsGreaterThanOrEqualTo(1);
@@ -46,7 +46,7 @@ public class WhenAnyValueMultiPropertyTests
         var fixture = new WhenAnyTestFixture { Value1 = "A", Value2 = "B" };
         var values = new List<PropertyValues<string, string>>();
 
-        using var sub = fixture.WhenAnyValue(x => x.Value1, x => x.Value2)
+        using var sub = fixture.WhenAnyValueUnsafe(x => x.Value1, x => x.Value2)
             .Subscribe(values.Add);
 
         await Assert.That(values.Count).IsGreaterThanOrEqualTo(1);
@@ -64,7 +64,7 @@ public class WhenAnyValueMultiPropertyTests
         var fixture = new WhenAnyTestFixture { Value1 = "A", Value2 = "B", Value3 = "C" };
         var values = new List<PropertyValues<string, string, string>>();
 
-        using var sub = fixture.WhenAnyValue(x => x.Value1, x => x.Value2, x => x.Value3)
+        using var sub = fixture.WhenAnyValueUnsafe(x => x.Value1, x => x.Value2, x => x.Value3)
             .Subscribe(values.Add);
 
         await Assert.That(values.Count).IsGreaterThanOrEqualTo(1);
@@ -83,7 +83,7 @@ public class WhenAnyValueMultiPropertyTests
         var fixture = new WhenAnyTestFixture { Value1 = "A", Value2 = "B", Value3 = "C", Value4 = "D" };
         var values = new List<PropertyValues<string, string, string, string>>();
 
-        using var sub = fixture.WhenAnyValue(
+        using var sub = fixture.WhenAnyValueUnsafe(
                 x => x.Value1,
                 x => x.Value2,
                 x => x.Value3,
@@ -106,7 +106,7 @@ public class WhenAnyValueMultiPropertyTests
         var values =
             new List<PropertyValues<string, string, string, string, string>>();
 
-        using var sub = fixture.WhenAnyValue(
+        using var sub = fixture.WhenAnyValueUnsafe(
                 x => x.Value1,
                 x => x.Value2,
                 x => x.Value3,
@@ -130,7 +130,7 @@ public class WhenAnyValueMultiPropertyTests
         var values =
             new List<PropertyValues<string, string, string, string, string, string>>();
 
-        using var sub = fixture.WhenAnyValue(
+        using var sub = fixture.WhenAnyValueUnsafe(
                 x => x.Value1,
                 x => x.Value2,
                 x => x.Value3,
@@ -155,7 +155,7 @@ public class WhenAnyValueMultiPropertyTests
         var values =
             new List<PropertyValues<string, string, string, string, string, string, string>>();
 
-        using var sub = fixture.WhenAnyValue(
+        using var sub = fixture.WhenAnyValueUnsafe(
                 x => x.Value1,
                 x => x.Value2,
                 x => x.Value3,
@@ -180,7 +180,7 @@ public class WhenAnyValueMultiPropertyTests
 
         string? lastItem8 = null;
 
-        using var sub = fixture.WhenAnyValue(
+        using var sub = fixture.WhenAnyValueUnsafe(
                 x => x.Value1,
                 x => x.Value2,
                 x => x.Value3,
@@ -205,7 +205,7 @@ public class WhenAnyValueMultiPropertyTests
 
         string? lastItem9 = null;
 
-        using var sub = fixture.WhenAnyValue(
+        using var sub = fixture.WhenAnyValueUnsafe(
                 x => x.Value1,
                 x => x.Value2,
                 x => x.Value3,
@@ -231,7 +231,7 @@ public class WhenAnyValueMultiPropertyTests
 
         string? lastItem10 = null;
 
-        using var sub = fixture.WhenAnyValue(
+        using var sub = fixture.WhenAnyValueUnsafe(
                 x => x.Value1,
                 x => x.Value2,
                 x => x.Value3,
@@ -271,7 +271,7 @@ public class WhenAnyValueMultiPropertyTests
 
         string? lastItem11 = null;
 
-        using var sub = fixture.WhenAnyValue(
+        using var sub = fixture.WhenAnyValueUnsafe(
                 x => x.Value1,
                 x => x.Value2,
                 x => x.Value3,
@@ -313,7 +313,7 @@ public class WhenAnyValueMultiPropertyTests
 
         string? lastItem12 = null;
 
-        using var sub = fixture.WhenAnyValue(
+        using var sub = fixture.WhenAnyValueUnsafe(
                 x => x.Value1,
                 x => x.Value2,
                 x => x.Value3,
@@ -341,7 +341,7 @@ public class WhenAnyValueMultiPropertyTests
         var fixture = new WhenAnyTestFixture { Value1 = "A" };
         var values = new List<string>();
 
-        using var sub = fixture.WhenAnyValue(x => x.Value1)
+        using var sub = fixture.WhenAnyValueUnsafe(x => x.Value1)
             .Subscribe(values.Add);
 
         fixture.Value1 = "B";
@@ -363,7 +363,7 @@ public class WhenAnyValueMultiPropertyTests
         var fixture = new WhenAnyTestFixture { Value1 = "Hello", Value2 = "World" };
         var values = new List<string>();
 
-        using var sub = fixture.WhenAnyValue(
+        using var sub = fixture.WhenAnyValueUnsafe(
                 x => x.Value1,
                 x => x.Value2,
                 static (v1, v2) => $"{v1} {v2}")
@@ -383,7 +383,7 @@ public class WhenAnyValueMultiPropertyTests
         var fixture = new HostTestFixture { Child = new() { IsNotNullString = "Deep" } };
         var values = new List<string>();
 
-        using var sub = fixture.WhenAnyValue(x => x.Child!.IsNotNullString)
+        using var sub = fixture.WhenAnyValueUnsafe(x => x.Child!.IsNotNullString)
             .Subscribe(values.Add);
 
         await Assert.That(values.Count).IsGreaterThanOrEqualTo(1);

--- a/src/tests/ReactiveUI.Binding.TrimValidation/ReactiveUI.Binding.TrimValidation.csproj
+++ b/src/tests/ReactiveUI.Binding.TrimValidation/ReactiveUI.Binding.TrimValidation.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net11.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <IsTestProject>false</IsTestProject>
+    <RootNamespace>ReactiveUI.Binding.AotValidation</RootNamespace>
+    <AssemblyName>ReactiveUI.Binding.TrimValidation</AssemblyName>
+
+    <!-- Trimming without ahead-of-time compilation is its own configuration: the linker runs but the JIT
+         still does, so a member trimmed away fails at run time rather than at publish. -->
+    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2055;IL2067;IL2070;IL2072;IL2075;IL2091</WarningsAsErrors>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reactive"/>
+  </ItemGroup>
+
+  <!-- The scenarios live once, in the AOT harness, and run under both linkers. -->
+  <ItemGroup>
+    <Compile Include="..\ReactiveUI.Binding.AotValidation\*.cs" LinkBase="Scenarios"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ReactiveUI.Binding\ReactiveUI.Binding.csproj"/>
+    <ProjectReference Include="..\..\ReactiveUI.Binding.SourceGenerators\ReactiveUI.Binding.SourceGenerators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="..\..\ReactiveUI.Binding.Analyzer\ReactiveUI.Binding.Analyzer.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"/>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature, with a breaking change.

## What is the new behavior?

**Reflection is reached only through an overload the consumer names, so a generated application carries no trimming requirement.**

- **Every observation and binding API has an `Unsafe` twin.** `WhenChangedUnsafe`, `WhenChangingUnsafe`, `WhenAnyValueUnsafe`, `WhenAnyUnsafe`, `WhenAnyObservableUnsafe`, `BindOneWayUnsafe`, `BindTwoWayUnsafe`, `BindUnsafe`, `OneWayBindUnsafe`, `BindToUnsafe`, `BindCommandUnsafe`, `BindInteractionUnsafe`, `InvokeCommandUnsafe`, and the scheduler overloads of each.
  - Every `Unsafe` overload carries `RequiresUnreferencedCode`; no unsuffixed name does.
  - The unsuffixed name throws when no generated dispatch claimed the call site, and the message names the twin that resolves it.
  - `WhenAnyDynamic` has no twin: it takes an `Expression` the caller built, so there is never a lambda for the generator to read.
- **A `PublishTrimmed` or `PublishAot` build reports the reflection at the call sites that asked for it, and nothing about the rest.**
- **A registered `ICreatesObservableForProperty` is honoured on every observed link.** A single-property observation, the first link of a chain, and a single-segment `BindInteraction` offer themselves to a registration on the same terms as an inner link. Where the generator found no mechanism the affinity offered is zero, so a registration outranks a read-once observation.
- **Both runtime leaves declare themselves trimmable and AOT compatible.** `ReactiveUI.Binding` and `ReactiveUI.Binding.Reactive` set `IsTrimmable` and `IsAotCompatible` on every framework that has a linker, with no suppressions.
- **A trimmed harness runs beside the ahead-of-time one.** Both publish on net11.0 with the IL diagnostics as errors, and both run their assertions on windows, linux and macos through a new Native AOT workflow.

## What is the current behavior?

- A call site the generator could not read takes the runtime expression engine silently. The four property-binding APIs fall through to it; `BindTo`, `BindCommand` and `BindInteraction` throw.
- The generated overload's unmatched arm calls the annotated stub unconditionally, so a consumer with a `WhenChanged`, `WhenAny` or `WhenAnyObservable` call site sees IL2026 even when every one of their call sites is claimed.
- A registered observation plugin is consulted for inner links of a multi-segment path only. A single-property observation uses the generated mechanism whatever is registered.
- Neither runtime leaf enables the trimming or AOT analysers, so the IL rules the `.editorconfig` declares never run over the source that ships.
- `IViewLocator.ResolveView(object)` closes `IViewFor<>` over a runtime type without saying that it needs dynamic code.

## What might this PR break?

- **An expression the generator cannot read throws instead of binding.** A lambda held in a variable, one built at run time, an indexer or field in the path, or a receiver typed as a type parameter reaches the unsuffixed overload, which throws and names the `Unsafe` twin. Change one identifier at those call sites.
- **`WhenAny` and `WhenAnyObservable` carry no `RequiresUnreferencedCode` on their unsuffixed names.** Drop any IL2026 suppression around those call sites; call the `Unsafe` twin where the reflection path is wanted.
- **`IViewLocator.ResolveView(object, string)` carries `RequiresDynamicCode`.** The generic `ResolveView<TViewModel>` is unaffected. Register the view, or call the generic overload, to stay ahead-of-time clean.
- **`RuntimeBindingConverter.TryConvert` resolves a converter from the declared types rather than the value's runtime type.** A converter registered for a derived type is not selected for a value whose declared type is a base or an interface.
- **The `Unsafe` scheduler overloads take their scheduler and converter arguments as required.**

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Most of the diff is mechanical: the `Unsafe` overloads in the new `*.Unsafe.cs` files beside each mixin, and the regenerated `*.g.verified.cs` baselines. The hand-written changes are:

- `src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/ObservationCodeGenerator.cs` - `EmitChainRootWithChoice`, and the choice in the two expression positions
- `src/ReactiveUI.Binding.SourceGenerators/Plugins/Observation/ChainRegistrationEmitter.cs` - the chooser, parameterised by the position it sits in
- `src/ReactiveUI.Binding.SourceGenerators/CodeGeneration/BindInteractionCodeGenerator.cs` - delegates every path length to the shared emitter
- `src/ReactiveUI.Binding.SourceGenerators/DiagnosticWarnings.cs` - RXUIBIND001, 003, 004, 006 and 009 describe what the call does
- `src/ReactiveUI.Binding.Shared/View/DefaultViewLocator.cs`, `Interfaces/IViewLocator.cs`, `Interfaces/ViewLocatorMixins.cs` - the dynamic-code requirement
- `src/ReactiveUI.Binding.Shared/Fallback/RuntimeBindingConverter.cs` - converter resolution from the declared types
- `src/ReactiveUI.Binding.Shared/ObservableForProperty/INPCObservableForProperty.cs`, `POCOObservableForProperty.cs` - neither reflects, so neither declares that it does
- `src/tests/ReactiveUI.Binding.TrimValidation/`, `.github/workflows/native-aot.yml` - the trimmed harness and the gate
- `README.md` - `When nothing claims the call`
